### PR TITLE
feat(credit-cards, loans, recurring-items): 日付シフトポリシーを追加

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -31,6 +31,11 @@ function getYearMonth(offsetMonths = 0) {
   return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
+function getLastDayOfMonth(offsetMonths = 0) {
+  const { year, month } = getJstDateParts();
+  return new Date(Date.UTC(year, month + offsetMonths + 1, 0)).getUTCDate();
+}
+
 function getFutureDayOfMonth() {
   const now = new Date();
   const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
@@ -164,7 +169,7 @@ test("shows a yellow disposable balance warning card without the red warning", a
     amount: 30000,
     dayOfMonth: getFutureDayOfMonth(),
     startDate: new Date(`${getYearMonth(0)}-01T00:00:00.000Z`),
-    endDate: new Date(`${getYearMonth(0)}-28T00:00:00.000Z`),
+    endDate: new Date(`${getYearMonth(0)}-${String(getLastDayOfMonth()).padStart(2, "0")}T00:00:00.000Z`),
     accountId: account.id,
     sortOrder: 1,
   });

--- a/e2e/recurring.spec.ts
+++ b/e2e/recurring.spec.ts
@@ -71,6 +71,34 @@ test("edits a recurring item", async ({ page }) => {
   await expect(page.getByRole("row", { name: /Subscription/ })).toContainText(formatCurrency(2500));
 });
 
+test("keeps recurring item date shift policy through create and edit", async ({ page }) => {
+  const account = await seedAccount({ name: "Main Account" });
+
+  await navigateTo(page, "/recurring");
+
+  await page.getByLabel("カテゴリ名 *").first().fill("Shifted Rent");
+  await page.getByLabel("種別").first().selectOption("expense");
+  await page.getByLabel("金額 (円)").first().fill("80000");
+  await page.getByLabel("毎月の発生日 (1-31)").first().fill("31");
+  await page.getByLabel("土日祝の扱い").first().selectOption("next");
+  await page.getByLabel("引き落とし口座 *").selectOption(account.id);
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  const row = page.getByRole("row", { name: /Shifted Rent/ });
+  await row.getByRole("button", { name: "編集" }).click();
+  await expect(page.getByLabel("土日祝の扱い").last()).toHaveValue("next");
+
+  await page.getByLabel("金額 (円)").last().fill("81000");
+  await page.getByRole("button", { name: "保存" }).click();
+  await waitForReload(page);
+
+  const updatedRow = page.getByRole("row", { name: /Shifted Rent/ });
+  await expect(updatedRow).toContainText(formatCurrency(81000));
+  await updatedRow.getByRole("button", { name: "編集" }).click();
+  await expect(page.getByLabel("土日祝の扱い").last()).toHaveValue("next");
+});
+
 test("deletes a recurring item", async ({ page }) => {
   const account = await seedAccount({ name: "Main Account" });
   await seedRecurringItem({

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,6 +19,7 @@
     "db:push": "pnpm --filter @sui/db db:push"
   },
   "dependencies": {
+    "@holiday-jp/holiday_jp": "^2.5.1",
     "@hono/node-server": "^2.0.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",

--- a/packages/backend/src/lib/business-day.test.ts
+++ b/packages/backend/src/lib/business-day.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { adjustToBusinessDay, isBusinessDay } from "./business-day";
+
+describe("isBusinessDay", () => {
+  it("returns true only for weekdays that are not Japanese holidays", () => {
+    expect(isBusinessDay("2026-05-01")).toBe(true);
+    expect(isBusinessDay("2026-05-02")).toBe(false);
+    expect(isBusinessDay("2026-05-03")).toBe(false);
+    expect(isBusinessDay("2026-05-04")).toBe(false);
+  });
+});
+
+describe("adjustToBusinessDay", () => {
+  it("keeps business days and none policy unchanged", () => {
+    expect(adjustToBusinessDay("2026-05-01", "previous")).toBe("2026-05-01");
+    expect(adjustToBusinessDay("2026-05-02", "none")).toBe("2026-05-02");
+  });
+
+  it("moves non-business days to the previous business day across month boundaries", () => {
+    expect(adjustToBusinessDay("2026-05-03", "previous")).toBe("2026-05-01");
+    expect(adjustToBusinessDay("2026-08-01", "previous")).toBe("2026-07-31");
+  });
+
+  it("moves non-business days to the next business day across month boundaries", () => {
+    expect(adjustToBusinessDay("2026-05-03", "next")).toBe("2026-05-07");
+    expect(adjustToBusinessDay("2026-05-31", "next")).toBe("2026-06-01");
+  });
+});

--- a/packages/backend/src/lib/business-day.ts
+++ b/packages/backend/src/lib/business-day.ts
@@ -1,0 +1,29 @@
+import holidayJp from "@holiday-jp/holiday_jp";
+
+export type DateShiftPolicy = "none" | "previous" | "next";
+
+function addDays(date: string, days: number) {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+}
+
+export function isBusinessDay(date: string): boolean {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  const day = value.getUTCDay();
+  return day !== 0 && day !== 6 && !holidayJp.isHoliday(date);
+}
+
+export function adjustToBusinessDay(date: string, policy: DateShiftPolicy): string {
+  if (policy === "none" || isBusinessDay(date)) {
+    return date;
+  }
+
+  const direction = policy === "previous" ? -1 : 1;
+  let adjusted = date;
+  do {
+    adjusted = addDays(adjusted, direction);
+  } while (!isBusinessDay(adjusted));
+
+  return adjusted;
+}

--- a/packages/backend/src/routes/credit-cards.integration.test.ts
+++ b/packages/backend/src/routes/credit-cards.integration.test.ts
@@ -76,4 +76,29 @@ describe("credit cards routes", () => {
     });
     expect(deleted.deletedAt).not.toBeNull();
   });
+
+  it("round-trips dateShiftPolicy and preserves it when omitted on update", async () => {
+    const account = await createAccount(testPrisma, { name: "Settlement" });
+
+    const create = await client.post("/api/credit-cards", {
+      name: "Visa",
+      settlementDay: 31,
+      dateShiftPolicy: "next",
+      accountId: account.id,
+      assumptionAmount: 42000,
+      sortOrder: 3,
+    });
+    const created = await parseJson<{ id: string; dateShiftPolicy: string }>(create);
+    expect(created.dateShiftPolicy).toBe("next");
+
+    const update = await client.put(`/api/credit-cards/${created.id}`, {
+      name: "Visa Gold",
+      settlementDay: 31,
+      accountId: account.id,
+      assumptionAmount: 43000,
+      sortOrder: 4,
+    });
+    const updated = await parseJson<{ dateShiftPolicy: string }>(update);
+    expect(updated.dateShiftPolicy).toBe("next");
+  });
 });

--- a/packages/backend/src/routes/credit-cards.ts
+++ b/packages/backend/src/routes/credit-cards.ts
@@ -4,13 +4,36 @@ import { prisma } from "../lib/db";
 import { handleRouteError, notFound } from "../lib/http";
 import { int32Schema, nonNegativeInt32Schema } from "../lib/validation";
 
-const payloadSchema = z.object({
+const dateShiftPolicySchema = z.enum(["none", "previous", "next"]);
+
+const basePayloadSchema = z.object({
   name: z.string().min(1).max(100),
   settlementDay: z.number().int().min(1).max(31).nullable().optional(),
   accountId: z.string().uuid(),
   assumptionAmount: nonNegativeInt32Schema(),
   sortOrder: int32Schema(),
 });
+
+const createPayloadSchema = basePayloadSchema.extend({
+  dateShiftPolicy: dateShiftPolicySchema.optional().default("none"),
+});
+
+const updatePayloadSchema = basePayloadSchema.extend({
+  dateShiftPolicy: dateShiftPolicySchema.optional(),
+});
+
+function buildCreditCardData(
+  body: z.infer<typeof createPayloadSchema> | z.infer<typeof updatePayloadSchema>,
+) {
+  return {
+    name: body.name,
+    settlementDay: body.settlementDay,
+    accountId: body.accountId,
+    assumptionAmount: body.assumptionAmount,
+    sortOrder: body.sortOrder,
+    ...(body.dateShiftPolicy !== undefined ? { dateShiftPolicy: body.dateShiftPolicy } : {}),
+  };
+}
 
 export const creditCardsRoutes = new Hono()
   .get("/", async (c) => {
@@ -23,8 +46,8 @@ export const creditCardsRoutes = new Hono()
   })
   .post("/", async (c) => {
     try {
-      const body = payloadSchema.parse(await c.req.json());
-      const card = await prisma.creditCard.create({ data: body });
+      const body = createPayloadSchema.parse(await c.req.json());
+      const card = await prisma.creditCard.create({ data: buildCreditCardData(body) });
       return c.json(card, 201);
     } catch (error) {
       return handleRouteError(c, error);
@@ -32,7 +55,7 @@ export const creditCardsRoutes = new Hono()
   })
   .put("/:id", async (c) => {
     try {
-      const body = payloadSchema.parse(await c.req.json());
+      const body = updatePayloadSchema.parse(await c.req.json());
       const existing = await prisma.creditCard.findFirst({
         where: { id: c.req.param("id"), deletedAt: null },
       });
@@ -42,7 +65,7 @@ export const creditCardsRoutes = new Hono()
 
       const card = await prisma.creditCard.update({
         where: { id: existing.id },
-        data: body,
+        data: buildCreditCardData(body),
       });
       return c.json(card);
     } catch (error) {

--- a/packages/backend/src/routes/dashboard.integration.test.ts
+++ b/packages/backend/src/routes/dashboard.integration.test.ts
@@ -172,6 +172,123 @@ describe("dashboard routes", () => {
     );
   });
 
+  it("applies dateShiftPolicy to recurring items and credit cards without shifting manual card settlement dates", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T00:00:00.000Z"));
+
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 100000,
+      sortOrder: 1,
+    });
+    const shiftedRecurring = await createRecurringItem(testPrisma, {
+      name: "Shifted Rent",
+      type: "expense",
+      amount: 80000,
+      dayOfMonth: 3,
+      dateShiftPolicy: "previous",
+      accountId: account.id,
+      sortOrder: 1,
+    });
+    const previousBoundary = await createRecurringItem(testPrisma, {
+      name: "Boundary Start",
+      type: "expense",
+      amount: 1000,
+      dayOfMonth: 3,
+      startDate: new Date("2026-05-03T00:00:00.000Z"),
+      dateShiftPolicy: "previous",
+      accountId: account.id,
+      sortOrder: 2,
+    });
+    const nextBoundary = await createRecurringItem(testPrisma, {
+      name: "Boundary End",
+      type: "expense",
+      amount: 1000,
+      dayOfMonth: 31,
+      endDate: new Date("2026-05-31T00:00:00.000Z"),
+      dateShiftPolicy: "next",
+      accountId: account.id,
+      sortOrder: 3,
+    });
+    const shiftedCard = await createCreditCard(testPrisma, {
+      name: "Shifted Card",
+      accountId: account.id,
+      settlementDay: 3,
+      assumptionAmount: 12000,
+      dateShiftPolicy: "previous",
+      sortOrder: 1,
+    });
+    const manualCard = await createCreditCard(testPrisma, {
+      name: "Manual Card",
+      accountId: account.id,
+      settlementDay: 3,
+      assumptionAmount: 15000,
+      dateShiftPolicy: "previous",
+      sortOrder: 2,
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-06",
+      settlementDate: new Date("2026-06-06T00:00:00.000Z"),
+      items: [{ creditCardId: manualCard.id, amount: 15000 }],
+    });
+
+    const response = await client.get("/api/dashboard/events?months=2");
+    const body = await parseJson<{ forecast: Array<{ id: string; date: string }> }>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.forecast).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: `recurring:${shiftedRecurring.id}:2026-05`,
+          date: "2026-05-01",
+        }),
+        expect.objectContaining({
+          id: `credit-card:${shiftedCard.id}:2026-05`,
+          date: "2026-05-01",
+        }),
+        expect.objectContaining({
+          id: `credit-card:${manualCard.id}:2026-06`,
+          date: "2026-06-06",
+        }),
+      ]),
+    );
+    expect(body.forecast.some((event) => event.id === `recurring:${previousBoundary.id}:2026-05`)).toBe(false);
+    expect(body.forecast.some((event) => event.id === `recurring:${nextBoundary.id}:2026-05`)).toBe(false);
+  });
+
+  it("does not auto-confirm recurring events shifted outside their active period", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-02T00:00:00.000Z"));
+
+    const account = await createAccount(testPrisma, {
+      name: "Main",
+      balance: 100000,
+      sortOrder: 1,
+    });
+    const recurring = await createRecurringItem(testPrisma, {
+      name: "Boundary Start",
+      type: "expense",
+      amount: 1000,
+      dayOfMonth: 3,
+      startDate: new Date("2026-05-03T00:00:00.000Z"),
+      dateShiftPolicy: "previous",
+      accountId: account.id,
+      sortOrder: 1,
+    });
+
+    const response = await client.get("/api/dashboard");
+    const body = await parseJson<{ totalBalance: number; forecast: Array<{ id: string }> }>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.totalBalance).toBe(100000);
+    expect(body.forecast.some((event) => event.id === `recurring:${recurring.id}:2026-05`)).toBe(false);
+
+    const transaction = await testPrisma.transaction.findUnique({
+      where: { forecastEventId: `recurring:${recurring.id}:2026-05` },
+    });
+    expect(transaction).toBeNull();
+  });
+
   it("applies account balance offsets only to dashboard balances", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));

--- a/packages/backend/src/routes/loans.integration.test.ts
+++ b/packages/backend/src/routes/loans.integration.test.ts
@@ -70,4 +70,29 @@ describe("loans routes", () => {
     });
     expect(deleted.deletedAt).not.toBeNull();
   });
+
+  it("round-trips dateShiftPolicy and preserves it when omitted on update", async () => {
+    const account = await createAccount(testPrisma, { name: "Main" });
+
+    const create = await client.post("/api/loans", {
+      name: "Laptop",
+      totalAmount: 240000,
+      paymentCount: 12,
+      startDate: "2026-04-10",
+      dateShiftPolicy: "next",
+      accountId: account.id,
+    });
+    const created = await parseJson<{ id: string; dateShiftPolicy: string }>(create);
+    expect(created.dateShiftPolicy).toBe("next");
+
+    const update = await client.put(`/api/loans/${created.id}`, {
+      name: "Laptop Updated",
+      totalAmount: 120000,
+      paymentCount: 6,
+      startDate: "2026-05-15",
+      accountId: account.id,
+    });
+    const updated = await parseJson<{ dateShiftPolicy: string }>(update);
+    expect(updated.dateShiftPolicy).toBe("next");
+  });
 });

--- a/packages/backend/src/routes/loans.ts
+++ b/packages/backend/src/routes/loans.ts
@@ -6,13 +6,34 @@ import { badRequest, handleRouteError, notFound } from "../lib/http";
 import { positiveInt32Schema } from "../lib/validation";
 import { getLoanSnapshot } from "../services/loans";
 
-const payloadSchema = z.object({
+const dateShiftPolicySchema = z.enum(["none", "previous", "next"]);
+
+const basePayloadSchema = z.object({
   name: z.string().min(1).max(100),
   totalAmount: positiveInt32Schema(),
   paymentCount: positiveInt32Schema(),
   startDate: z.string(),
   accountId: z.string().uuid(),
 });
+
+const createPayloadSchema = basePayloadSchema.extend({
+  dateShiftPolicy: dateShiftPolicySchema.optional().default("none"),
+});
+
+const updatePayloadSchema = basePayloadSchema.extend({
+  dateShiftPolicy: dateShiftPolicySchema.optional(),
+});
+
+function buildLoanData(body: z.infer<typeof createPayloadSchema> | z.infer<typeof updatePayloadSchema>) {
+  return {
+    name: body.name,
+    totalAmount: body.totalAmount,
+    paymentCount: body.paymentCount,
+    startDate: new Date(`${body.startDate}T00:00:00.000Z`),
+    accountId: body.accountId,
+    ...(body.dateShiftPolicy !== undefined ? { dateShiftPolicy: body.dateShiftPolicy } : {}),
+  };
+}
 
 export const loansRoutes = new Hono()
   .get("/", async (c) => {
@@ -37,16 +58,13 @@ export const loansRoutes = new Hono()
   })
   .post("/", async (c) => {
     try {
-      const body = payloadSchema.parse(await c.req.json());
+      const body = createPayloadSchema.parse(await c.req.json());
       if (!isDateString(body.startDate)) {
         return badRequest(c, "startDate must be YYYY-MM-DD");
       }
 
       const loan = await prisma.loan.create({
-        data: {
-          ...body,
-          startDate: new Date(`${body.startDate}T00:00:00.000Z`),
-        },
+        data: buildLoanData(body),
       });
       return c.json(loan, 201);
     } catch (error) {
@@ -55,7 +73,7 @@ export const loansRoutes = new Hono()
   })
   .put("/:id", async (c) => {
     try {
-      const body = payloadSchema.parse(await c.req.json());
+      const body = updatePayloadSchema.parse(await c.req.json());
       if (!isDateString(body.startDate)) {
         return badRequest(c, "startDate must be YYYY-MM-DD");
       }
@@ -69,10 +87,7 @@ export const loansRoutes = new Hono()
 
       const loan = await prisma.loan.update({
         where: { id: existing.id },
-        data: {
-          ...body,
-          startDate: new Date(`${body.startDate}T00:00:00.000Z`),
-        },
+        data: buildLoanData(body),
       });
       return c.json(loan);
     } catch (error) {

--- a/packages/backend/src/routes/recurring-items.integration.test.ts
+++ b/packages/backend/src/routes/recurring-items.integration.test.ts
@@ -71,6 +71,42 @@ describe("recurring items routes", () => {
     expect(saved.type).toBe("income");
   });
 
+  it("round-trips dateShiftPolicy and preserves it when omitted on update", async () => {
+    const account = await createAccount(testPrisma, { name: "Main" });
+
+    const create = await client.post("/api/recurring-items", {
+      name: "Rent",
+      type: "expense",
+      amount: 80000,
+      dayOfMonth: 31,
+      startDate: null,
+      endDate: null,
+      dateShiftPolicy: "next",
+      accountId: account.id,
+      enabled: true,
+      sortOrder: 1,
+    });
+    const created = await parseJson<{ id: string; dateShiftPolicy: string }>(create);
+    expect(created.dateShiftPolicy).toBe("next");
+
+    const update = await client.put(`/api/recurring-items/${created.id}`, {
+      name: "Rent Updated",
+      type: "expense",
+      amount: 81000,
+      dayOfMonth: 31,
+      startDate: null,
+      endDate: null,
+      accountId: account.id,
+      enabled: true,
+      sortOrder: 2,
+    });
+    const updated = await parseJson<{ dateShiftPolicy: string }>(update);
+    expect(updated.dateShiftPolicy).toBe("next");
+
+    const list = await parseJson<Array<{ id: string; dateShiftPolicy: string }>>(await client.get("/api/recurring-items"));
+    expect(list.find((item) => item.id === created.id)?.dateShiftPolicy).toBe("next");
+  });
+
   it("rejects periods where startDate is after endDate", async () => {
     const account = await createAccount(testPrisma, { name: "Main" });
 

--- a/packages/backend/src/routes/recurring-items.ts
+++ b/packages/backend/src/routes/recurring-items.ts
@@ -5,7 +5,9 @@ import { prisma } from "../lib/db";
 import { badRequest, handleRouteError, notFound } from "../lib/http";
 import { int32Schema, nonNegativeInt32Schema } from "../lib/validation";
 
-const payloadSchema = z.object({
+const dateShiftPolicySchema = z.enum(["none", "previous", "next"]);
+
+const basePayloadSchema = z.object({
   name: z.string().min(1).max(100),
   type: z.enum(["income", "expense"]),
   amount: nonNegativeInt32Schema(),
@@ -15,6 +17,14 @@ const payloadSchema = z.object({
   accountId: z.string().uuid(),
   enabled: z.boolean(),
   sortOrder: int32Schema(),
+});
+
+const createPayloadSchema = basePayloadSchema.extend({
+  dateShiftPolicy: dateShiftPolicySchema.optional().default("none"),
+});
+
+const updatePayloadSchema = basePayloadSchema.extend({
+  dateShiftPolicy: dateShiftPolicySchema.optional(),
 });
 
 function isOptionalDateString(value: string | null) {
@@ -45,11 +55,20 @@ function serializeRecurringItem<T extends { startDate: Date | null; endDate: Dat
   };
 }
 
-function buildRecurringItemData(body: z.infer<typeof payloadSchema>) {
+function buildRecurringItemData(
+  body: z.infer<typeof createPayloadSchema> | z.infer<typeof updatePayloadSchema>,
+) {
   return {
-    ...body,
+    name: body.name,
+    type: body.type,
+    amount: body.amount,
+    dayOfMonth: body.dayOfMonth,
     startDate: body.startDate ? fromDateOnlyString(body.startDate) : null,
     endDate: body.endDate ? fromDateOnlyString(body.endDate) : null,
+    accountId: body.accountId,
+    enabled: body.enabled,
+    sortOrder: body.sortOrder,
+    ...(body.dateShiftPolicy !== undefined ? { dateShiftPolicy: body.dateShiftPolicy } : {}),
   };
 }
 
@@ -64,7 +83,7 @@ export const recurringItemsRoutes = new Hono()
   })
   .post("/", async (c) => {
     try {
-      const body = payloadSchema.parse(await c.req.json());
+      const body = createPayloadSchema.parse(await c.req.json());
       const periodError = validatePeriod(body.startDate, body.endDate);
       if (periodError) {
         return badRequest(c, periodError);
@@ -78,7 +97,7 @@ export const recurringItemsRoutes = new Hono()
   })
   .put("/:id", async (c) => {
     try {
-      const body = payloadSchema.parse(await c.req.json());
+      const body = updatePayloadSchema.parse(await c.req.json());
       const periodError = validatePeriod(body.startDate, body.endDate);
       if (periodError) {
         return badRequest(c, periodError);

--- a/packages/backend/src/services/forecast.ts
+++ b/packages/backend/src/services/forecast.ts
@@ -8,6 +8,7 @@ import {
   resolveDateFromYearMonth,
   toDateOnlyString,
 } from "../lib/dates";
+import { adjustToBusinessDay } from "../lib/business-day";
 import { resolveBillingAmount } from "./billings";
 import { buildLoanForecastEvents } from "./loans";
 
@@ -139,7 +140,17 @@ export async function buildDashboard(
         continue;
       }
 
-      const date = resolveDateFromYearMonth(yearMonth, item.dayOfMonth);
+      const baseDate = resolveDateFromYearMonth(yearMonth, item.dayOfMonth);
+      const date = adjustToBusinessDay(baseDate, item.dateShiftPolicy);
+      const startDate = toDateOnlyString(item.startDate);
+      const endDate = toDateOnlyString(item.endDate);
+      if (startDate && date < startDate) {
+        continue;
+      }
+
+      if (endDate && date > endDate) {
+        continue;
+      }
 
       rawEvents.push({
         id: createRecurringId(item.id, yearMonth),
@@ -164,7 +175,10 @@ export async function buildDashboard(
       const amount = resolvedBilling.amount;
       const date = billing?.settlementDate
         ? billing.settlementDate.toISOString().slice(0, 10)
-        : resolveDateFromYearMonth(yearMonth, card.settlementDay ?? defaultSettlementDay);
+        : adjustToBusinessDay(
+            resolveDateFromYearMonth(yearMonth, card.settlementDay ?? defaultSettlementDay),
+            card.dateShiftPolicy,
+          );
 
       if (amount <= 0) {
         continue;

--- a/packages/backend/src/services/loans.test.ts
+++ b/packages/backend/src/services/loans.test.ts
@@ -9,6 +9,7 @@ function createLoan(overrides: Partial<Loan> = {}): Loan {
     totalAmount: 1000,
     startDate: new Date("2026-01-15T00:00:00.000Z"),
     paymentCount: 3,
+    dateShiftPolicy: "none",
     accountId: "account-1",
     deletedAt: null,
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -138,6 +139,42 @@ describe("buildLoanForecastEvents", () => {
       334,
       334,
       333,
+    ]);
+  });
+
+  it("does not shift the first payment month", () => {
+    const loan = createLoan({
+      startDate: new Date("2026-05-03T00:00:00.000Z"),
+      dateShiftPolicy: "next",
+      paymentCount: 2,
+    });
+
+    expect(buildLoanForecastEvents(loan, [], "2026-05-01", 2)).toEqual([
+      {
+        id: "loan:loan-1:2026-05",
+        date: "2026-05-03",
+        amount: 500,
+        description: "ローン: Car Loan",
+      },
+      {
+        id: "loan:loan-1:2026-06",
+        date: "2026-06-03",
+        amount: 500,
+        description: "ローン: Car Loan",
+      },
+    ]);
+  });
+
+  it("shifts payments after the first month", () => {
+    const loan = createLoan({
+      startDate: new Date("2026-05-06T00:00:00.000Z"),
+      dateShiftPolicy: "previous",
+      paymentCount: 2,
+    });
+
+    expect(buildLoanForecastEvents(loan, [], "2026-05-01", 2).map((event) => event.date)).toEqual([
+      "2026-05-06",
+      "2026-06-05",
     ]);
   });
 });

--- a/packages/backend/src/services/loans.ts
+++ b/packages/backend/src/services/loans.ts
@@ -1,4 +1,5 @@
 import type { Loan, Transaction } from "@sui/db";
+import { adjustToBusinessDay } from "../lib/business-day";
 import { addMonthsToYearMonth, getCurrentYearMonth, resolveDateFromYearMonth, toDateOnlyString } from "../lib/dates";
 
 interface LoanTransactionSummary {
@@ -90,7 +91,10 @@ export function buildLoanForecastEvents(
       continue;
     }
 
-    const date = resolveDateFromYearMonth(yearMonth, dayOfMonth);
+    const baseDate = resolveDateFromYearMonth(yearMonth, dayOfMonth);
+    const date = yearMonth === startYearMonth
+      ? baseDate
+      : adjustToBusinessDay(baseDate, loan.dateShiftPolicy);
     if (date < startDate) {
       continue;
     }

--- a/packages/db/prisma/migrations/20260429000000_add_date_shift_policy/migration.sql
+++ b/packages/db/prisma/migrations/20260429000000_add_date_shift_policy/migration.sql
@@ -1,0 +1,10 @@
+CREATE TYPE "DateShiftPolicy" AS ENUM ('none', 'previous', 'next');
+
+ALTER TABLE "recurring_items"
+  ADD COLUMN "date_shift_policy" "DateShiftPolicy" NOT NULL DEFAULT 'none';
+
+ALTER TABLE "credit_cards"
+  ADD COLUMN "date_shift_policy" "DateShiftPolicy" NOT NULL DEFAULT 'none';
+
+ALTER TABLE "loans"
+  ADD COLUMN "date_shift_policy" "DateShiftPolicy" NOT NULL DEFAULT 'none';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -21,6 +21,12 @@ enum TransactionType {
   transfer
 }
 
+enum DateShiftPolicy {
+  none
+  previous
+  next
+}
+
 model Account {
   id                String        @id @default(uuid()) @db.Uuid
   name              String        @db.VarChar(100)
@@ -40,36 +46,38 @@ model Account {
 }
 
 model RecurringItem {
-  id         String            @id @default(uuid()) @db.Uuid
-  name       String            @db.VarChar(100)
-  type       RecurringItemType
-  amount     Int
-  dayOfMonth Int               @map("day_of_month")
-  accountId  String?           @map("account_id") @db.Uuid
-  enabled    Boolean           @default(true)
-  startDate  DateTime?         @map("start_date") @db.Date
-  endDate    DateTime?         @map("end_date") @db.Date
-  sortOrder  Int               @map("sort_order")
-  deletedAt  DateTime?         @map("deleted_at")
-  createdAt  DateTime          @default(now()) @map("created_at")
-  updatedAt  DateTime          @updatedAt @map("updated_at")
-  account    Account?          @relation(fields: [accountId], references: [id])
+  id              String          @id @default(uuid()) @db.Uuid
+  name            String          @db.VarChar(100)
+  type            RecurringItemType
+  amount          Int
+  dayOfMonth      Int             @map("day_of_month")
+  accountId       String?         @map("account_id") @db.Uuid
+  enabled         Boolean         @default(true)
+  startDate       DateTime?       @map("start_date") @db.Date
+  endDate         DateTime?       @map("end_date") @db.Date
+  dateShiftPolicy DateShiftPolicy @default(none) @map("date_shift_policy")
+  sortOrder       Int             @map("sort_order")
+  deletedAt       DateTime?       @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  account         Account?        @relation(fields: [accountId], references: [id])
 
   @@map("recurring_items")
 }
 
 model CreditCard {
-  id            String           @id @default(uuid()) @db.Uuid
-  name          String           @db.VarChar(100)
-  settlementDay Int?             @map("settlement_day")
-  accountId     String?          @map("account_id") @db.Uuid
-  assumptionAmount Int           @map("assumption_amount")
-  sortOrder     Int              @map("sort_order")
-  deletedAt     DateTime?        @map("deleted_at")
-  createdAt     DateTime         @default(now()) @map("created_at")
-  updatedAt     DateTime         @updatedAt @map("updated_at")
-  items         CreditCardItem[]
-  account       Account?         @relation(fields: [accountId], references: [id])
+  id              String          @id @default(uuid()) @db.Uuid
+  name            String          @db.VarChar(100)
+  settlementDay   Int?            @map("settlement_day")
+  accountId       String?         @map("account_id") @db.Uuid
+  assumptionAmount Int            @map("assumption_amount")
+  dateShiftPolicy DateShiftPolicy @default(none) @map("date_shift_policy")
+  sortOrder       Int             @map("sort_order")
+  deletedAt       DateTime?       @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  items           CreditCardItem[]
+  account         Account?        @relation(fields: [accountId], references: [id])
 
   @@map("credit_cards")
 }
@@ -115,16 +123,17 @@ model CreditCardItem {
 }
 
 model Loan {
-  id           String    @id @default(uuid()) @db.Uuid
-  name         String    @db.VarChar(100)
-  totalAmount  Int       @map("total_amount")
-  startDate    DateTime  @map("start_date") @db.Date
-  paymentCount Int       @map("payment_count")
-  accountId    String?   @map("account_id") @db.Uuid
-  deletedAt    DateTime? @map("deleted_at")
-  createdAt    DateTime  @default(now()) @map("created_at")
-  updatedAt    DateTime  @updatedAt @map("updated_at")
-  account      Account?  @relation(fields: [accountId], references: [id])
+  id              String          @id @default(uuid()) @db.Uuid
+  name            String          @db.VarChar(100)
+  totalAmount     Int             @map("total_amount")
+  startDate       DateTime        @map("start_date") @db.Date
+  paymentCount    Int             @map("payment_count")
+  dateShiftPolicy DateShiftPolicy @default(none) @map("date_shift_policy")
+  accountId       String?         @map("account_id") @db.Uuid
+  deletedAt       DateTime?       @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  account         Account?        @relation(fields: [accountId], references: [id])
 
   @@map("loans")
 }

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -26,6 +26,7 @@ export async function createRecurringItem(
     dayOfMonth?: number;
     startDate?: Date | null;
     endDate?: Date | null;
+    dateShiftPolicy?: "none" | "previous" | "next";
     accountId: string;
     enabled?: boolean;
     sortOrder?: number;
@@ -40,6 +41,7 @@ export async function createRecurringItem(
       dayOfMonth: data.dayOfMonth ?? 1,
       startDate: data.startDate ?? null,
       endDate: data.endDate ?? null,
+      dateShiftPolicy: data.dateShiftPolicy ?? "none",
       accountId: data.accountId,
       enabled: data.enabled ?? true,
       sortOrder: data.sortOrder ?? 0,
@@ -55,6 +57,7 @@ export async function createCreditCard(
     accountId: string;
     settlementDay?: number | null;
     assumptionAmount?: number;
+    dateShiftPolicy?: "none" | "previous" | "next";
     sortOrder?: number;
     deletedAt?: Date | null;
   },
@@ -65,6 +68,7 @@ export async function createCreditCard(
       accountId: data.accountId,
       settlementDay: data.settlementDay ?? null,
       assumptionAmount: data.assumptionAmount ?? 10000,
+      dateShiftPolicy: data.dateShiftPolicy ?? "none",
       sortOrder: data.sortOrder ?? 0,
       deletedAt: data.deletedAt ?? null,
     },
@@ -136,6 +140,7 @@ export async function createLoan(
     totalAmount?: number;
     paymentCount?: number;
     startDate?: Date;
+    dateShiftPolicy?: "none" | "previous" | "next";
     accountId: string;
     deletedAt?: Date | null;
   },
@@ -146,6 +151,7 @@ export async function createLoan(
       totalAmount: data.totalAmount ?? 1000,
       paymentCount: data.paymentCount ?? 1,
       startDate: data.startDate ?? new Date("2026-01-01T00:00:00.000Z"),
+      dateShiftPolicy: data.dateShiftPolicy ?? "none",
       accountId: data.accountId,
       deletedAt: data.deletedAt ?? null,
     },

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -15,7 +15,7 @@ export function DialogContent({
       <DialogPrimitive.Overlay className="fixed inset-0 bg-black/70 backdrop-blur-sm" />
       <DialogPrimitive.Content
         className={cn(
-          "fixed left-1/2 top-1/2 w-[min(92vw,32rem)] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-white/10 bg-card p-6 shadow-glow",
+          "fixed left-1/2 top-1/2 max-h-[calc(100vh-2rem)] w-[min(92vw,32rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-2xl border border-white/10 bg-card p-6 shadow-glow",
           className,
         )}
       >
@@ -27,4 +27,3 @@ export function DialogContent({
 
 export const DialogTitle = DialogPrimitive.Title;
 export const DialogDescription = DialogPrimitive.Description;
-

--- a/packages/frontend/src/routes/credit-cards.tsx
+++ b/packages/frontend/src/routes/credit-cards.tsx
@@ -1,4 +1,4 @@
-import { INT4_MAX, type Account, type BillingResponse, type CreditCard } from "@sui/shared";
+import { INT4_MAX, type Account, type BillingResponse, type CreditCard, type DateShiftPolicy } from "@sui/shared";
 import { useMemo, useState, startTransition } from "react";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
@@ -15,6 +15,7 @@ import { getCurrentYearMonth } from "../lib/utils";
 type CreditCardForm = {
   name: string;
   settlementDay: number | null;
+  dateShiftPolicy: DateShiftPolicy;
   accountId: string;
   assumptionAmount: number;
   sortOrder: number;
@@ -23,6 +24,7 @@ type CreditCardForm = {
 const emptyCard: CreditCardForm = {
   name: "",
   settlementDay: 27,
+  dateShiftPolicy: "none",
   accountId: "",
   assumptionAmount: 0,
   sortOrder: 0,
@@ -129,6 +131,7 @@ export function CreditCardsPage() {
       body: JSON.stringify({
         name: card.name,
         settlementDay: card.settlementDay,
+        dateShiftPolicy: card.dateShiftPolicy,
         accountId: card.accountId,
         assumptionAmount: card.assumptionAmount,
         sortOrder: card.sortOrder,
@@ -164,6 +167,7 @@ export function CreditCardsPage() {
     setEditForm({
       name: card.name,
       settlementDay: card.settlementDay,
+      dateShiftPolicy: card.dateShiftPolicy,
       accountId: card.accountId ?? "",
       assumptionAmount: card.assumptionAmount,
       sortOrder: card.sortOrder,
@@ -352,6 +356,10 @@ function CreditCardFormFields({
         </Select>
       </label>
       <label className="grid gap-2 text-sm">
+        <span>土日祝の扱い</span>
+        <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
+      </label>
+      <label className="grid gap-2 text-sm">
         <span>月間仮定額 *</span>
         <Input type="number" min={0} max={INT4_MAX} value={form.assumptionAmount} onChange={(event) => onChange({ ...form, assumptionAmount: Number(event.target.value) })} />
       </label>
@@ -360,6 +368,22 @@ function CreditCardFormFields({
         <Input type="number" value={form.sortOrder} onChange={(event) => onChange({ ...form, sortOrder: Number(event.target.value) })} />
       </label>
     </>
+  );
+}
+
+function DateShiftSelect({
+  value,
+  onChange,
+}: {
+  value: DateShiftPolicy;
+  onChange: (value: DateShiftPolicy) => void;
+}) {
+  return (
+    <Select value={value} onChange={(event) => onChange(event.target.value as DateShiftPolicy)}>
+      <option value="none">シフトなし</option>
+      <option value="previous">前営業日</option>
+      <option value="next">後営業日</option>
+    </Select>
   );
 }
 

--- a/packages/frontend/src/routes/loans.tsx
+++ b/packages/frontend/src/routes/loans.tsx
@@ -1,4 +1,4 @@
-import type { Account, Loan } from "@sui/shared";
+import type { Account, DateShiftPolicy, Loan } from "@sui/shared";
 import { startTransition, useState } from "react";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
@@ -14,6 +14,7 @@ type LoanForm = {
   totalAmount: number;
   startDate: string;
   paymentCount: number;
+  dateShiftPolicy: DateShiftPolicy;
   accountId: string;
 };
 
@@ -22,6 +23,7 @@ const emptyForm: LoanForm = {
   totalAmount: 0,
   startDate: "",
   paymentCount: 1,
+  dateShiftPolicy: "none",
   accountId: "",
 };
 
@@ -115,6 +117,7 @@ export function LoansPage() {
       totalAmount: loan.totalAmount,
       startDate: loan.startDate.slice(0, 10),
       paymentCount: loan.paymentCount,
+      dateShiftPolicy: loan.dateShiftPolicy,
       accountId: loan.accountId ?? "",
     });
     setEditMidwayMode(false);
@@ -313,6 +316,10 @@ function LoanFormFields({
           ))}
         </Select>
       </label>
+      <label className="grid gap-2 text-sm">
+        <span>土日祝の扱い</span>
+        <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onFormChange({ ...form, dateShiftPolicy })} />
+      </label>
     </div>
   );
 }
@@ -371,6 +378,10 @@ function LoanEditModal({
                 </option>
               ))}
             </Select>
+          </label>
+          <label className="grid gap-2 text-sm">
+            <span>土日祝の扱い</span>
+            <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onFormChange({ ...form, dateShiftPolicy })} />
           </label>
           {!midwayMode ? (
             <>
@@ -451,6 +462,22 @@ function LoanEditModal({
         </Button>
       </div>
     </div>
+  );
+}
+
+function DateShiftSelect({
+  value,
+  onChange,
+}: {
+  value: DateShiftPolicy;
+  onChange: (value: DateShiftPolicy) => void;
+}) {
+  return (
+    <Select value={value} onChange={(event) => onChange(event.target.value as DateShiftPolicy)}>
+      <option value="none">シフトなし</option>
+      <option value="previous">前営業日</option>
+      <option value="next">後営業日</option>
+    </Select>
   );
 }
 

--- a/packages/frontend/src/routes/recurring.tsx
+++ b/packages/frontend/src/routes/recurring.tsx
@@ -1,4 +1,4 @@
-import type { Account, RecurringItem } from "@sui/shared";
+import type { Account, DateShiftPolicy, RecurringItem } from "@sui/shared";
 import { useState, startTransition } from "react";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
@@ -17,6 +17,7 @@ type RecurringForm = {
   dayOfMonth: number;
   startDate: string | null;
   endDate: string | null;
+  dateShiftPolicy: DateShiftPolicy;
   accountId: string;
   enabled: boolean;
   sortOrder: number;
@@ -29,6 +30,7 @@ const emptyForm: RecurringForm = {
   dayOfMonth: 1,
   startDate: null,
   endDate: null,
+  dateShiftPolicy: "none",
   accountId: "",
   enabled: true,
   sortOrder: 0,
@@ -106,6 +108,7 @@ export function RecurringPage() {
         dayOfMonth: item.dayOfMonth,
         startDate: item.startDate,
         endDate: item.endDate,
+        dateShiftPolicy: item.dateShiftPolicy,
         accountId: item.accountId ?? "",
         enabled: item.enabled,
         sortOrder: item.sortOrder,
@@ -131,6 +134,7 @@ export function RecurringPage() {
       dayOfMonth: item.dayOfMonth,
       startDate: item.startDate,
       endDate: item.endDate,
+      dateShiftPolicy: item.dateShiftPolicy,
       accountId: item.accountId ?? "",
       enabled: item.enabled,
       sortOrder: item.sortOrder,
@@ -263,6 +267,10 @@ function RecurringFormFields({
         <span>終了日</span>
         <Input type="date" value={form.endDate ?? ""} onChange={(event) => onChange({ ...form, endDate: parseOptionalDate(event.target.value) })} />
       </label>
+      <label className="grid gap-2 text-sm">
+        <span>土日祝の扱い</span>
+        <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
+      </label>
       <label className="grid gap-2 text-sm xl:col-span-2">
         <span>{form.type === "income" ? "振り込み先口座 *" : "引き落とし口座 *"}</span>
         <Select value={form.accountId} onChange={(event) => onChange({ ...form, accountId: event.target.value })}>
@@ -359,6 +367,10 @@ function RecurringEditModal({
             ))}
           </Select>
         </label>
+        <label className="grid gap-2 text-sm">
+          <span>土日祝の扱い</span>
+          <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
+        </label>
         <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_8rem] md:items-end">
           <label className="grid gap-2 text-sm">
             <span>表示順</span>
@@ -380,6 +392,22 @@ function RecurringEditModal({
         </Button>
       </div>
     </div>
+  );
+}
+
+function DateShiftSelect({
+  value,
+  onChange,
+}: {
+  value: DateShiftPolicy;
+  onChange: (value: DateShiftPolicy) => void;
+}) {
+  return (
+    <Select value={value} onChange={(event) => onChange(event.target.value as DateShiftPolicy)}>
+      <option value="none">シフトなし</option>
+      <option value="previous">前営業日</option>
+      <option value="next">後営業日</option>
+    </Select>
   );
 }
 

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -2,6 +2,7 @@ import type {
   Account,
   BillingMonth,
   CreditCard,
+  DateShiftPolicy,
   ForecastEvent,
   Loan,
   RecurringItem,
@@ -46,6 +47,7 @@ export interface CreateRecurringItemPayload {
   dayOfMonth: number;
   startDate: string | null;
   endDate: string | null;
+  dateShiftPolicy?: DateShiftPolicy;
   accountId: string;
   enabled: boolean;
   sortOrder: number;
@@ -56,6 +58,7 @@ export type UpdateRecurringItemPayload = CreateRecurringItemPayload;
 export interface CreateCreditCardPayload {
   name: string;
   settlementDay?: number | null;
+  dateShiftPolicy?: DateShiftPolicy;
   accountId: string;
   assumptionAmount: number;
   sortOrder: number;
@@ -88,6 +91,7 @@ export interface CreateLoanPayload {
   totalAmount: number;
   startDate: string;
   paymentCount: number;
+  dateShiftPolicy?: DateShiftPolicy;
   accountId: string;
 }
 

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -1,5 +1,6 @@
 export type TransactionType = "income" | "expense" | "transfer";
 export type RecurringItemType = "income" | "expense";
+export type DateShiftPolicy = "none" | "previous" | "next";
 
 export interface Account {
   id: string;
@@ -20,6 +21,7 @@ export interface RecurringItem {
   dayOfMonth: number;
   startDate: string | null;
   endDate: string | null;
+  dateShiftPolicy: DateShiftPolicy;
   accountId: string | null;
   account: Account | null;
   enabled: boolean;
@@ -36,6 +38,7 @@ export interface CreditCard {
   accountId: string | null;
   account: Account | null;
   assumptionAmount: number;
+  dateShiftPolicy: DateShiftPolicy;
   sortOrder: number;
   deletedAt: string | null;
   createdAt: string;
@@ -62,6 +65,7 @@ export interface Loan {
   totalAmount: number;
   startDate: string;
   paymentCount: number;
+  dateShiftPolicy: DateShiftPolicy;
   accountId: string | null;
   account: Account | null;
   remainingBalance: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
 
   packages/backend:
     dependencies:
+      '@holiday-jp/holiday_jp':
+        specifier: ^2.5.1
+        version: 2.5.1
       '@hono/node-server':
         specifier: ^2.0.0
         version: 2.0.0(hono@4.12.15)
@@ -580,6 +583,9 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@holiday-jp/holiday_jp@2.5.1':
+    resolution: {integrity: sha512-KuXfzsp0xlP830WDZRbsHj99wJzamx4fS55usUJFz+oHZmZ4gJfVdyiyv/rIWK+O7RgfHSi5j5Ajy0ZK/Vlnyg==}
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -3477,6 +3483,8 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@holiday-jp/holiday_jp@2.5.1': {}
 
   '@hono/node-server@1.19.11(hono@4.12.15)':
     dependencies:


### PR DESCRIPTION
- クレジットカード、ローン、定期アイテムに日付シフトポリシーを追加し、作成および更新時に適切に処理するように変更した。
- フロントエンドで日付シフトポリシーの選択肢を追加し、フォームに反映させた。
- テストケースを追加し、日付シフトポリシーの動作を確認した。
- Prismaスキーマを更新し、データベースに日付シフトポリシーの列を追加した。