### PR TITLE
enhance: ダッシュボード予測イベントAPIを分離して期間フィルタに対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages/db/generated
 packages/db/src/generated
 packages/db/prisma/dev.db
 packages/db/prisma/dev.db-journal
+tmp.md

--- a/packages/backend/src/routes/dashboard.integration.test.ts
+++ b/packages/backend/src/routes/dashboard.integration.test.ts
@@ -27,6 +27,47 @@ describe("dashboard routes", () => {
     });
   });
 
+  it("returns event-only dashboard data for the requested forecast period", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 100000,
+      sortOrder: 1,
+    });
+    const recurring = await createRecurringItem(testPrisma, {
+      name: "Salary",
+      type: "income",
+      amount: 300000,
+      dayOfMonth: 20,
+      accountId: account.id,
+      sortOrder: 1,
+    });
+
+    const response = await client.get("/api/dashboard/events?months=1");
+    const body = await parseJson<{
+      forecast: Array<{ id: string; date: string }>;
+      accountForecasts: Array<{ accountId: string; accountName: string; events: Array<{ id: string }> }>;
+    }>(response);
+
+    expect(response.status).toBe(200);
+    expect(body).not.toHaveProperty("totalBalance");
+    expect(body.forecast).toEqual([
+      expect.objectContaining({
+        id: `recurring:${recurring.id}:2026-03`,
+        date: "2026-03-20",
+      }),
+    ]);
+    expect(body.accountForecasts).toEqual([
+      expect.objectContaining({
+        accountId: account.id,
+        accountName: "Main",
+        events: [expect.objectContaining({ id: `recurring:${recurring.id}:2026-03` })],
+      }),
+    ]);
+  });
+
   it("builds forecast events from recurring items, billings, assumptions, and loans while excluding confirmed events", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -11,6 +11,10 @@ const payloadSchema = z.object({
   accountId: z.string().uuid().optional(),
 });
 
+const eventsQuerySchema = z.object({
+  months: z.coerce.number().int().min(1).max(24).default(3),
+});
+
 function isPrismaUniqueConstraintError(error: unknown): error is { code: string } {
   return (
     typeof error === "object" &&
@@ -24,6 +28,19 @@ export const dashboardRoutes = new Hono()
   .get("/", async (c) => {
     const dashboard = await buildDashboard(prisma);
     return c.json(dashboard);
+  })
+  .get("/events", async (c) => {
+    const { months } = eventsQuerySchema.parse(c.req.query());
+    const dashboard = await buildDashboard(prisma, { forecastMonths: months });
+
+    return c.json({
+      forecast: dashboard.forecast,
+      accountForecasts: dashboard.accountForecasts.map(({ accountId, accountName, events }) => ({
+        accountId,
+        accountName,
+        events,
+      })),
+    });
   })
   .post("/confirm", async (c) => {
     try {

--- a/packages/backend/src/services/forecast.ts
+++ b/packages/backend/src/services/forecast.ts
@@ -60,7 +60,10 @@ function getDisposableBalance(account: { balance: number; balanceOffset: number 
   return account.balance - account.balanceOffset;
 }
 
-export async function buildDashboard(prisma: PrismaClient): Promise<DashboardResponse> {
+export async function buildDashboard(
+  prisma: PrismaClient,
+  options?: { forecastMonths?: number },
+): Promise<DashboardResponse> {
   const today = getJstToday();
   const currentYearMonth = getCurrentYearMonth(today);
 
@@ -95,7 +98,7 @@ export async function buildDashboard(prisma: PrismaClient): Promise<DashboardRes
     ]);
 
   const defaultSettlementDay = Number(DEFAULT_SETTINGS.credit_card_settlement_day);
-  const forecastMonths = Number(DEFAULT_SETTINGS.forecast_months);
+  const forecastMonths = options?.forecastMonths ?? Number(DEFAULT_SETTINGS.forecast_months);
 
   const billingMap = new Map(
     billings.map((billing) => [

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import type { Account, DashboardResponse, ForecastEvent } from "@sui/shared";
+import type { Account, DashboardEventsResponse, DashboardResponse, ForecastEvent } from "@sui/shared";
 import {
   Line,
   LineChart,
@@ -27,14 +27,40 @@ import { apiFetch } from "../lib/api";
 import { formatChartDateWithYear, formatCurrency, formatDateWithYear } from "../lib/format";
 import { getTodayDate } from "../lib/utils";
 
+type DashboardPeriodPreset = "next1Month" | "next3Months" | "next6Months" | "next1Year" | "all";
+
+const DEFAULT_DASHBOARD_PERIOD: DashboardPeriodPreset = "next3Months";
+
+const dashboardPeriodOptions: Array<{ value: DashboardPeriodPreset; label: string }> = [
+  { value: "next1Month", label: "1ヶ月" },
+  { value: "next3Months", label: "3ヶ月" },
+  { value: "next6Months", label: "6ヶ月" },
+  { value: "next1Year", label: "1年" },
+  { value: "all", label: "全期間" },
+];
+
+const presetToMonths: Record<DashboardPeriodPreset, number> = {
+  next1Month: 1,
+  next3Months: 3,
+  next6Months: 6,
+  next1Year: 12,
+  all: 24,
+};
+
 export function DashboardPage() {
   const [reloadKey, setReloadKey] = useState(0);
   const [selectedTab, setSelectedTab] = useState<string>("total");
+  const [periodPreset, setPeriodPreset] = useState<DashboardPeriodPreset>(DEFAULT_DASHBOARD_PERIOD);
   const [selectedEvent, setSelectedEvent] = useState<ForecastEvent | null>(null);
   const [confirmAmount, setConfirmAmount] = useState(0);
   const [accountId, setAccountId] = useState("");
+  const months = presetToMonths[periodPreset];
 
-  const { data, loading, error } = useResource(
+  const {
+    data: dashboardData,
+    loading: dashboardLoading,
+    error: dashboardError,
+  } = useResource(
     () =>
       Promise.all([
         apiFetch<DashboardResponse>("/api/dashboard"),
@@ -42,16 +68,30 @@ export function DashboardPage() {
       ]).then(([dashboard, accounts]) => ({ dashboard, accounts })),
     [reloadKey],
   );
+  const {
+    data: eventsData,
+    loading: eventsLoading,
+    error: eventsError,
+  } = useResource(
+    () => apiFetch<DashboardEventsResponse>(`/api/dashboard/events?months=${months}`),
+    [reloadKey, months],
+  );
 
   const today = getTodayDate();
-  const accounts = data?.accounts ?? [];
-  const accountForecasts = data?.dashboard.accountForecasts ?? [];
+  const accounts = dashboardData?.accounts ?? [];
+  const accountForecasts = dashboardData?.dashboard.accountForecasts ?? [];
   const selectedAccountForecast =
     selectedTab === "total"
       ? null
       : accountForecasts.find((forecast) => forecast.accountId === selectedTab) ?? null;
-  const activeForecast = selectedAccountForecast?.events ?? data?.dashboard.forecast ?? [];
-  const currentBalance = selectedAccountForecast?.currentBalance ?? data?.dashboard.totalBalance ?? 0;
+  const selectedAccountEvents =
+    selectedTab === "total"
+      ? null
+      : eventsData?.accountForecasts.find((forecast) => forecast.accountId === selectedTab) ?? null;
+  const chartForecast = selectedAccountForecast?.events ?? dashboardData?.dashboard.forecast ?? [];
+  const tableForecast = selectedAccountEvents?.events ?? eventsData?.forecast ?? [];
+  const currentBalance =
+    selectedAccountForecast?.currentBalance ?? dashboardData?.dashboard.totalBalance ?? 0;
   const chartData = [
     {
       id: "today-marker",
@@ -61,7 +101,7 @@ export function DashboardPage() {
       balance: currentBalance,
       accountId: selectedAccountForecast?.accountId ?? null,
     },
-    ...activeForecast,
+    ...chartForecast,
   ];
   const chartDomain: [number, number] =
     chartData.length === 0
@@ -125,25 +165,25 @@ export function DashboardPage() {
       ) : null}
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <SummaryCard title="総所持金" value={formatCurrency(data?.dashboard.totalBalance ?? 0)} />
-        <SummaryCard title="全体の最小残高" value={formatCurrency(data?.dashboard.minBalance ?? 0)} />
+        <SummaryCard title="総所持金" value={formatCurrency(dashboardData?.dashboard.totalBalance ?? 0)} />
+        <SummaryCard title="全体の最小残高" value={formatCurrency(dashboardData?.dashboard.minBalance ?? 0)} />
         <SummaryCard
           title="次の収入"
           value={
-            data?.dashboard.nextIncome
-              ? `${formatDateWithYear(data.dashboard.nextIncome.date)} ${formatCurrency(data.dashboard.nextIncome.amount)}`
+            dashboardData?.dashboard.nextIncome
+              ? `${formatDateWithYear(dashboardData.dashboard.nextIncome.date)} ${formatCurrency(dashboardData.dashboard.nextIncome.amount)}`
               : "なし"
           }
-          detail={data?.dashboard.nextIncome?.description}
+          detail={dashboardData?.dashboard.nextIncome?.description}
         />
         <SummaryCard
           title="次の支出"
           value={
-            data?.dashboard.nextExpense
-              ? `${formatDateWithYear(data.dashboard.nextExpense.date)} ${formatCurrency(data.dashboard.nextExpense.amount)}`
+            dashboardData?.dashboard.nextExpense
+              ? `${formatDateWithYear(dashboardData.dashboard.nextExpense.date)} ${formatCurrency(dashboardData.dashboard.nextExpense.amount)}`
               : "なし"
           }
-          detail={data?.dashboard.nextExpense?.description}
+          detail={dashboardData?.dashboard.nextExpense?.description}
         />
       </section>
 
@@ -178,10 +218,10 @@ export function DashboardPage() {
             </Button>
           )}
         </div>
-        {loading ? (
+        {dashboardLoading ? (
           <StateMessage message="読み込み中..." />
-        ) : error ? (
-          <StateMessage message={error} tone="danger" />
+        ) : dashboardError ? (
+          <StateMessage message={dashboardError} tone="danger" />
         ) : chartData.length === 0 ? (
           <StateMessage message="表示できる予測イベントがありません。" />
         ) : (
@@ -229,46 +269,70 @@ export function DashboardPage() {
       </Card>
 
       <Card>
-        <div className="mb-4">
-          <h2 className="text-xl font-semibold">{selectedAccountForecast ? `${selectedAccountForecast.accountName} の予測イベント` : "予測イベント"}</h2>
-          <p className="text-sm text-white/60">当日以降の未確定イベントだけを表示します。</p>
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <h2 className="text-xl font-semibold">
+            {selectedAccountForecast ? `${selectedAccountForecast.accountName} の予測イベント` : "予測イベント"}
+          </h2>
+          <Select
+            aria-label="予測イベントの表示期間"
+            className="w-auto min-w-28"
+            value={periodPreset}
+            onChange={(event) => setPeriodPreset(event.target.value as DashboardPeriodPreset)}
+          >
+            {dashboardPeriodOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
         </div>
-        <TableWrapper>
-          <Table>
-            <thead>
-              <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] text-white/45">
-                <th className="px-3 py-3">日付</th>
-                <th className="px-3 py-3">種別</th>
-                <th className="px-3 py-3">内容</th>
-                <th className="px-3 py-3">金額</th>
-                <th className="px-3 py-3">残高</th>
-                <th className="px-3 py-3">対象口座</th>
-                <th className="px-3 py-3" />
-              </tr>
-            </thead>
-            <tbody>
-              {activeForecast.map((event) => (
-                <tr key={event.id} className="border-b border-white/5">
-                  <td className="px-3 py-3 text-white/70">{formatDateWithYear(event.date)}</td>
-                  <td className="px-3 py-3">
-                    <span className={event.type === "income" ? "text-sky-300" : "text-pink-300"}>
-                      {event.type === "income" ? "収入" : "支出"}
-                    </span>
-                  </td>
-                  <td className="px-3 py-3">{event.description}</td>
-                  <td className="px-3 py-3">{formatCurrency(event.amount)}</td>
-                  <td className="px-3 py-3">{formatCurrency(event.balance)}</td>
-                  <td className="px-3 py-3">{accounts.find((account) => account.id === event.accountId)?.name ?? "-"}</td>
-                  <td className="px-3 py-3 text-right">
-                    <Button variant="ghost" onClick={() => openConfirm(event)}>
-                      確定
-                    </Button>
-                  </td>
+        <p className="mb-4 text-sm text-white/60">当日以降の未確定イベントだけを表示します。</p>
+        {eventsLoading ? (
+          <StateMessage message="読み込み中..." />
+        ) : eventsError ? (
+          <StateMessage message={eventsError} tone="danger" />
+        ) : tableForecast.length === 0 ? (
+          <StateMessage message="表示できる予測イベントがありません。" />
+        ) : (
+          <TableWrapper>
+            <Table>
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] text-white/45">
+                  <th className="px-3 py-3">日付</th>
+                  <th className="px-3 py-3">種別</th>
+                  <th className="px-3 py-3">内容</th>
+                  <th className="px-3 py-3">金額</th>
+                  <th className="px-3 py-3">残高</th>
+                  <th className="px-3 py-3">対象口座</th>
+                  <th className="px-3 py-3" />
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-        </TableWrapper>
+              </thead>
+              <tbody>
+                {tableForecast.map((event) => (
+                  <tr key={event.id} className="border-b border-white/5">
+                    <td className="px-3 py-3 text-white/70">{formatDateWithYear(event.date)}</td>
+                    <td className="px-3 py-3">
+                      <span className={event.type === "income" ? "text-sky-300" : "text-pink-300"}>
+                        {event.type === "income" ? "収入" : "支出"}
+                      </span>
+                    </td>
+                    <td className="px-3 py-3">{event.description}</td>
+                    <td className="px-3 py-3">{formatCurrency(event.amount)}</td>
+                    <td className="px-3 py-3">{formatCurrency(event.balance)}</td>
+                    <td className="px-3 py-3">
+                      {accounts.find((account) => account.id === event.accountId)?.name ?? "-"}
+                    </td>
+                    <td className="px-3 py-3 text-right">
+                      <Button variant="ghost" onClick={() => openConfirm(event)}>
+                        確定
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </TableWrapper>
+        )}
       </Card>
 
       <Dialog open={Boolean(selectedEvent)} onOpenChange={(open) => !open && setSelectedEvent(null)}>

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -128,6 +128,50 @@ describe("MCP server", () => {
         ],
       },
     });
+    addRoute("GET", "/api/dashboard/events?months=6", {
+      body: {
+        forecast: [
+          {
+            id: "event-1",
+            date: "2026-03-25",
+            type: "income",
+            description: "給与",
+            amount: 250000,
+            balance: 373456,
+            accountId: "11111111-1111-4111-a111-111111111111",
+          },
+        ],
+        accountForecasts: [
+          {
+            accountId: "11111111-1111-4111-a111-111111111111",
+            accountName: "三菱UFJ銀行",
+            events: [
+              {
+                id: "event-1",
+                date: "2026-03-25",
+                type: "income",
+                description: "給与",
+                amount: 250000,
+                balance: 373456,
+                accountId: "11111111-1111-4111-a111-111111111111",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    addRoute("GET", "/api/dashboard/events?months=3", {
+      body: {
+        forecast: [],
+        accountForecasts: [
+          {
+            accountId: "11111111-1111-4111-a111-111111111111",
+            accountName: "三菱UFJ銀行",
+            events: [],
+          },
+        ],
+      },
+    });
     addRoute("GET", "/api/accounts", {
       body: [{
         id: "11111111-1111-4111-a111-111111111111",
@@ -324,6 +368,30 @@ describe("MCP server", () => {
     });
   });
 
+  it("uses the events API when get_dashboard is called with months", async () => {
+    const result = await client.callTool({
+      name: "get_dashboard",
+      arguments: { months: 3 },
+    });
+
+    expect(getToolText(result)).toContain("未確定イベント総数: 0件");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/dashboard",
+      body: undefined,
+    });
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/dashboard/events?months=3",
+      body: undefined,
+    });
+  });
+
   it("forwards transaction list filters to the REST API", async () => {
     await client.callTool({
       name: "list_transactions",
@@ -364,6 +432,35 @@ describe("MCP server", () => {
     expect(requests).toContainEqual({
       method: "GET",
       path: "/api/transactions?page=1&limit=100&startDate=2026-03-01&endDate=2026-03-31",
+      body: undefined,
+    });
+  });
+
+  it("builds forecast-analysis with month-scoped dashboard events", async () => {
+    const prompt = await client.getPrompt({
+      name: "forecast-analysis",
+      arguments: { months: "6" },
+    });
+
+    const promptText = prompt.messages[0]?.content.type === "text"
+      ? prompt.messages[0].content.text
+      : "";
+    expect(promptText).toContain("今後 6 ヶ月");
+    expect(promptText).toContain("\"forecast\": [");
+    expect(promptText).not.toContain("\"id\": \"event-2\"");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/dashboard",
+      body: undefined,
+    });
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/dashboard/events?months=6",
       body: undefined,
     });
   });

--- a/packages/mcp/src/format.ts
+++ b/packages/mcp/src/format.ts
@@ -70,7 +70,8 @@ export function formatDashboardText(data: DashboardResponse, today: string) {
   return lines.join("\n");
 }
 
-export function formatForecastSummary(data: DashboardResponse) {
+export function formatForecastSummary(data: DashboardResponse, forecastMonths?: number) {
+  const months = forecastMonths ?? Number(DEFAULT_SETTINGS.forecast_months);
   const minEvent = data.forecast.reduce<{ amount: number; date: string } | null>((current, event) => {
     if (!current || event.balance < current.amount) {
       return { amount: event.balance, date: event.date };
@@ -84,7 +85,7 @@ export function formatForecastSummary(data: DashboardResponse) {
     "",
     `■ 現在の合計残高: ${formatCurrency(data.totalBalance)}`,
     `■ 予測最小残高:   ${formatCurrency(minEvent?.amount ?? data.totalBalance)}（${minEvent?.date ?? "該当なし"}）`,
-    `■ 予測期間:       ${DEFAULT_SETTINGS.forecast_months}ヶ月`,
+    `■ 予測期間:       ${months}ヶ月`,
     "",
     "【口座別】",
   ];

--- a/packages/mcp/src/prompts/budget-advice.ts
+++ b/packages/mcp/src/prompts/budget-advice.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
   BillingResponse,
   CreditCardsResponse,
+  DashboardEventsResponse,
   DashboardResponse,
   LoansResponse,
   RecurringItemsResponse,
@@ -18,6 +19,22 @@ function toMonthDateRange(month: string) {
   const endDate = `${month}-${String(lastDay).padStart(2, "0")}`;
 
   return { startDate, endDate };
+}
+
+function replaceDashboardEvents(
+  dashboard: DashboardResponse,
+  events: DashboardEventsResponse,
+): DashboardResponse {
+  const eventMap = new Map(events.accountForecasts.map((forecast) => [forecast.accountId, forecast.events]));
+
+  return {
+    ...dashboard,
+    forecast: events.forecast,
+    accountForecasts: dashboard.accountForecasts.map((forecast) => ({
+      ...forecast,
+      events: eventMap.get(forecast.accountId) ?? [],
+    })),
+  };
 }
 
 export function registerAnalysisPrompts(server: McpServer, apiClient: SuiApiClient) {
@@ -70,11 +87,14 @@ export function registerAnalysisPrompts(server: McpServer, apiClient: SuiApiClie
     "forecast-analysis",
     "残高予測の分析と改善提案を生成する",
     {
-      months: z.number().int().min(1).max(24).optional().describe("分析対象月数"),
+      months: z.coerce.number().int().min(1).max(24).optional().describe("分析対象月数"),
     },
     async ({ months = 6 }) => {
-      const dashboard = await apiClient.get<DashboardResponse>("/api/dashboard");
-      const relevantEvents = dashboard.forecast.slice(0, months * 10);
+      const [dashboard, events] = await Promise.all([
+        apiClient.get<DashboardResponse>("/api/dashboard"),
+        apiClient.get<DashboardEventsResponse>(`/api/dashboard/events?months=${months}`),
+      ]);
+      const scopedDashboard = replaceDashboardEvents(dashboard, events);
 
       return {
         messages: [{
@@ -91,10 +111,7 @@ export function registerAnalysisPrompts(server: McpServer, apiClient: SuiApiClie
               "4. 具体的な対策案",
               "",
               "【ダッシュボード】",
-              JSON.stringify({
-                ...dashboard,
-                forecast: relevantEvents,
-              }, null, 2),
+              JSON.stringify(scopedDashboard, null, 2),
             ].join("\n"),
           },
         }],

--- a/packages/mcp/src/tools/dashboard.ts
+++ b/packages/mcp/src/tools/dashboard.ts
@@ -1,17 +1,46 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ConfirmForecastPayload, DashboardResponse, Transaction } from "@sui/shared";
+import type {
+  ConfirmForecastPayload,
+  DashboardEventsResponse,
+  DashboardResponse,
+  Transaction,
+} from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatDashboardText } from "../format";
 import { positiveMoneySchema, textContent, uuidSchema } from "../helpers";
 import { z } from "zod";
 
+function replaceDashboardEvents(
+  dashboard: DashboardResponse,
+  events: DashboardEventsResponse,
+): DashboardResponse {
+  const eventMap = new Map(events.accountForecasts.map((forecast) => [forecast.accountId, forecast.events]));
+
+  return {
+    ...dashboard,
+    forecast: events.forecast,
+    accountForecasts: dashboard.accountForecasts.map((forecast) => ({
+      ...forecast,
+      events: eventMap.get(forecast.accountId) ?? [],
+    })),
+  };
+}
+
 export function registerDashboardTools(server: McpServer, apiClient: SuiApiClient) {
   server.tool(
     "get_dashboard",
     "ダッシュボードデータ（残高予測・直近イベント・口座別予測）を取得する",
-    {},
-    async () => {
-      const data = await apiClient.get<DashboardResponse>("/api/dashboard");
+    {
+      months: z.number().int().min(1).max(24).optional().describe("予測イベントの取得期間（月数、省略時は全期間）"),
+    },
+    async ({ months }) => {
+      const dashboard = await apiClient.get<DashboardResponse>("/api/dashboard");
+      const data = months
+        ? replaceDashboardEvents(
+            dashboard,
+            await apiClient.get<DashboardEventsResponse>(`/api/dashboard/events?months=${months}`),
+          )
+        : dashboard;
       const now = new Date();
       const today = new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
       return textContent(formatDashboardText(data, today));

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -18,6 +18,11 @@ export interface DashboardResponse {
   accountForecasts: AccountForecast[];
 }
 
+export interface DashboardEventsResponse {
+  forecast: ForecastEvent[];
+  accountForecasts: Pick<AccountForecast, "accountId" | "accountName" | "events">[];
+}
+
 export interface ConfirmForecastPayload {
   forecastEventId: string;
   amount: number;


### PR DESCRIPTION
This pull request introduces a new `/api/dashboard/events` endpoint that allows clients to fetch forecast events for a specified number of months, and updates both the backend and frontend to support dynamic, period-based event filtering and display. The frontend dashboard now lets users select the forecast period, and the MCP server and analysis prompts are updated to use and test the new scoped events API.

**Backend API and Service Enhancements:**

- Added a new `/api/dashboard/events` GET endpoint that returns only forecast events and account forecasts for a user-specified period (`months`), with validation and defaulting to 3 months. The main dashboard builder (`buildDashboard`) was updated to accept an optional `forecastMonths` parameter. [[1]](diffhunk://#diff-179ddcc401605ef81d5985cdb6375f483fdfad2564b673e16e58c2c0c065108eR14-R17) [[2]](diffhunk://#diff-179ddcc401605ef81d5985cdb6375f483fdfad2564b673e16e58c2c0c065108eR32-R44) [[3]](diffhunk://#diff-39789cb3138cb76a0900b30c9b1eca02a60a5937f8d81fd37ce8cd4c3e87b74fL63-R66) [[4]](diffhunk://#diff-39789cb3138cb76a0900b30c9b1eca02a60a5937f8d81fd37ce8cd4c3e87b74fL98-R101) [[5]](diffhunk://#diff-a7c5c7b74ddf9a1aa94ae6bd2156ac9d97bef5dbcef99c8a1d344b80613810e2R30-R70)

**Frontend Dashboard Improvements:**

- The dashboard page now supports selecting the forecast period (1, 3, 6, 12, or 24 months) via a dropdown. It fetches and displays events for the selected period, separating chart and table data sources and updating loading/error handling accordingly. [[1]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL1-R1) [[2]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dR30-R94) [[3]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL64-R104) [[4]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL128-R186) [[5]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL181-R224) [[6]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL232-R296) [[7]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL250-R311) [[8]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL261-R324) [[9]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dR335)

**MCP Server & Prompt Integration:**

- The MCP server and analysis prompts now use the new events endpoint to fetch month-scoped forecast data. The analysis prompt (`forecast-analysis`) combines `/api/dashboard` and `/api/dashboard/events`, ensuring the summary and advice are based on the selected period. [[1]](diffhunk://#diff-43e34c77c434d8811a30686c14833b1aee7adeaa54ee652b934ab3a63db3b5aaR5) [[2]](diffhunk://#diff-43e34c77c434d8811a30686c14833b1aee7adeaa54ee652b934ab3a63db3b5aaR24-R39) [[3]](diffhunk://#diff-43e34c77c434d8811a30686c14833b1aee7adeaa54ee652b934ab3a63db3b5aaL73-R97) [[4]](diffhunk://#diff-bafad27a91db50bb46485549e58004eba67470c25bac55d6207de28f6057723aL73-R74) [[5]](diffhunk://#diff-bafad27a91db50bb46485549e58004eba67470c25bac55d6207de28f6057723aL87-R88)

**Testing and Mock Data:**

- Added and updated integration and unit tests to cover the new endpoint, its query parameters, and its integration with the MCP server, including prompt generation and tool calls. [[1]](diffhunk://#diff-a775487b98c9b47bfea24f9c1b578aea96509b74b4fc6cae48023c185ce68a23R131-R174) [[2]](diffhunk://#diff-a775487b98c9b47bfea24f9c1b578aea96509b74b4fc6cae48023c185ce68a23R371-R394) [[3]](diffhunk://#diff-a775487b98c9b47bfea24f9c1b578aea96509b74b4fc6cae48023c185ce68a23R438-R466)

---

**Backend API & Service:**
- Added `/api/dashboard/events` endpoint with `months` query parameter to return forecast events scoped to the requested period. Updated `buildDashboard` to accept `forecastMonths`. [[1]](diffhunk://#diff-179ddcc401605ef81d5985cdb6375f483fdfad2564b673e16e58c2c0c065108eR14-R17) [[2]](diffhunk://#diff-179ddcc401605ef81d5985cdb6375f483fdfad2564b673e16e58c2c0c065108eR32-R44) [[3]](diffhunk://#diff-39789cb3138cb76a0900b30c9b1eca02a60a5937f8d81fd37ce8cd4c3e87b74fL63-R66) [[4]](diffhunk://#diff-39789cb3138cb76a0900b30c9b1eca02a60a5937f8d81fd37ce8cd4c3e87b74fL98-R101) [[5]](diffhunk://#diff-a7c5c7b74ddf9a1aa94ae6bd2156ac9d97bef5dbcef99c8a1d344b80613810e2R30-R70)

**Frontend Dashboard:**
- Implemented period selection for forecast events, fetching and displaying data for the selected period, and improved UI state handling for event tables. [[1]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL1-R1) [[2]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dR30-R94) [[3]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL64-R104) [[4]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL128-R186) [[5]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL181-R224) [[6]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL232-R296) [[7]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL250-R311) [[8]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dL261-R324) [[9]](diffhunk://#diff-8e317d124951eb30e18c1af1a8e403f7f82135b117ad50da0c9e097e3e10bc4dR335)

**MCP Integration:**
- Updated MCP server and prompts to use the new scoped events API, including combining dashboard and event data for period-specific analysis. [[1]](diffhunk://#diff-43e34c77c434d8811a30686c14833b1aee7adeaa54ee652b934ab3a63db3b5aaR5) [[2]](diffhunk://#diff-43e34c77c434d8811a30686c14833b1aee7adeaa54ee652b934ab3a63db3b5aaR24-R39) [[3]](diffhunk://#diff-43e34c77c434d8811a30686c14833b1aee7adeaa54ee652b934ab3a63db3b5aaL73-R97) [[4]](diffhunk://#diff-bafad27a91db50bb46485549e58004eba67470c25bac55d6207de28f6057723aL73-R74) [[5]](diffhunk://#diff-bafad27a91db50bb46485549e58004eba67470c25bac55d6207de28f6057723aL87-R88)

**Testing:**
- Added and updated tests for the new endpoint, query parameter handling, and MCP prompt/tool integration. [[1]](diffhunk://#diff-a775487b98c9b47bfea24f9c1b578aea96509b74b4fc6cae48023c185ce68a23R131-R174) [[2]](diffhunk://#diff-a775487b98c9b47bfea24f9c1b578aea96509b74b4fc6cae48023c185ce68a23R371-R394) [[3]](diffhunk://#diff-a775487b98c9b47bfea24f9c1b578aea96509b74b4fc6cae48023c185ce68a23R438-R466)