### PR TITLE
feat(mcp): mTLSサポートの追加と関連するテストの実装

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -14,6 +14,13 @@ pnpm build
 | 変数 | デフォルト | 説明 |
 |------|-----------|------|
 | `SUI_API_URL` | `http://localhost:3000` | sui バックエンド API の URL |
+| `SUI_API_CLIENT_CERT_PATH` | （未設定） | mTLS 用のクライアント証明書 (PEM) のパス。指定する場合は `SUI_API_CLIENT_KEY_PATH` も必須 |
+| `SUI_API_CLIENT_KEY_PATH` | （未設定） | mTLS 用のクライアント秘密鍵 (PEM) のパス |
+| `SUI_API_CLIENT_KEY_PASSPHRASE` | （未設定） | クライアント秘密鍵のパスフレーズ（鍵が暗号化されている場合のみ） |
+| `SUI_API_CA_CERT_PATH` | （未設定） | サーバー証明書を検証するための CA 証明書 (PEM) のパス。プライベート CA で発行された証明書を使う場合に指定 |
+| `SUI_API_TLS_REJECT_UNAUTHORIZED` | `true` | `false` を指定すると TLS 証明書の検証を無効化（開発用途のみ推奨） |
+
+mTLS で保護された API に接続する場合、`SUI_API_CLIENT_CERT_PATH` と `SUI_API_CLIENT_KEY_PATH` を必ず両方指定してください。片方のみの指定は起動時にエラーになります。
 
 ### Claude Desktop での設定例
 
@@ -24,7 +31,10 @@ pnpm build
       "command": "npx",
       "args": ["@soli0222/sui-mcp"],
       "env": {
-        "SUI_API_URL": "http://localhost:3000"
+        "SUI_API_URL": "https://sui.example.com",
+        "SUI_API_CLIENT_CERT_PATH": "/path/to/client.crt",
+        "SUI_API_CLIENT_KEY_PATH": "/path/to/client.key",
+        "SUI_API_CA_CERT_PATH": "/path/to/ca.crt"
       }
     }
   }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "undici": "^7.24.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/mcp/src/__tests__/api-client.test.ts
+++ b/packages/mcp/src/__tests__/api-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { Dispatcher } from "undici";
 import { SuiApiClient } from "../api-client";
 
 describe("SuiApiClient", () => {
@@ -47,5 +48,44 @@ describe("SuiApiClient", () => {
     );
 
     await expect(client.delete("/api/accounts/1")).rejects.toThrow("API error: 502");
+  });
+
+  it("forwards the configured dispatcher in fetch init for every method", async () => {
+    const fetchImpl = vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const dispatcher = { id: "fake-dispatcher" } as unknown as Dispatcher;
+    const client = new SuiApiClient("http://example.test", fetchImpl, dispatcher);
+
+    await client.get("/api/x");
+    await client.post("/api/x", { a: 1 });
+    await client.put("/api/x", { a: 2 });
+    await client.delete("/api/x");
+
+    expect(fetchImpl.mock.calls).toHaveLength(4);
+    for (const call of fetchImpl.mock.calls) {
+      const init = call[1] as { dispatcher?: unknown };
+      expect(init.dispatcher).toBe(dispatcher);
+    }
+  });
+
+  it("omits the dispatcher key when none is configured", async () => {
+    const fetchImpl = vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const client = new SuiApiClient("http://example.test", fetchImpl);
+
+    await client.get("/api/x");
+
+    const init = fetchImpl.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(init).not.toHaveProperty("dispatcher");
   });
 });

--- a/packages/mcp/src/__tests__/tls.test.ts
+++ b/packages/mcp/src/__tests__/tls.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Agent } from "undici";
+import { buildMtlsDispatcher } from "../tls";
+
+let workDir: string;
+let certPath: string;
+let keyPath: string;
+let caPath: string;
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), "sui-mcp-tls-"));
+  certPath = join(workDir, "client.crt");
+  keyPath = join(workDir, "client.key");
+  caPath = join(workDir, "ca.crt");
+  writeFileSync(certPath, "-----BEGIN CERTIFICATE-----\nclient\n-----END CERTIFICATE-----");
+  writeFileSync(keyPath, "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----");
+  writeFileSync(caPath, "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----");
+});
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("buildMtlsDispatcher", () => {
+  it("returns undefined when no TLS env vars are set", () => {
+    expect(buildMtlsDispatcher({})).toBeUndefined();
+  });
+
+  it("returns an undici Agent when client cert and key are provided", () => {
+    const dispatcher = buildMtlsDispatcher({
+      SUI_API_CLIENT_CERT_PATH: certPath,
+      SUI_API_CLIENT_KEY_PATH: keyPath,
+    });
+    expect(dispatcher).toBeInstanceOf(Agent);
+  });
+
+  it("supports CA-only configuration without a client cert", () => {
+    const dispatcher = buildMtlsDispatcher({ SUI_API_CA_CERT_PATH: caPath });
+    expect(dispatcher).toBeInstanceOf(Agent);
+  });
+
+  it("respects SUI_API_TLS_REJECT_UNAUTHORIZED=false on its own", () => {
+    const dispatcher = buildMtlsDispatcher({ SUI_API_TLS_REJECT_UNAUTHORIZED: "false" });
+    expect(dispatcher).toBeInstanceOf(Agent);
+  });
+
+  it("throws when only the cert path is set", () => {
+    expect(() =>
+      buildMtlsDispatcher({ SUI_API_CLIENT_CERT_PATH: certPath }),
+    ).toThrow(/SUI_API_CLIENT_CERT_PATH と SUI_API_CLIENT_KEY_PATH/);
+  });
+
+  it("throws when only the key path is set", () => {
+    expect(() =>
+      buildMtlsDispatcher({ SUI_API_CLIENT_KEY_PATH: keyPath }),
+    ).toThrow(/SUI_API_CLIENT_CERT_PATH と SUI_API_CLIENT_KEY_PATH/);
+  });
+
+  it("throws when the cert file does not exist", () => {
+    expect(() =>
+      buildMtlsDispatcher({
+        SUI_API_CLIENT_CERT_PATH: join(workDir, "missing.crt"),
+        SUI_API_CLIENT_KEY_PATH: keyPath,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/mcp/src/api-client.ts
+++ b/packages/mcp/src/api-client.ts
@@ -1,4 +1,8 @@
+import type { Dispatcher } from "undici";
+
 export type FetchLike = typeof fetch;
+
+type FetchInit = RequestInit & { dispatcher?: Dispatcher };
 
 async function parseErrorMessage(response: Response) {
   const body = await response.json().catch(() => null);
@@ -13,12 +17,18 @@ export class SuiApiClient {
   constructor(
     private readonly baseUrl: string,
     private readonly fetchImpl: FetchLike = fetch,
+    private readonly dispatcher?: Dispatcher,
   ) {}
 
+  private buildInit(init: FetchInit): FetchInit {
+    return this.dispatcher ? { ...init, dispatcher: this.dispatcher } : init;
+  }
+
   async get<T>(path: string): Promise<T> {
-    const response = await this.fetchImpl(new URL(path, this.baseUrl), {
-      method: "GET",
-    });
+    const response = await this.fetchImpl(
+      new URL(path, this.baseUrl),
+      this.buildInit({ method: "GET" }),
+    );
     if (!response.ok) {
       throw new Error(await parseErrorMessage(response));
     }
@@ -26,11 +36,14 @@ export class SuiApiClient {
   }
 
   async post<T>(path: string, body: unknown): Promise<T> {
-    const response = await this.fetchImpl(new URL(path, this.baseUrl), {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    });
+    const response = await this.fetchImpl(
+      new URL(path, this.baseUrl),
+      this.buildInit({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
     if (!response.ok) {
       throw new Error(await parseErrorMessage(response));
     }
@@ -41,11 +54,14 @@ export class SuiApiClient {
   }
 
   async put<T>(path: string, body: unknown): Promise<T> {
-    const response = await this.fetchImpl(new URL(path, this.baseUrl), {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    });
+    const response = await this.fetchImpl(
+      new URL(path, this.baseUrl),
+      this.buildInit({
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
     if (!response.ok) {
       throw new Error(await parseErrorMessage(response));
     }
@@ -53,9 +69,10 @@ export class SuiApiClient {
   }
 
   async delete(path: string): Promise<void> {
-    const response = await this.fetchImpl(new URL(path, this.baseUrl), {
-      method: "DELETE",
-    });
+    const response = await this.fetchImpl(
+      new URL(path, this.baseUrl),
+      this.buildInit({ method: "DELETE" }),
+    );
     if (!response.ok) {
       throw new Error(await parseErrorMessage(response));
     }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,9 +1,11 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SuiApiClient } from "./api-client";
 import { buildServer } from "./server";
+import { buildMtlsDispatcher } from "./tls";
 
 const apiBaseUrl = process.env.SUI_API_URL ?? "http://localhost:3000";
-const apiClient = new SuiApiClient(apiBaseUrl);
+const dispatcher = buildMtlsDispatcher();
+const apiClient = new SuiApiClient(apiBaseUrl, fetch, dispatcher);
 const server = buildServer({ apiClient });
 const transport = new StdioServerTransport();
 

--- a/packages/mcp/src/tls.ts
+++ b/packages/mcp/src/tls.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { Agent, type Dispatcher } from "undici";
+
+export interface MtlsEnv {
+  SUI_API_CLIENT_CERT_PATH?: string;
+  SUI_API_CLIENT_KEY_PATH?: string;
+  SUI_API_CLIENT_KEY_PASSPHRASE?: string;
+  SUI_API_CA_CERT_PATH?: string;
+  SUI_API_TLS_REJECT_UNAUTHORIZED?: string;
+}
+
+export function buildMtlsDispatcher(env: MtlsEnv = process.env): Dispatcher | undefined {
+  const certPath = env.SUI_API_CLIENT_CERT_PATH;
+  const keyPath = env.SUI_API_CLIENT_KEY_PATH;
+  const caPath = env.SUI_API_CA_CERT_PATH;
+  const passphrase = env.SUI_API_CLIENT_KEY_PASSPHRASE;
+  const rejectRaw = env.SUI_API_TLS_REJECT_UNAUTHORIZED;
+
+  const hasClientAuth = Boolean(certPath) || Boolean(keyPath);
+  const hasTlsConfig = hasClientAuth || Boolean(caPath) || rejectRaw !== undefined;
+  if (!hasTlsConfig) {
+    return undefined;
+  }
+
+  if (Boolean(certPath) !== Boolean(keyPath)) {
+    throw new Error(
+      "SUI_API_CLIENT_CERT_PATH と SUI_API_CLIENT_KEY_PATH は両方を指定してください",
+    );
+  }
+
+  return new Agent({
+    connect: {
+      cert: certPath ? readFileSync(certPath) : undefined,
+      key: keyPath ? readFileSync(keyPath) : undefined,
+      ca: caPath ? readFileSync(caPath) : undefined,
+      passphrase,
+      rejectUnauthorized: rejectRaw === undefined ? undefined : rejectRaw !== "false",
+    },
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      undici:
+        specifier: ^7.24.5
+        version: 7.24.5
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
- README.mdにmTLS用の環境変数を追加
- package.jsonにundici依存関係を追加
- SuiApiClientにdispatcherを追加し、fetchの初期化に使用
- tls.tsを新規作成し、mTLSディスパッチャーを構築する関数を実装
- api-client.test.tsにdispatcherのテストを追加
- tls.test.tsを新規作成し、mTLSディスパッチャーのテストを実装
- index.tsでmTLSディスパッチャーを使用するように変更