### PR TITLE
feat(mcp): MCPサーバーにHTTP/SSEモードを追加

### DIFF
--- a/.github/workflows/mcp-docker.yaml
+++ b/.github/workflows/mcp-docker.yaml
@@ -1,0 +1,126 @@
+name: Publish MCP Docker image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  TAGS: |
+    type=semver,pattern={{version}}
+    type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          echo "REGISTRY_IMAGE=${GITHUB_REPOSITORY,,}-mcp" >> "$GITHUB_ENV"
+
+      - name: Check out the repo
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.TAGS }}
+
+      - name: Log in to the ghcr.io registry
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push to ghcr.io
+        id: build
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: .
+          file: Dockerfile.mcp
+          push: true
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=mcp-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=mcp-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: mcp-digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - build
+    steps:
+      - name: Prepare
+        run: echo "REGISTRY_IMAGE=${GITHUB_REPOSITORY,,}-mcp" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@v8.0.1
+        with:
+          path: /tmp/digests
+          pattern: mcp-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.TAGS }}
+
+      - name: Log in to the ghcr.io registry
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,29 @@
+FROM node:24.15.0-bookworm AS build
+WORKDIR /app
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY packages/db/package.json packages/db/package.json
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/mcp/package.json packages/mcp/package.json
+
+RUN pnpm install --frozen-lockfile
+
+COPY packages/shared packages/shared
+COPY packages/mcp packages/mcp
+
+RUN pnpm --filter @soli0222/sui-mcp build
+RUN pnpm deploy --legacy --filter @soli0222/sui-mcp --prod /deploy
+
+FROM node:24.15.0-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV SUI_MCP_TRANSPORT=streamable-http
+ENV SUI_MCP_ADDRESS=0.0.0.0:8000
+
+COPY --from=build --chown=node:node /deploy /app
+
+USER node
+EXPOSE 8000
+
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ npx @soli0222/sui-mcp -t streamable-http --address :8000
 
 HTTP transport では `/healthz` をヘルスチェックに利用できます。
 
+MCP サーバーのみを Docker で起動する場合:
+
+```bash
+docker compose -f compose.mcp.yaml up -d --build
+```
+
 
 ## 本番ビルド
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ bash scripts/seed.sh all
 | `STATIC_DIR` | フロントエンドの静的ファイルパス | `../frontend/dist` |
 | `VITE_API_BASE` | フロントエンドからの API ベース URL | `http://localhost:3000` |
 | `SUI_API_URL` | MCP サーバーからの API ベース URL | `http://localhost:3000` |
+| `SUI_MCP_TRANSPORT` | MCP サーバーの transport (`stdio`, `sse`, `streamable-http`) | `stdio` |
+| `SUI_MCP_ADDRESS` | MCP HTTP transport の待受アドレス | `localhost:8000` |
+| `SUI_MCP_BASE_PATH` | MCP HTTP transport のベースパス | （未設定） |
+| `SUI_MCP_ENDPOINT_PATH` | Streamable HTTP の MCP エンドポイント | `/mcp` |
 
 ## API エンドポイント
 
@@ -214,6 +218,20 @@ Claude Desktop (`claude_desktop_config.json`) / VS Code (`.vscode/mcp.json`):
   }
 }
 ```
+
+### HTTP / SSE モード
+
+コンテナや常駐プロセスとして MCP サーバーを公開する場合は、 transport を指定できます。
+
+```bash
+# Legacy SSE: http://localhost:8000/sse
+npx @soli0222/sui-mcp -t sse --address :8000
+
+# Streamable HTTP: http://localhost:8000/mcp
+npx @soli0222/sui-mcp -t streamable-http --address :8000
+```
+
+HTTP transport では `/healthz` をヘルスチェックに利用できます。
 
 
 ## 本番ビルド

--- a/compose.mcp.yaml
+++ b/compose.mcp.yaml
@@ -1,0 +1,23 @@
+services:
+  mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile.mcp
+      target: runtime
+    image: sui-mcp:latest
+    ports:
+      - "${SUI_MCP_PORT:-8000}:8000"
+    environment:
+      SUI_API_URL: ${SUI_API_URL:-http://host.docker.internal:3000}
+      SUI_MCP_TRANSPORT: ${SUI_MCP_TRANSPORT:-streamable-http}
+      SUI_MCP_ADDRESS: 0.0.0.0:8000
+      SUI_MCP_BASE_PATH: ${SUI_MCP_BASE_PATH:-}
+      SUI_MCP_ENDPOINT_PATH: ${SUI_MCP_ENDPOINT_PATH:-/mcp}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"const base=process.env.SUI_MCP_BASE_PATH||''; fetch('http://127.0.0.1:8000'+base+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -49,6 +49,27 @@ sui-mcp -t streamable-http --address :8000 --base-path /sui --endpoint-path /mcp
 
 HTTP transport ではヘルスチェックとして `/healthz`（`--base-path` 指定時は `<base-path>/healthz`）を提供します。
 
+### Docker
+
+MCP サーバーのみをコンテナとして起動できます。既定では Streamable HTTP を `:8000` で公開し、sui API はホスト側の `http://host.docker.internal:3000` を参照します。
+
+```bash
+docker compose -f compose.mcp.yaml up -d --build
+```
+
+別の API URL に接続する場合:
+
+```bash
+SUI_API_URL=https://sui.example.com docker compose -f compose.mcp.yaml up -d --build
+```
+
+公開されるエンドポイント:
+
+| 用途 | URL |
+|------|-----|
+| Streamable HTTP | `http://localhost:8000/mcp` |
+| Health check | `http://localhost:8000/healthz` |
+
 ### Claude Desktop での設定例
 
 ```json

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -19,8 +19,35 @@ pnpm build
 | `SUI_API_CLIENT_KEY_PASSPHRASE` | （未設定） | クライアント秘密鍵のパスフレーズ（鍵が暗号化されている場合のみ） |
 | `SUI_API_CA_CERT_PATH` | （未設定） | サーバー証明書を検証するための CA 証明書 (PEM) のパス。プライベート CA で発行された証明書を使う場合に指定 |
 | `SUI_API_TLS_REJECT_UNAUTHORIZED` | `true` | `false` を指定すると TLS 証明書の検証を無効化（開発用途のみ推奨） |
+| `SUI_MCP_TRANSPORT` | `stdio` | MCP クライアントとの transport。`stdio`, `sse`, `streamable-http` |
+| `SUI_MCP_ADDRESS` | `localhost:8000` | `sse` / `streamable-http` の待受アドレス |
+| `SUI_MCP_BASE_PATH` | （未設定） | `sse` / `streamable-http` のベースパス |
+| `SUI_MCP_ENDPOINT_PATH` | `/mcp` | `streamable-http` の MCP エンドポイント |
 
 mTLS で保護された API に接続する場合、`SUI_API_CLIENT_CERT_PATH` と `SUI_API_CLIENT_KEY_PATH` を必ず両方指定してください。片方のみの指定は起動時にエラーになります。
+
+### Transport
+
+既定は Claude Desktop などがサブプロセスとして起動する `stdio` です。
+
+```bash
+sui-mcp
+```
+
+コンテナや常駐プロセスとして公開する場合は、 `-t` / `--transport` で HTTP transport を指定できます。
+
+```bash
+# Legacy SSE: GET /sse, POST /message
+sui-mcp -t sse --address :8000
+
+# Streamable HTTP: /mcp
+sui-mcp -t streamable-http --address :8000
+
+# パスを前置きする場合
+sui-mcp -t streamable-http --address :8000 --base-path /sui --endpoint-path /mcp
+```
+
+HTTP transport ではヘルスチェックとして `/healthz`（`--base-path` 指定時は `<base-path>/healthz`）を提供します。
 
 ### Claude Desktop での設定例
 

--- a/packages/mcp/src/__tests__/cli.test.ts
+++ b/packages/mcp/src/__tests__/cli.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseCliOptions } from "../cli";
+
+describe("parseCliOptions", () => {
+  it("defaults to stdio transport", () => {
+    expect(parseCliOptions([], {})).toMatchObject({
+      transport: "stdio",
+      address: "localhost:8000",
+      basePath: "",
+      endpointPath: "/mcp",
+      help: false,
+    });
+  });
+
+  it("parses Grafana-style HTTP transport flags", () => {
+    expect(
+      parseCliOptions(
+        ["-t", "sse", "--address", ":9090", "--base-path", "/sui/", "--endpoint-path=/rpc/"],
+        {},
+      ),
+    ).toMatchObject({
+      transport: "sse",
+      address: ":9090",
+      basePath: "/sui",
+      endpointPath: "/rpc",
+    });
+  });
+
+  it("allows environment defaults", () => {
+    expect(
+      parseCliOptions([], {
+        SUI_MCP_TRANSPORT: "streamable-http",
+        SUI_MCP_ADDRESS: "0.0.0.0:8080",
+        SUI_MCP_BASE_PATH: "mcp",
+      }),
+    ).toMatchObject({
+      transport: "streamable-http",
+      address: "0.0.0.0:8080",
+      basePath: "/mcp",
+    });
+  });
+
+  it("rejects unsupported transports", () => {
+    expect(() => parseCliOptions(["--transport", "websocket"], {})).toThrow("Unsupported transport");
+  });
+});

--- a/packages/mcp/src/__tests__/http-server.test.ts
+++ b/packages/mcp/src/__tests__/http-server.test.ts
@@ -1,0 +1,78 @@
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { FetchLike } from "../api-client";
+import { SuiApiClient } from "../api-client";
+import type { CliOptions } from "../cli";
+import { startHttpServer } from "../http-server";
+import { afterEach, describe, expect, it } from "vitest";
+
+const fetchImpl: FetchLike = async () =>
+  new Response(JSON.stringify({ error: "unexpected upstream request" }), {
+    status: 500,
+    headers: { "content-type": "application/json" },
+  });
+
+function baseOptions(transport: CliOptions["transport"]): CliOptions {
+  return {
+    transport,
+    address: "127.0.0.1:0",
+    basePath: "",
+    endpointPath: "/mcp",
+    help: false,
+  };
+}
+
+async function closeServer(server: Awaited<ReturnType<typeof startHttpServer>>) {
+  server.close();
+  await once(server, "close");
+}
+
+describe("HTTP MCP server", () => {
+  const servers: Array<Awaited<ReturnType<typeof startHttpServer>>> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map(closeServer));
+  });
+
+  async function start(options: CliOptions) {
+    const apiClient = new SuiApiClient("http://localhost:3000", fetchImpl);
+    const server = await startHttpServer(options, apiClient);
+    servers.push(server);
+    const address = server.address() as AddressInfo;
+    return `http://127.0.0.1:${address.port}`;
+  }
+
+  it("serves a health check for HTTP transports", async () => {
+    const url = await start(baseOptions("streamable-http"));
+
+    const response = await fetch(`${url}/healthz`);
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("ok\n");
+  });
+
+  it("accepts streamable HTTP MCP clients", async () => {
+    const url = await start(baseOptions("streamable-http"));
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+
+    await client.connect(new StreamableHTTPClientTransport(new URL(`${url}/mcp`)));
+    const tools = await client.listTools();
+    await client.close();
+
+    expect(tools.tools.map((tool) => tool.name)).toContain("get_dashboard");
+  });
+
+  it("accepts legacy SSE MCP clients", async () => {
+    const url = await start(baseOptions("sse"));
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+
+    await client.connect(new SSEClientTransport(new URL(`${url}/sse`)));
+    const tools = await client.listTools();
+    await client.close();
+
+    expect(tools.tools.map((tool) => tool.name)).toContain("get_dashboard");
+  });
+});

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,0 +1,123 @@
+export type TransportMode = "stdio" | "sse" | "streamable-http";
+
+export interface CliOptions {
+  transport: TransportMode;
+  address: string;
+  basePath: string;
+  endpointPath: string;
+  help: boolean;
+}
+
+const DEFAULT_TRANSPORT = "stdio";
+const DEFAULT_ADDRESS = "localhost:8000";
+const DEFAULT_BASE_PATH = "";
+const DEFAULT_ENDPOINT_PATH = "/mcp";
+
+function readValue(args: string[], index: number, flag: string) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseTransport(value: string): TransportMode {
+  if (value === "stdio" || value === "sse" || value === "streamable-http") {
+    return value;
+  }
+  throw new Error(`Unsupported transport: ${value}`);
+}
+
+function normalizeBasePath(path: string) {
+  if (!path || path === "/") {
+    return "";
+  }
+  return `/${path.replace(/^\/+|\/+$/g, "")}`;
+}
+
+function normalizeEndpointPath(path: string) {
+  const normalized = `/${path.replace(/^\/+/, "")}`;
+  return normalized.replace(/\/+$/g, "") || "/";
+}
+
+export function parseCliOptions(args: string[], env: NodeJS.ProcessEnv = process.env): CliOptions {
+  const options: CliOptions = {
+    transport: parseTransport(env.SUI_MCP_TRANSPORT ?? DEFAULT_TRANSPORT),
+    address: env.SUI_MCP_ADDRESS ?? DEFAULT_ADDRESS,
+    basePath: normalizeBasePath(env.SUI_MCP_BASE_PATH ?? DEFAULT_BASE_PATH),
+    endpointPath: normalizeEndpointPath(env.SUI_MCP_ENDPOINT_PATH ?? DEFAULT_ENDPOINT_PATH),
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "-h" || arg === "--help") {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === "-t" || arg === "--transport") {
+      options.transport = parseTransport(readValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--transport=")) {
+      options.transport = parseTransport(arg.slice("--transport=".length));
+      continue;
+    }
+
+    if (arg === "--address") {
+      options.address = readValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--address=")) {
+      options.address = arg.slice("--address=".length);
+      continue;
+    }
+
+    if (arg === "--base-path") {
+      options.basePath = normalizeBasePath(readValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--base-path=")) {
+      options.basePath = normalizeBasePath(arg.slice("--base-path=".length));
+      continue;
+    }
+
+    if (arg === "--endpoint-path") {
+      options.endpointPath = normalizeEndpointPath(readValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--endpoint-path=")) {
+      options.endpointPath = normalizeEndpointPath(arg.slice("--endpoint-path=".length));
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+export function helpText() {
+  return `Usage: sui-mcp [options]
+
+Options:
+  -t, --transport <stdio|sse|streamable-http>  Transport type (default: stdio)
+      --address <host:port>                    Listen address for HTTP transports (default: localhost:8000)
+      --base-path <path>                       Base path for HTTP transports
+      --endpoint-path <path>                   Streamable HTTP endpoint path (default: /mcp)
+  -h, --help                                   Show this help
+
+Environment variables:
+  SUI_MCP_TRANSPORT, SUI_MCP_ADDRESS, SUI_MCP_BASE_PATH, SUI_MCP_ENDPOINT_PATH
+  SUI_API_URL and SUI_API_* TLS variables configure the upstream sui API connection
+`;
+}

--- a/packages/mcp/src/http-server.ts
+++ b/packages/mcp/src/http-server.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { SuiApiClient } from "./api-client";
+import type { CliOptions } from "./cli";
+import { buildServer } from "./server";
+
+interface ListenAddress {
+  host?: string;
+  port: number;
+}
+
+interface ServerSession {
+  close: () => Promise<void>;
+}
+
+function joinPath(basePath: string, path: string) {
+  return `${basePath}${path}` || "/";
+}
+
+function parseListenAddress(address: string): ListenAddress {
+  const separator = address.lastIndexOf(":");
+  if (separator === -1) {
+    const port = Number(address);
+    if (!Number.isInteger(port) || port < 0) {
+      throw new Error(`Invalid address: ${address}`);
+    }
+    return { port };
+  }
+
+  const host = address.slice(0, separator);
+  const port = Number(address.slice(separator + 1));
+  if (!Number.isInteger(port) || port < 0) {
+    throw new Error(`Invalid address: ${address}`);
+  }
+
+  return { host: host || undefined, port };
+}
+
+function sendText(res: ServerResponse, status: number, text: string) {
+  res.writeHead(status, { "content-type": "text/plain; charset=utf-8" });
+  res.end(text);
+}
+
+function requestPath(req: IncomingMessage) {
+  const host = req.headers.host ?? "localhost";
+  return new URL(req.url ?? "/", `http://${host}`).pathname;
+}
+
+export async function startHttpServer(options: CliOptions, apiClient: SuiApiClient) {
+  const healthPath = joinPath(options.basePath, "/healthz");
+  const ssePath = joinPath(options.basePath, "/sse");
+  const messagePath = joinPath(options.basePath, "/message");
+  const streamablePath = joinPath(options.basePath, options.endpointPath);
+  const sseSessions = new Map<string, ServerSession & { transport: SSEServerTransport }>();
+  const streamableSessions = new Map<string, ServerSession & { transport: StreamableHTTPServerTransport }>();
+
+  const server = createServer(async (req, res) => {
+    const path = requestPath(req);
+
+    try {
+      if (req.method === "GET" && path === healthPath) {
+        sendText(res, 200, "ok\n");
+        return;
+      }
+
+      if (options.transport === "sse") {
+        if (req.method === "GET" && path === ssePath) {
+          const transport = new SSEServerTransport(messagePath, res);
+          const mcpServer = buildServer({ apiClient });
+          sseSessions.set(transport.sessionId, {
+            transport,
+            close: () => mcpServer.close(),
+          });
+          transport.onclose = () => {
+            sseSessions.delete(transport.sessionId);
+          };
+          await mcpServer.connect(transport);
+          return;
+        }
+
+        if (req.method === "POST" && path === messagePath) {
+          const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+          const sessionId = url.searchParams.get("sessionId");
+          const session = sessionId ? sseSessions.get(sessionId) : undefined;
+          if (!session) {
+            sendText(res, 404, "SSE session not found\n");
+            return;
+          }
+          await session.transport.handlePostMessage(req, res);
+          return;
+        }
+      }
+
+      if (options.transport === "streamable-http" && path === streamablePath) {
+        const sessionId = req.headers["mcp-session-id"];
+        const normalizedSessionId = Array.isArray(sessionId) ? sessionId[0] : sessionId;
+        let session = normalizedSessionId ? streamableSessions.get(normalizedSessionId) : undefined;
+
+        if (normalizedSessionId && !session) {
+          sendText(res, 404, "MCP session not found\n");
+          return;
+        }
+
+        if (!session) {
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: randomUUID,
+            onsessioninitialized: (initializedSessionId) => {
+              streamableSessions.set(initializedSessionId, {
+                transport,
+                close: () => mcpServer.close(),
+              });
+            },
+            onsessionclosed: (closedSessionId) => {
+              streamableSessions.delete(closedSessionId);
+            },
+          });
+          const mcpServer = buildServer({ apiClient });
+          transport.onclose = () => {
+            if (transport.sessionId) {
+              streamableSessions.delete(transport.sessionId);
+            }
+          };
+          await mcpServer.connect(transport);
+          session = {
+            transport,
+            close: () => mcpServer.close(),
+          };
+        }
+
+        await session.transport.handleRequest(req, res);
+        return;
+      }
+
+      sendText(res, 404, "not found\n");
+    } catch (error) {
+      console.error(error);
+      if (!res.headersSent) {
+        sendText(res, 500, "internal server error\n");
+      } else {
+        res.end();
+      }
+    }
+  });
+
+  server.on("close", () => {
+    for (const session of [...sseSessions.values(), ...streamableSessions.values()]) {
+      void session.close();
+    }
+    sseSessions.clear();
+    streamableSessions.clear();
+  });
+
+  const address = parseListenAddress(options.address);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(address.port, address.host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const actualAddress = server.address();
+  const displayAddress =
+    typeof actualAddress === "object" && actualAddress
+      ? `${actualAddress.address === "::" ? "0.0.0.0" : actualAddress.address}:${actualAddress.port}`
+      : options.address;
+  console.error(`sui-mcp ${options.transport} listening on ${displayAddress}`);
+
+  return server;
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,8 +1,16 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { fetch as undiciFetch } from "undici";
 import { SuiApiClient } from "./api-client";
+import { helpText, parseCliOptions } from "./cli";
+import { startHttpServer } from "./http-server";
 import { buildServer } from "./server";
 import { buildMtlsDispatcher } from "./tls";
+
+const options = parseCliOptions(process.argv.slice(2));
+if (options.help) {
+  console.log(helpText());
+  process.exit(0);
+}
 
 const apiBaseUrl = process.env.SUI_API_URL ?? "http://localhost:3000";
 const dispatcher = buildMtlsDispatcher();
@@ -11,7 +19,11 @@ const apiClient = new SuiApiClient(
   dispatcher ? (undiciFetch as unknown as typeof fetch) : fetch,
   dispatcher,
 );
-const server = buildServer({ apiClient });
-const transport = new StdioServerTransport();
 
-await server.connect(transport);
+if (options.transport === "stdio") {
+  const server = buildServer({ apiClient });
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+} else {
+  await startHttpServer(options, apiClient);
+}


### PR DESCRIPTION
- README.mdにMCPサーバーのtransportオプションを追加
- cli.tsにtransportオプションの解析機能を追加
- http-server.tsを新規作成し、HTTP/SSEサーバーの実装を追加
- cli.test.tsを新規作成し、CLIオプションのテストを追加
- http-server.test.tsを新規作成し、HTTPサーバーのテストを追加
- index.tsを修正し、transportオプションに応じたサーバー起動処理を追加