### PR TITLE
feat(loans): ローン管理に支払方法を追加しクレカ分割を予測対象外にする

### DIFF
--- a/e2e/helpers/db-runner.ts
+++ b/e2e/helpers/db-runner.ts
@@ -67,7 +67,8 @@ type DbCommand =
       totalAmount?: number;
       startDate?: string;
       paymentCount?: number;
-      accountId: string;
+      paymentMethod?: "account_withdrawal" | "credit_card";
+      accountId: string | null;
     };
   }
   | {
@@ -161,6 +162,7 @@ async function run(command: DbCommand) {
           ? new Date(command.payload.startDate)
           : new Date("2026-03-20T00:00:00.000Z"),
         paymentCount: command.payload.paymentCount ?? 12,
+        paymentMethod: command.payload.paymentMethod ?? "account_withdrawal",
         accountId: command.payload.accountId,
       });
     case "seedBilling":

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -69,7 +69,8 @@ type DbCommand =
       totalAmount?: number;
       startDate?: string;
       paymentCount?: number;
-      accountId: string;
+      paymentMethod?: "account_withdrawal" | "credit_card";
+      accountId: string | null;
     };
   }
   | {
@@ -328,7 +329,8 @@ export async function seedLoan(overrides: {
   totalAmount?: number;
   startDate?: Date;
   paymentCount?: number;
-  accountId: string;
+  paymentMethod?: "account_withdrawal" | "credit_card";
+  accountId: string | null;
 }): Promise<Loan> {
   return runDbCommand<Loan>({
     action: "seedLoan",
@@ -337,6 +339,7 @@ export async function seedLoan(overrides: {
       totalAmount: overrides.totalAmount,
       startDate: serializeOptionalDate(overrides.startDate),
       paymentCount: overrides.paymentCount,
+      paymentMethod: overrides.paymentMethod,
       accountId: overrides.accountId,
     },
   });

--- a/e2e/loans.spec.ts
+++ b/e2e/loans.spec.ts
@@ -19,6 +19,7 @@ test("creates a loan in normal mode", async ({ page }) => {
 
   await navigateTo(page, "/loans");
 
+  await page.getByRole("button", { name: "ローンを追加" }).click();
   await page.getByLabel("商品名 *").first().fill("Laptop");
   await page.getByLabel("総支払額 *").first().fill("120000");
   await page.getByLabel("初回引落日 *").fill("2026-04-15");
@@ -35,6 +36,7 @@ test("creates a loan in midway mode", async ({ page }) => {
 
   await navigateTo(page, "/loans");
 
+  await page.getByRole("button", { name: "ローンを追加" }).click();
   await page.getByText("途中から入力する").first().click();
   await page.getByLabel("商品名 *").first().fill("Camera");
   await page.getByLabel("残り残高 *").first().fill("60000");
@@ -53,6 +55,7 @@ test("updates the monthly payment preview in real time", async ({ page }) => {
 
   await navigateTo(page, "/loans");
 
+  await page.getByRole("button", { name: "ローンを追加" }).click();
   await page.getByLabel("商品名 *").first().fill("Preview Loan");
   await page.getByLabel("総支払額 *").first().fill("1000");
   await page.getByLabel("支払回数 *").fill("3");

--- a/e2e/scenarios/loan-flow.spec.ts
+++ b/e2e/scenarios/loan-flow.spec.ts
@@ -12,6 +12,7 @@ test("creates a loan, reflects it on the dashboard, and updates the snapshot aft
 
   await navigateTo(page, "/loans");
 
+  await page.getByRole("button", { name: "ローンを追加" }).click();
   await page.getByLabel("商品名 *").first().fill("PCローン");
   await page.getByLabel("総支払額 *").first().fill("60000");
   await page.getByLabel("初回引落日 *").fill(getFutureDate(7));

--- a/packages/backend/src/routes/loans.integration.test.ts
+++ b/packages/backend/src/routes/loans.integration.test.ts
@@ -60,6 +60,7 @@ describe("loans routes", () => {
       id: created.id,
       name: "Laptop Updated",
       paymentCount: 6,
+      paymentMethod: "account_withdrawal",
     });
 
     const remove = await client.delete(`/api/loans/${created.id}`);
@@ -94,5 +95,47 @@ describe("loans routes", () => {
     });
     const updated = await parseJson<{ dateShiftPolicy: string }>(update);
     expect(updated.dateShiftPolicy).toBe("next");
+  });
+
+  it("preserves paymentMethod when omitted on update", async () => {
+    const create = await client.post("/api/loans", {
+      name: "Phone",
+      totalAmount: 120000,
+      paymentCount: 12,
+      startDate: "2026-04-10",
+      paymentMethod: "credit_card",
+      accountId: null,
+    });
+    const created = await parseJson<{ id: string; paymentMethod: string }>(create);
+    expect(created.paymentMethod).toBe("credit_card");
+
+    const update = await client.put(`/api/loans/${created.id}`, {
+      name: "Phone Updated",
+      totalAmount: 60000,
+      paymentCount: 6,
+      startDate: "2026-05-15",
+      accountId: null,
+    });
+    const updated = await parseJson<{ paymentMethod: string; accountId: string | null }>(update);
+    expect(updated.paymentMethod).toBe("credit_card");
+    expect(updated.accountId).toBeNull();
+  });
+
+  it("creates credit card installment loans without an account", async () => {
+    const create = await client.post("/api/loans", {
+      name: "Phone installments",
+      totalAmount: 120000,
+      paymentCount: 12,
+      startDate: "2026-04-10",
+      paymentMethod: "credit_card",
+      accountId: null,
+    });
+
+    expect(create.status).toBe(201);
+    expect(await parseJson(create)).toMatchObject({
+      name: "Phone installments",
+      paymentMethod: "credit_card",
+      accountId: null,
+    });
   });
 });

--- a/packages/backend/src/routes/loans.ts
+++ b/packages/backend/src/routes/loans.ts
@@ -7,22 +7,33 @@ import { positiveInt32Schema } from "../lib/validation";
 import { getLoanSnapshot } from "../services/loans";
 
 const dateShiftPolicySchema = z.enum(["none", "previous", "next"]);
+const paymentMethodSchema = z.enum(["account_withdrawal", "credit_card"]);
 
 const basePayloadSchema = z.object({
   name: z.string().min(1).max(100),
   totalAmount: positiveInt32Schema(),
   paymentCount: positiveInt32Schema(),
   startDate: z.string(),
-  accountId: z.string().uuid(),
+  paymentMethod: paymentMethodSchema.optional(),
+  accountId: z.preprocess((value) => (value === "" ? null : value), z.string().uuid().nullable()),
 });
 
 const createPayloadSchema = basePayloadSchema.extend({
   dateShiftPolicy: dateShiftPolicySchema.optional().default("none"),
+  paymentMethod: paymentMethodSchema.optional().default("account_withdrawal"),
 });
 
 const updatePayloadSchema = basePayloadSchema.extend({
   dateShiftPolicy: dateShiftPolicySchema.optional(),
 });
+
+function validatePaymentSource(body: z.infer<typeof createPayloadSchema> | z.infer<typeof updatePayloadSchema>) {
+  if (body.paymentMethod === "account_withdrawal" && !body.accountId) {
+    return "accountId is required when paymentMethod is account_withdrawal";
+  }
+
+  return null;
+}
 
 function buildLoanData(body: z.infer<typeof createPayloadSchema> | z.infer<typeof updatePayloadSchema>) {
   return {
@@ -30,8 +41,13 @@ function buildLoanData(body: z.infer<typeof createPayloadSchema> | z.infer<typeo
     totalAmount: body.totalAmount,
     paymentCount: body.paymentCount,
     startDate: new Date(`${body.startDate}T00:00:00.000Z`),
-    accountId: body.accountId,
     ...(body.dateShiftPolicy !== undefined ? { dateShiftPolicy: body.dateShiftPolicy } : {}),
+    ...(body.paymentMethod !== undefined
+      ? {
+          paymentMethod: body.paymentMethod,
+          accountId: body.paymentMethod === "account_withdrawal" ? body.accountId : null,
+        }
+      : {}),
   };
 }
 
@@ -62,6 +78,10 @@ export const loansRoutes = new Hono()
       if (!isDateString(body.startDate)) {
         return badRequest(c, "startDate must be YYYY-MM-DD");
       }
+      const paymentSourceError = validatePaymentSource(body);
+      if (paymentSourceError) {
+        return badRequest(c, paymentSourceError);
+      }
 
       const loan = await prisma.loan.create({
         data: buildLoanData(body),
@@ -76,6 +96,10 @@ export const loansRoutes = new Hono()
       const body = updatePayloadSchema.parse(await c.req.json());
       if (!isDateString(body.startDate)) {
         return badRequest(c, "startDate must be YYYY-MM-DD");
+      }
+      const paymentSourceError = validatePaymentSource(body);
+      if (paymentSourceError) {
+        return badRequest(c, paymentSourceError);
       }
 
       const existing = await prisma.loan.findFirst({

--- a/packages/backend/src/services/loans.test.ts
+++ b/packages/backend/src/services/loans.test.ts
@@ -10,6 +10,7 @@ function createLoan(overrides: Partial<Loan> = {}): Loan {
     startDate: new Date("2026-01-15T00:00:00.000Z"),
     paymentCount: 3,
     dateShiftPolicy: "none",
+    paymentMethod: "account_withdrawal",
     accountId: "account-1",
     deletedAt: null,
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -176,5 +177,14 @@ describe("buildLoanForecastEvents", () => {
       "2026-05-06",
       "2026-06-05",
     ]);
+  });
+
+  it("does not build forecast events for credit card installments", () => {
+    const loan = createLoan({
+      paymentMethod: "credit_card",
+      accountId: null,
+    });
+
+    expect(buildLoanForecastEvents(loan, [], "2026-01-01", 4)).toEqual([]);
   });
 });

--- a/packages/backend/src/services/loans.ts
+++ b/packages/backend/src/services/loans.ts
@@ -70,6 +70,10 @@ export function buildLoanForecastEvents(
   today: string,
   forecastMonths: number,
 ) {
+  if (loan.paymentMethod === "credit_card") {
+    return [];
+  }
+
   const summary = buildLoanTransactionSummaries(transactions).get(loan.id);
   let remainingBalance = Math.max(loan.totalAmount - (summary?.totalPaid ?? 0), 0);
   let remainingPayments = Math.max(loan.paymentCount - (summary?.paidMonths.size ?? 0), 0);

--- a/packages/db/prisma/migrations/20260506000000_add_loan_payment_method/migration.sql
+++ b/packages/db/prisma/migrations/20260506000000_add_loan_payment_method/migration.sql
@@ -1,0 +1,4 @@
+CREATE TYPE "LoanPaymentMethod" AS ENUM ('account_withdrawal', 'credit_card');
+
+ALTER TABLE "loans"
+  ADD COLUMN "payment_method" "LoanPaymentMethod" NOT NULL DEFAULT 'account_withdrawal';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,11 @@ enum DateShiftPolicy {
   next
 }
 
+enum LoanPaymentMethod {
+  account_withdrawal
+  credit_card
+}
+
 model Account {
   id                String        @id @default(uuid()) @db.Uuid
   name              String        @db.VarChar(100)
@@ -129,6 +134,7 @@ model Loan {
   startDate       DateTime        @map("start_date") @db.Date
   paymentCount    Int             @map("payment_count")
   dateShiftPolicy DateShiftPolicy @default(none) @map("date_shift_policy")
+  paymentMethod   LoanPaymentMethod @default(account_withdrawal) @map("payment_method")
   accountId       String?         @map("account_id") @db.Uuid
   deletedAt       DateTime?       @map("deleted_at")
   createdAt       DateTime        @default(now()) @map("created_at")

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -141,7 +141,8 @@ export async function createLoan(
     paymentCount?: number;
     startDate?: Date;
     dateShiftPolicy?: "none" | "previous" | "next";
-    accountId: string;
+    paymentMethod?: "account_withdrawal" | "credit_card";
+    accountId?: string | null;
     deletedAt?: Date | null;
   },
 ) {
@@ -152,7 +153,8 @@ export async function createLoan(
       paymentCount: data.paymentCount ?? 1,
       startDate: data.startDate ?? new Date("2026-01-01T00:00:00.000Z"),
       dateShiftPolicy: data.dateShiftPolicy ?? "none",
-      accountId: data.accountId,
+      paymentMethod: data.paymentMethod ?? "account_withdrawal",
+      accountId: data.paymentMethod === "credit_card" ? null : data.accountId,
       deletedAt: data.deletedAt ?? null,
     },
   });

--- a/packages/frontend/src/routes/loans.tsx
+++ b/packages/frontend/src/routes/loans.tsx
@@ -1,4 +1,4 @@
-import type { Account, DateShiftPolicy, Loan } from "@sui/shared";
+import type { Account, DateShiftPolicy, Loan, LoanPaymentMethod } from "@sui/shared";
 import { startTransition, useState } from "react";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
@@ -15,6 +15,7 @@ type LoanForm = {
   startDate: string;
   paymentCount: number;
   dateShiftPolicy: DateShiftPolicy;
+  paymentMethod: LoanPaymentMethod;
   accountId: string;
 };
 
@@ -24,6 +25,7 @@ const emptyForm: LoanForm = {
   startDate: "",
   paymentCount: 1,
   dateShiftPolicy: "none",
+  paymentMethod: "account_withdrawal",
   accountId: "",
 };
 
@@ -37,6 +39,14 @@ function getPreviewAmount(totalAmount: number, paymentCount: number) {
   }
 
   return Math.ceil(totalAmount / paymentCount);
+}
+
+function buildLoanPayload(form: LoanForm, totalAmount: number) {
+  return {
+    ...form,
+    totalAmount,
+    accountId: form.paymentMethod === "credit_card" ? null : form.accountId,
+  };
 }
 
 export function LoansPage() {
@@ -63,13 +73,13 @@ export function LoansPage() {
   const canCreate =
     form.name.trim().length > 0 &&
     form.startDate !== "" &&
-    form.accountId !== "" &&
+    (form.paymentMethod === "credit_card" || form.accountId !== "") &&
     form.paymentCount >= 1 &&
     getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode) > 0;
   const canSaveEdit =
     editForm.name.trim().length > 0 &&
     editForm.startDate !== "" &&
-    editForm.accountId !== "" &&
+    (editForm.paymentMethod === "credit_card" || editForm.accountId !== "") &&
     editForm.paymentCount >= 1 &&
     getEffectiveTotalAmount(editForm.totalAmount, editRemainingBalance, editMidwayMode) > 0;
 
@@ -78,10 +88,7 @@ export function LoansPage() {
   const createLoan = async () => {
     await apiFetch("/api/loans", {
       method: "POST",
-      body: JSON.stringify({
-        ...form,
-        totalAmount: getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode),
-      }),
+      body: JSON.stringify(buildLoanPayload(form, getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode))),
     });
 
     setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
@@ -93,10 +100,9 @@ export function LoansPage() {
   const updateLoan = async (loanId: string, nextForm: LoanForm, nextRemainingBalance: number, nextMidwayMode: boolean) => {
     await apiFetch(`/api/loans/${loanId}`, {
       method: "PUT",
-      body: JSON.stringify({
-        ...nextForm,
-        totalAmount: getEffectiveTotalAmount(nextForm.totalAmount, nextRemainingBalance, nextMidwayMode),
-      }),
+      body: JSON.stringify(
+        buildLoanPayload(nextForm, getEffectiveTotalAmount(nextForm.totalAmount, nextRemainingBalance, nextMidwayMode)),
+      ),
     });
     reload();
   };
@@ -118,6 +124,7 @@ export function LoansPage() {
       startDate: loan.startDate.slice(0, 10),
       paymentCount: loan.paymentCount,
       dateShiftPolicy: loan.dateShiftPolicy,
+      paymentMethod: loan.paymentMethod,
       accountId: loan.accountId ?? "",
     });
     setEditMidwayMode(false);
@@ -223,7 +230,10 @@ function LoanRow({
             現在の残り残高 {formatCurrency(loan.remainingBalance)} / 残り {loan.remainingPayments} 回 / 次回 {formatCurrency(loan.nextPaymentAmount)}
           </div>
           <div className="mt-2 text-sm text-white/55">
-            引き落とし口座 {accounts.find((account) => account.id === loan.accountId)?.name ?? "未設定"} / 初回引落日 {formatDateWithYear(loan.startDate.slice(0, 10))}
+            {loan.paymentMethod === "credit_card"
+              ? "支払方法 クレカ分割"
+              : `引き落とし口座 ${accounts.find((account) => account.id === loan.accountId)?.name ?? "未設定"}`}{" "}
+            / 初回引落日 {formatDateWithYear(loan.startDate.slice(0, 10))}
           </div>
         </div>
         <div className="flex justify-end gap-2">
@@ -236,7 +246,9 @@ function LoanRow({
         </div>
       </div>
       <div className="text-sm text-white/60">
-        予測ベースの次回支払額と残り回数を一覧表示しています。
+        {loan.paymentMethod === "credit_card"
+          ? "クレカ分割のため、取引予測には反映しません。"
+          : "予測ベースの次回支払額と残り回数を一覧表示しています。"}
       </div>
     </div>
   );
@@ -306,16 +318,31 @@ function LoanFormFields({
         />
       </label>
       <label className="grid gap-2 text-sm">
-        <span>引き落とし口座 *</span>
-        <Select value={form.accountId} onChange={(event) => onFormChange({ ...form, accountId: event.target.value })}>
-          <option value="">口座を選択</option>
-          {accounts.map((account) => (
-            <option key={account.id} value={account.id}>
-              {account.name}
-            </option>
-          ))}
+        <span>支払方法 *</span>
+        <Select
+          value={form.paymentMethod}
+          onChange={(event) => {
+            const paymentMethod = event.target.value as LoanPaymentMethod;
+            onFormChange({ ...form, paymentMethod, accountId: paymentMethod === "credit_card" ? "" : form.accountId });
+          }}
+        >
+          <option value="account_withdrawal">口座引落し</option>
+          <option value="credit_card">クレカ分割</option>
         </Select>
       </label>
+      {form.paymentMethod === "account_withdrawal" ? (
+        <label className="grid gap-2 text-sm">
+          <span>引き落とし口座 *</span>
+          <Select value={form.accountId} onChange={(event) => onFormChange({ ...form, accountId: event.target.value })}>
+            <option value="">口座を選択</option>
+            {accounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.name}
+              </option>
+            ))}
+          </Select>
+        </label>
+      ) : null}
       <label className="grid gap-2 text-sm">
         <span>土日祝の扱い</span>
         <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onFormChange({ ...form, dateShiftPolicy })} />
@@ -369,16 +396,31 @@ function LoanEditModal({
             />
           </label>
           <label className="grid gap-2 text-sm">
-            <span>引き落とし口座 *</span>
-            <Select value={form.accountId} onChange={(event) => onFormChange({ ...form, accountId: event.target.value })}>
-              <option value="">口座を選択</option>
-              {accounts.map((account) => (
-                <option key={account.id} value={account.id}>
-                  {account.name}
-                </option>
-              ))}
+            <span>支払方法 *</span>
+            <Select
+              value={form.paymentMethod}
+              onChange={(event) => {
+                const paymentMethod = event.target.value as LoanPaymentMethod;
+                onFormChange({ ...form, paymentMethod, accountId: paymentMethod === "credit_card" ? "" : form.accountId });
+              }}
+            >
+              <option value="account_withdrawal">口座引落し</option>
+              <option value="credit_card">クレカ分割</option>
             </Select>
           </label>
+          {form.paymentMethod === "account_withdrawal" ? (
+            <label className="grid gap-2 text-sm">
+              <span>引き落とし口座 *</span>
+              <Select value={form.accountId} onChange={(event) => onFormChange({ ...form, accountId: event.target.value })}>
+                <option value="">口座を選択</option>
+                {accounts.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.name}
+                  </option>
+                ))}
+              </Select>
+            </label>
+          ) : null}
           <label className="grid gap-2 text-sm">
             <span>土日祝の扱い</span>
             <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onFormChange({ ...form, dateShiftPolicy })} />

--- a/packages/frontend/src/routes/loans.tsx
+++ b/packages/frontend/src/routes/loans.tsx
@@ -54,6 +54,7 @@ export function LoansPage() {
   const [form, setForm] = useState<LoanForm>(emptyForm);
   const [midwayMode, setMidwayMode] = useState(false);
   const [remainingBalance, setRemainingBalance] = useState(0);
+  const [createOpen, setCreateOpen] = useState(false);
   const [editingLoan, setEditingLoan] = useState<Loan | null>(null);
   const [editForm, setEditForm] = useState<LoanForm>(emptyForm);
   const [editMidwayMode, setEditMidwayMode] = useState(false);
@@ -94,6 +95,7 @@ export function LoansPage() {
     setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
     setMidwayMode(false);
     setRemainingBalance(0);
+    setCreateOpen(false);
     reload();
   };
 
@@ -147,34 +149,25 @@ export function LoansPage() {
     closeEdit();
   };
 
+  const closeCreate = () => {
+    setCreateOpen(false);
+    setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
+    setMidwayMode(false);
+    setRemainingBalance(0);
+  };
+
   return (
     <div className="grid gap-6">
-      <Card className="grid gap-4">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-xl font-semibold">ローンを追加</h2>
-          <MidwayToggle enabled={midwayMode} onChange={setMidwayMode} />
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold">ローン管理</h2>
+          <p className="mt-2 text-sm text-white/60">登録済みローンの残高や支払予定を管理します。</p>
         </div>
-        <LoanFormFields
-          accounts={accounts}
-          form={form}
-          midwayMode={midwayMode}
-          remainingBalance={remainingBalance}
-          onFormChange={setForm}
-          onRemainingBalanceChange={setRemainingBalance}
-        />
-        <LoanPreview
-          totalAmount={getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode)}
-          paymentCount={form.paymentCount}
-        />
-        <div className="flex justify-end">
-          <Button disabled={!canCreate} onClick={createLoan}>
-            追加
-          </Button>
-        </div>
-        <div className="text-sm text-white/60">
-          {loading ? "読み込み中..." : error ?? "途中参入モードでは残り残高・次回引落日・残り回数をそのまま保存します。"}
-        </div>
-      </Card>
+        <Button className="min-h-10 gap-2" onClick={() => setCreateOpen(true)}>
+          <span className="text-lg leading-none">+</span>
+          ローンを追加
+        </Button>
+      </div>
 
       <Card className="grid gap-3">
         <div className="flex items-center justify-between gap-3">
@@ -206,7 +199,84 @@ export function LoansPage() {
           />
         </DialogContent>
       </Dialog>
+
+      <LoanCreateModal
+        open={createOpen}
+        accounts={accounts}
+        form={form}
+        midwayMode={midwayMode}
+        remainingBalance={remainingBalance}
+        canCreate={canCreate}
+        loading={loading}
+        error={error}
+        onOpenChange={(open) => {
+          if (open) {
+            setCreateOpen(true);
+          } else {
+            closeCreate();
+          }
+        }}
+        onFormChange={setForm}
+        onRemainingBalanceChange={setRemainingBalance}
+        onMidwayModeChange={setMidwayMode}
+        onCreate={createLoan}
+      />
     </div>
+  );
+}
+
+function LoanCreateModal({
+  open,
+  accounts,
+  form,
+  midwayMode,
+  remainingBalance,
+  canCreate,
+  loading,
+  error,
+  onOpenChange,
+  onFormChange,
+  onRemainingBalanceChange,
+  onMidwayModeChange,
+  onCreate,
+}: {
+  open: boolean;
+  accounts: Account[];
+  form: LoanForm;
+  midwayMode: boolean;
+  remainingBalance: number;
+  canCreate: boolean;
+  loading: boolean;
+  error: string | null;
+  onOpenChange: (open: boolean) => void;
+  onFormChange: (next: LoanForm) => void;
+  onRemainingBalanceChange: (value: number) => void;
+  onMidwayModeChange: (value: boolean) => void;
+  onCreate: () => Promise<void>;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(92vw,40rem)]">
+        <DialogTitle className="text-lg font-semibold">ローンを追加</DialogTitle>
+        <DialogDescription className="mt-2 text-sm text-white/60">
+          途中参入モードを含めてローン情報を登録します。
+        </DialogDescription>
+        <LoanEditModal
+          accounts={accounts}
+          form={form}
+          midwayMode={midwayMode}
+          remainingBalance={remainingBalance}
+          canSave={canCreate}
+          actionLabel="追加"
+          helperText={loading ? "読み込み中..." : error ?? "クレカ分割は取引予測には反映されません。"}
+          onFormChange={onFormChange}
+          onRemainingBalanceChange={onRemainingBalanceChange}
+          onMidwayModeChange={onMidwayModeChange}
+          onCancel={() => onOpenChange(false)}
+          onSave={onCreate}
+        />
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -254,103 +324,6 @@ function LoanRow({
   );
 }
 
-function LoanFormFields({
-  accounts,
-  form,
-  midwayMode,
-  remainingBalance,
-  onFormChange,
-  onRemainingBalanceChange,
-}: {
-  accounts: Account[];
-  form: LoanForm;
-  midwayMode: boolean;
-  remainingBalance: number;
-  onFormChange: (next: LoanForm) => void;
-  onRemainingBalanceChange: (value: number) => void;
-}) {
-  return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
-      <label className="grid gap-2 text-sm xl:col-span-2">
-        <span>商品名 *</span>
-        <Input value={form.name} onChange={(event) => onFormChange({ ...form, name: event.target.value })} />
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>総支払額 *</span>
-        <Input
-          type="number"
-          min={0}
-          inputMode="numeric"
-          disabled={midwayMode}
-          className={midwayMode ? "bg-white/5 text-white/35" : undefined}
-          value={form.totalAmount}
-          onChange={(event) => onFormChange({ ...form, totalAmount: parseNumber(event.target.value) })}
-        />
-      </label>
-      {midwayMode ? (
-        <label className="grid gap-2 text-sm">
-          <span>残り残高 *</span>
-          <Input
-            type="number"
-            min={0}
-            inputMode="numeric"
-            value={remainingBalance}
-            onChange={(event) => onRemainingBalanceChange(parseNumber(event.target.value))}
-          />
-        </label>
-      ) : null}
-      <label className="grid gap-2 text-sm">
-        <span>{midwayMode ? "次回引落日 *" : "初回引落日 *"}</span>
-        <Input
-          type="date"
-          value={form.startDate}
-          onChange={(event) => onFormChange({ ...form, startDate: event.target.value })}
-        />
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>{midwayMode ? "残り回数 *" : "支払回数 *"}</span>
-        <Input
-          type="number"
-          min={1}
-          inputMode="numeric"
-          value={form.paymentCount}
-          onChange={(event) => onFormChange({ ...form, paymentCount: parseNumber(event.target.value) })}
-        />
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>支払方法 *</span>
-        <Select
-          value={form.paymentMethod}
-          onChange={(event) => {
-            const paymentMethod = event.target.value as LoanPaymentMethod;
-            onFormChange({ ...form, paymentMethod, accountId: paymentMethod === "credit_card" ? "" : form.accountId });
-          }}
-        >
-          <option value="account_withdrawal">口座引落し</option>
-          <option value="credit_card">クレカ分割</option>
-        </Select>
-      </label>
-      {form.paymentMethod === "account_withdrawal" ? (
-        <label className="grid gap-2 text-sm">
-          <span>引き落とし口座 *</span>
-          <Select value={form.accountId} onChange={(event) => onFormChange({ ...form, accountId: event.target.value })}>
-            <option value="">口座を選択</option>
-            {accounts.map((account) => (
-              <option key={account.id} value={account.id}>
-                {account.name}
-              </option>
-            ))}
-          </Select>
-        </label>
-      ) : null}
-      <label className="grid gap-2 text-sm">
-        <span>土日祝の扱い</span>
-        <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onFormChange({ ...form, dateShiftPolicy })} />
-      </label>
-    </div>
-  );
-}
-
 function LoanEditModal({
   accounts,
   form,
@@ -362,6 +335,8 @@ function LoanEditModal({
   onMidwayModeChange,
   onCancel,
   onSave,
+  actionLabel = "保存",
+  helperText,
 }: {
   accounts: Account[];
   form: LoanForm;
@@ -373,6 +348,8 @@ function LoanEditModal({
   onMidwayModeChange: (value: boolean) => void;
   onCancel: () => void;
   onSave: () => void;
+  actionLabel?: string;
+  helperText?: string;
 }) {
   return (
     <div className="mt-6 grid gap-5">
@@ -493,6 +470,7 @@ function LoanEditModal({
           totalAmount={getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode)}
           paymentCount={form.paymentCount}
         />
+        {helperText ? <div className="text-sm text-white/60">{helperText}</div> : null}
       </section>
 
       <div className="flex justify-end gap-3 border-t border-white/10 pt-4">
@@ -500,7 +478,7 @@ function LoanEditModal({
           キャンセル
         </Button>
         <Button disabled={!canSave} onClick={onSave}>
-          保存
+          {actionLabel}
         </Button>
       </div>
     </div>

--- a/packages/mcp/src/tools/loans.ts
+++ b/packages/mcp/src/tools/loans.ts
@@ -10,7 +10,8 @@ const loanPayload = {
   totalAmount: positiveMoneySchema.describe("総額"),
   paymentCount: positiveMoneySchema.describe("支払回数"),
   startDate: dateSchema.describe("開始日"),
-  accountId: uuidSchema.describe("支払口座 ID"),
+  paymentMethod: z.enum(["account_withdrawal", "credit_card"]).optional().describe("支払方法"),
+  accountId: uuidSchema.nullable().describe("支払口座 ID。クレカ分割の場合は null"),
 };
 
 export function registerLoanTools(server: McpServer, apiClient: SuiApiClient) {

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -5,6 +5,7 @@ import type {
   DateShiftPolicy,
   ForecastEvent,
   Loan,
+  LoanPaymentMethod,
   RecurringItem,
   Subscription,
   Transaction,
@@ -92,7 +93,8 @@ export interface CreateLoanPayload {
   startDate: string;
   paymentCount: number;
   dateShiftPolicy?: DateShiftPolicy;
-  accountId: string;
+  paymentMethod?: LoanPaymentMethod;
+  accountId: string | null;
 }
 
 export type UpdateLoanPayload = CreateLoanPayload;

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -1,6 +1,7 @@
 export type TransactionType = "income" | "expense" | "transfer";
 export type RecurringItemType = "income" | "expense";
 export type DateShiftPolicy = "none" | "previous" | "next";
+export type LoanPaymentMethod = "account_withdrawal" | "credit_card";
 
 export interface Account {
   id: string;
@@ -66,6 +67,7 @@ export interface Loan {
   startDate: string;
   paymentCount: number;
   dateShiftPolicy: DateShiftPolicy;
+  paymentMethod: LoanPaymentMethod;
   accountId: string | null;
   account: Account | null;
   remainingBalance: number;


### PR DESCRIPTION
## 概要
ローン管理に支払方法を追加し、口座引落し以外にクレカ分割を登録できるようにしました。

## 変更内容
- ローンに `paymentMethod` を追加
  - `account_withdrawal`: 取引予測に反映
  - `credit_card`: 取引予測には反映しない
- Prisma migration を追加
- ローン作成・更新 API の validation を更新
- フロントのローン追加/編集フォームに支払方法を追加
- クレカ分割選択時は引き落とし口座を不要化
- 追加フォームを編集と同じ中央モーダル形式に変更
- MCP と E2E helper の型を更新

## 確認
- [x] `make typecheck`
- [x] `make lint`
- [x] `make test-unit`
- [x] `make test-integration`
- [x] `make build`