### PR TITLE
feat(transactions): 取引の削除機能を実装

### DIFF
--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -53,6 +53,52 @@ test("edits an existing transaction from the history table", async ({ page }) =>
   await expect(page.getByText("Lunch")).toHaveCount(0);
 });
 
+test("deletes a manual transaction and restores the account balance", async ({ page }) => {
+  const account = await seedAccount({ name: "Main Account", balance: 8800 });
+  const today = getFutureDate(0);
+
+  await seedTransaction({
+    accountId: account.id,
+    description: "Lunch",
+    amount: 1200,
+    type: "expense",
+    date: new Date(`${today}T00:00:00.000Z`),
+  });
+
+  await navigateTo(page, "/transactions");
+
+  const row = page.getByRole("row", { name: /Lunch/ });
+  await row.getByRole("button", { name: "削除" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toContainText("残高が元に戻ります");
+  await dialog.getByRole("button", { name: "削除" }).click();
+  await waitForReload(page);
+
+  await expect(page.getByText("Lunch")).toHaveCount(0);
+  await expect(page.getByText(formatCurrency(10000))).toBeVisible();
+});
+
+test("disables the delete button for forecast-confirmed transactions", async ({ page }) => {
+  const account = await seedAccount({ name: "Main Account", balance: 8800 });
+  const today = getFutureDate(0);
+
+  await seedTransaction({
+    accountId: account.id,
+    description: "Forecast Lunch",
+    amount: 1200,
+    type: "expense",
+    forecastEventId: "forecast:1",
+    date: new Date(`${today}T00:00:00.000Z`),
+  });
+
+  await navigateTo(page, "/transactions");
+
+  const row = page.getByRole("row", { name: /Forecast Lunch/ });
+  await expect(row.getByRole("button", { name: "編集" })).toBeVisible();
+  await expect(row.getByRole("button", { name: "削除" })).toBeDisabled();
+});
+
 test("records a transfer transaction and shows both account names", async ({ page }) => {
   const source = await seedAccount({ name: "Account A", balance: 10000, sortOrder: 1 });
   const destination = await seedAccount({ name: "Account B", balance: 5000, sortOrder: 2 });

--- a/packages/backend/src/routes/loans.ts
+++ b/packages/backend/src/routes/loans.ts
@@ -23,7 +23,7 @@ export const loansRoutes = new Hono()
         orderBy: [{ startDate: "asc" }, { createdAt: "asc" }],
       }),
       prisma.transaction.findMany({
-        where: { forecastEventId: { startsWith: "loan:" } },
+        where: { forecastEventId: { startsWith: "loan:" }, deletedAt: null },
         select: { forecastEventId: true, amount: true },
       }),
     ]);

--- a/packages/backend/src/routes/transactions.integration.test.ts
+++ b/packages/backend/src/routes/transactions.integration.test.ts
@@ -697,4 +697,225 @@ describe("transactions routes", () => {
       error: "Transaction not found",
     });
   });
+
+  it("deletes an expense transaction and restores the account balance", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 800,
+      sortOrder: 1,
+    });
+    const existing = await createTransaction(testPrisma, {
+      accountId: account.id,
+      date: new Date("2026-03-14T00:00:00.000Z"),
+      description: "Lunch",
+      amount: 200,
+      type: "expense",
+    });
+
+    const response = await client.delete(`/api/transactions/${existing.id}`);
+
+    expect(response.status).toBe(204);
+
+    const [updatedAccount, deletedTransaction] = await Promise.all([
+      testPrisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      testPrisma.transaction.findUniqueOrThrow({ where: { id: existing.id } }),
+    ]);
+    expect(updatedAccount.balance).toBe(1000);
+    expect(deletedTransaction.deletedAt).not.toBeNull();
+  });
+
+  it("deletes an income transaction and restores the account balance", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 1200,
+      sortOrder: 1,
+    });
+    const existing = await createTransaction(testPrisma, {
+      accountId: account.id,
+      date: new Date("2026-03-14T00:00:00.000Z"),
+      description: "Bonus",
+      amount: 200,
+      type: "income",
+    });
+
+    const response = await client.delete(`/api/transactions/${existing.id}`);
+
+    expect(response.status).toBe(204);
+
+    const updatedAccount = await testPrisma.account.findUniqueOrThrow({
+      where: { id: account.id },
+    });
+    expect(updatedAccount.balance).toBe(1000);
+  });
+
+  it("deletes a transfer transaction and restores both account balances", async () => {
+    const source = await createAccount(testPrisma, {
+      name: "Source",
+      balance: 700,
+      sortOrder: 1,
+    });
+    const destination = await createAccount(testPrisma, {
+      name: "Destination",
+      balance: 800,
+      sortOrder: 2,
+    });
+    const existing = await createTransaction(testPrisma, {
+      accountId: source.id,
+      transferToAccountId: destination.id,
+      date: new Date("2026-03-14T00:00:00.000Z"),
+      description: "Move funds",
+      amount: 300,
+      type: "transfer",
+    });
+
+    const response = await client.delete(`/api/transactions/${existing.id}`);
+
+    expect(response.status).toBe(204);
+
+    const [updatedSource, updatedDestination] = await Promise.all([
+      testPrisma.account.findUniqueOrThrow({ where: { id: source.id } }),
+      testPrisma.account.findUniqueOrThrow({ where: { id: destination.id } }),
+    ]);
+    expect(updatedSource.balance).toBe(1000);
+    expect(updatedDestination.balance).toBe(500);
+  });
+
+  it("hides deleted transactions from the transaction list", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 800,
+      sortOrder: 1,
+    });
+    const deleted = await createTransaction(testPrisma, {
+      accountId: account.id,
+      date: new Date("2026-03-14T00:00:00.000Z"),
+      description: "Deleted expense",
+      amount: 200,
+      type: "expense",
+      deletedAt: new Date("2026-03-15T00:00:00.000Z"),
+    });
+    const visible = await createTransaction(testPrisma, {
+      accountId: account.id,
+      date: new Date("2026-03-16T00:00:00.000Z"),
+      description: "Visible expense",
+      amount: 100,
+      type: "expense",
+    });
+
+    const response = await client.get(`/api/transactions?accountId=${account.id}`);
+    const body = await parseJson<{
+      items: Array<{ id: string }>;
+      total: number;
+    }>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.total).toBe(1);
+    expect(body.items.map((item) => item.id)).toEqual([visible.id]);
+    expect(body.items.map((item) => item.id)).not.toContain(deleted.id);
+  });
+
+  it("hides deleted transactions from balance history", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 1000,
+      sortOrder: 1,
+    });
+
+    await createTransaction(testPrisma, {
+      accountId: account.id,
+      date: new Date("2026-03-01T00:00:00.000Z"),
+      description: "Salary",
+      amount: 500,
+      type: "income",
+    });
+    await createTransaction(testPrisma, {
+      accountId: account.id,
+      date: new Date("2026-03-05T00:00:00.000Z"),
+      description: "Deleted lunch",
+      amount: 200,
+      type: "expense",
+      deletedAt: new Date("2026-03-06T00:00:00.000Z"),
+    });
+    await createTransaction(testPrisma, {
+      accountId: account.id,
+      date: new Date("2026-03-10T00:00:00.000Z"),
+      description: "Dinner",
+      amount: 300,
+      type: "expense",
+    });
+
+    const response = await client.get(
+      `/api/transactions/balance-history?accountId=${account.id}&startDate=2026-03-01&endDate=2026-03-10`,
+    );
+    const body = await parseJson<{
+      points: Array<{ date: string; balance: number; description: string }>;
+    }>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.points).toEqual([
+      { date: "2026-03-01", balance: 1300, description: "Salary" },
+      { date: "2026-03-10", balance: 1000, description: "Dinner" },
+    ]);
+  });
+
+  it("rejects deleting forecast-confirmed transactions", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 800,
+      sortOrder: 1,
+    });
+    const existing = await createTransaction(testPrisma, {
+      accountId: account.id,
+      date: new Date("2026-03-14T00:00:00.000Z"),
+      description: "Forecast expense",
+      amount: 200,
+      type: "expense",
+      forecastEventId: "forecast-1",
+    });
+
+    const response = await client.delete(`/api/transactions/${existing.id}`);
+
+    expect(response.status).toBe(403);
+    expect(await parseJson(response)).toEqual({
+      error: "Forecast-confirmed transactions cannot be deleted",
+    });
+
+    const [updatedAccount, stored] = await Promise.all([
+      testPrisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      testPrisma.transaction.findUniqueOrThrow({ where: { id: existing.id } }),
+    ]);
+    expect(updatedAccount.balance).toBe(800);
+    expect(stored.deletedAt).toBeNull();
+  });
+
+  it("returns 404 when deleting an already deleted transaction", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 1000,
+      sortOrder: 1,
+    });
+    const existing = await createTransaction(testPrisma, {
+      accountId: account.id,
+      description: "Deleted",
+      amount: 100,
+      type: "expense",
+      deletedAt: new Date("2026-03-14T00:00:00.000Z"),
+    });
+
+    const response = await client.delete(`/api/transactions/${existing.id}`);
+
+    expect(response.status).toBe(404);
+    expect(await parseJson(response)).toEqual({
+      error: "Transaction not found",
+    });
+  });
+
+  it("returns 404 when deleting a missing transaction", async () => {
+    const response = await client.delete("/api/transactions/00000000-0000-0000-0000-000000000000");
+
+    expect(response.status).toBe(404);
+    expect(await parseJson(response)).toEqual({
+      error: "Transaction not found",
+    });
+  });
 });

--- a/packages/backend/src/routes/transactions.ts
+++ b/packages/backend/src/routes/transactions.ts
@@ -272,7 +272,7 @@ export const transactionsRoutes = new Hono()
         endDate: c.req.query("endDate"),
       });
 
-      const where: Prisma.TransactionWhereInput = {};
+      const where: Prisma.TransactionWhereInput = { deletedAt: null };
       if (accountId) {
         where.OR = [
           { accountId },
@@ -351,6 +351,7 @@ export const transactionsRoutes = new Hono()
       const [transactionsAfterRange, transactionsInRange] = await Promise.all([
         prisma.transaction.findMany({
           where: {
+            deletedAt: null,
             ...scope,
             date: { gt: fromDateOnlyString(resolvedEndDate) },
           },
@@ -367,6 +368,7 @@ export const transactionsRoutes = new Hono()
         }),
         prisma.transaction.findMany({
           where: {
+            deletedAt: null,
             ...scope,
             date: {
               ...(startDate ? { gte: fromDateOnlyString(startDate) } : {}),
@@ -485,8 +487,8 @@ export const transactionsRoutes = new Hono()
   })
   .put("/:id", async (c) => {
     try {
-      const existing = await prisma.transaction.findUnique({
-        where: { id: c.req.param("id") },
+      const existing = await prisma.transaction.findFirst({
+        where: { id: c.req.param("id"), deletedAt: null },
       });
       if (!existing) {
         return notFound(c, "Transaction not found");
@@ -535,6 +537,31 @@ export const transactionsRoutes = new Hono()
       });
 
       return c.json(transaction);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .delete("/:id", async (c) => {
+    try {
+      const existing = await prisma.transaction.findFirst({
+        where: { id: c.req.param("id"), deletedAt: null },
+      });
+      if (!existing) {
+        return notFound(c, "Transaction not found");
+      }
+      if (existing.forecastEventId !== null) {
+        return c.json({ error: "Forecast-confirmed transactions cannot be deleted" }, 403);
+      }
+
+      await prisma.$transaction(async (tx) => {
+        await revertBalanceEffect(tx, existing);
+        await tx.transaction.update({
+          where: { id: existing.id },
+          data: { deletedAt: new Date() },
+        });
+      });
+
+      return c.body(null, 204);
     } catch (error) {
       return handleRouteError(c, error);
     }

--- a/packages/db/prisma/migrations/20260418000000_add_transaction_deleted_at/migration.sql
+++ b/packages/db/prisma/migrations/20260418000000_add_transaction_deleted_at/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "transactions"
+  ADD COLUMN "deleted_at" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -138,6 +138,7 @@ model Transaction {
   type                TransactionType
   description         String          @db.VarChar(200)
   amount              Int
+  deletedAt           DateTime?       @map("deleted_at")
   createdAt           DateTime        @default(now()) @map("created_at")
   account             Account         @relation("account_transactions", fields: [accountId], references: [id])
   transferToAccount   Account?        @relation("transfer_account_transactions", fields: [transferToAccountId], references: [id])

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -162,6 +162,7 @@ export async function createTransaction(
     type?: TransactionType;
     description?: string;
     amount?: number;
+    deletedAt?: Date | null;
   },
 ) {
   return prisma.transaction.create({
@@ -173,6 +174,7 @@ export async function createTransaction(
       type: data.type ?? "expense",
       description: data.description ?? "Test transaction",
       amount: data.amount ?? 1000,
+      deletedAt: data.deletedAt ?? null,
     },
   });
 }

--- a/packages/frontend/src/routes/transactions.tsx
+++ b/packages/frontend/src/routes/transactions.tsx
@@ -220,6 +220,7 @@ export function TransactionsPage() {
   const [form, setForm] = useState(emptyForm);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [editForm, setEditForm] = useState<TransactionForm>(emptyForm);
+  const [deletingTransaction, setDeletingTransaction] = useState<Transaction | null>(null);
   const range =
     periodPreset === "custom"
       ? { startDate: customStartDate, endDate: customEndDate }
@@ -313,6 +314,29 @@ export function TransactionsPage() {
       body: JSON.stringify(toTransactionPayload(editForm)),
     });
     closeEdit();
+    reload();
+  };
+
+  const openDelete = (transaction: Transaction) => {
+    setDeletingTransaction(transaction);
+  };
+
+  const closeDelete = () => {
+    setDeletingTransaction(null);
+  };
+
+  const confirmDelete = async () => {
+    if (!deletingTransaction) {
+      return;
+    }
+
+    await apiFetch(`/api/transactions/${deletingTransaction.id}`, {
+      method: "DELETE",
+    });
+    closeDelete();
+    if (transactionItems.length === 1 && page > 1) {
+      setPage((value) => value - 1);
+    }
     reload();
   };
 
@@ -448,7 +472,12 @@ export function TransactionsPage() {
             </thead>
             <tbody>
               {transactionItems.map((transaction) => (
-                <TransactionRow key={transaction.id} transaction={transaction} onEdit={openEdit} />
+                <TransactionRow
+                  key={transaction.id}
+                  transaction={transaction}
+                  onEdit={openEdit}
+                  onDelete={openDelete}
+                />
               ))}
             </tbody>
           </Table>
@@ -489,6 +518,48 @@ export function TransactionsPage() {
                 保存
               </Button>
             </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(deletingTransaction)} onOpenChange={(open) => !open && closeDelete()}>
+        <DialogContent className="w-[min(92vw,32rem)]">
+          <DialogTitle className="text-lg font-semibold">取引を削除</DialogTitle>
+          <DialogDescription className="mt-2 text-sm text-white/60">
+            この操作は取り消せません。削除すると口座残高が元に戻ります。
+          </DialogDescription>
+          {deletingTransaction ? (
+            <div className="mt-6 grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-white/60">日付</span>
+                <span>{formatDateWithYear(deletingTransaction.date)}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-white/60">内容</span>
+                <span>{deletingTransaction.description}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-white/60">金額</span>
+                <span>{formatCurrency(deletingTransaction.amount)}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-white/60">対象口座</span>
+                <span>
+                  {deletingTransaction.accountName}
+                  {deletingTransaction.transferToAccountName
+                    ? ` -> ${deletingTransaction.transferToAccountName}`
+                    : ""}
+                </span>
+              </div>
+            </div>
+          ) : null}
+          <div className="mt-6 flex justify-end gap-3">
+            <Button variant="ghost" onClick={closeDelete}>
+              キャンセル
+            </Button>
+            <Button variant="danger" onClick={confirmDelete}>
+              削除
+            </Button>
           </div>
         </DialogContent>
       </Dialog>
@@ -572,9 +643,11 @@ function TransactionFormFields({
 function TransactionRow({
   transaction,
   onEdit,
+  onDelete,
 }: {
   transaction: Transaction;
   onEdit: (transaction: Transaction) => void;
+  onDelete: (transaction: Transaction) => void;
 }) {
   return (
     <tr className="border-b border-white/5">
@@ -591,9 +664,19 @@ function TransactionRow({
         {transaction.transferToAccountName ? ` -> ${transaction.transferToAccountName}` : ""}
       </td>
       <td className="px-3 py-3 text-right">
-        <Button variant="ghost" onClick={() => onEdit(transaction)}>
-          編集
-        </Button>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={() => onEdit(transaction)}>
+            編集
+          </Button>
+          <Button
+            variant="ghost"
+            className="text-pink-300 hover:bg-pink-500/10 disabled:text-white/30 disabled:hover:bg-transparent"
+            disabled={transaction.forecastEventId !== null}
+            onClick={() => onDelete(transaction)}
+          >
+            削除
+          </Button>
+        </div>
       </td>
     </tr>
   );

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -343,6 +343,9 @@ describe("MCP server", () => {
         createdAt: "2026-03-20T00:00:00.000Z",
       },
     });
+    addRoute("DELETE", "/api/transactions/33333333-3333-4333-a333-333333333333", {
+      status: 204,
+    });
     addRoute("PUT", "/api/transactions/22222222-2222-4222-a222-222222222222", {
       body: {
         id: "22222222-2222-4222-a222-222222222222",
@@ -395,6 +398,7 @@ describe("MCP server", () => {
       "list_subscriptions",
       "create_transaction",
       "update_transaction",
+      "delete_transaction",
       "get_balance_history",
       "update_billing",
       "confirm_forecast",
@@ -510,6 +514,27 @@ describe("MCP server", () => {
         description: "ディナー",
         amount: 3200,
       },
+    });
+  });
+
+  it("forwards transaction deletes to the REST API", async () => {
+    const result = await client.callTool({
+      name: "delete_transaction",
+      arguments: {
+        id: "33333333-3333-4333-a333-333333333333",
+      },
+    });
+
+    expect(getToolText(result)).toContain("33333333-3333-4333-a333-333333333333");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "DELETE",
+      path: "/api/transactions/33333333-3333-4333-a333-333333333333",
+      body: undefined,
     });
   });
 

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -109,6 +109,18 @@ export function registerTransactionTools(server: McpServer, apiClient: SuiApiCli
   );
 
   server.tool(
+    "delete_transaction",
+    "手動で登録された取引を削除する（soft delete。口座残高は自動的に元に戻る。予測確定で自動生成された取引は削除不可）",
+    {
+      id: uuidSchema.describe("取引 ID"),
+    },
+    async ({ id }) => {
+      await apiClient.delete(`/api/transactions/${id}`);
+      return textContent(`取引を削除しました: ${id}`);
+    },
+  );
+
+  server.tool(
     "get_balance_history",
     "口座の過去の残高推移を取得します。期間と口座でフィルタ可能です。",
     {


### PR DESCRIPTION
- 取引を削除し、口座残高を自動的に元に戻す機能を追加。
- 削除された取引はリストから非表示にする。
- 予測確定された取引は削除不可とする。
- フロントエンドに削除確認ダイアログを追加。
- バックエンドに削除APIを実装し、テストを追加。