### PR TITLE
[codex] Apply credit card safety valve from next month

### DIFF
--- a/e2e/credit-cards.spec.ts
+++ b/e2e/credit-cards.spec.ts
@@ -126,7 +126,7 @@ test("shows applied totals including assumptions in the summary", async ({ page 
   await expect(page.getByText("請求月サマリー").locator("..")).toContainText(formatCurrency(32345));
 });
 
-test("uses the assumption for months two ahead when the actual amount is lower", async ({ page }) => {
+test("uses the assumption for next month when the actual amount is lower", async ({ page }) => {
   const account = await seedAccount({ name: "Settlement Account" });
   await seedCreditCard({
     name: "Visa",
@@ -137,7 +137,7 @@ test("uses the assumption for months two ahead when the actual amount is lower",
 
   await navigateTo(page, "/credit-cards");
 
-  await page.locator('input[type="month"]').fill(toYearMonth(getJstDate(2)));
+  await page.locator('input[type="month"]').fill(toYearMonth(getJstDate(1)));
 
   const cardPanel = page.locator("div.grid.gap-2.rounded-2xl").filter({ hasText: "Visa" }).first();
   await cardPanel.locator('input[type="number"]').first().fill("42000");

--- a/e2e/scenarios/credit-card-flow.spec.ts
+++ b/e2e/scenarios/credit-card-flow.spec.ts
@@ -32,7 +32,7 @@ test("reflects saved credit card billing amounts on the dashboard forecast", asy
   await waitForReload(page);
 
   const cardPanel = page.locator("div.grid.gap-2.rounded-2xl").filter({ hasText: "メインカード" }).first();
-  await cardPanel.locator('input[type="number"]').first().fill("75000");
+  await cardPanel.locator('input[type="number"]').first().fill("125000");
   await page.getByRole("button", { name: "月次請求を保存" }).click();
   await waitForReload(page);
   await expect(cardPanel).toContainText("実額を使用");
@@ -42,5 +42,5 @@ test("reflects saved credit card billing amounts on the dashboard forecast", asy
   const actualRow = page.locator("table").last().getByRole("row").filter({
     has: page.getByText("メインカード 引き落とし"),
   }).first();
-  await expect(actualRow).toContainText(formatCurrency(75000));
+  await expect(actualRow).toContainText(formatCurrency(125000));
 });

--- a/packages/backend/src/routes/billings.integration.test.ts
+++ b/packages/backend/src/routes/billings.integration.test.ts
@@ -89,7 +89,7 @@ describe("billings routes", () => {
     expect(assumptionCard.id).toBeTruthy();
   });
 
-  it("keeps actual values for the current and next month even when they are below assumptions", async () => {
+  it("keeps low actual values only for the current month and applies the safety valve from next month", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2025-09-07T00:00:00.000Z"));
 
@@ -130,9 +130,9 @@ describe("billings routes", () => {
     });
     expect(await parseJson(nextResponse)).toMatchObject({
       total: 6000,
-      appliedTotal: 16000,
-      safetyValveActive: false,
-      sourceType: "actual",
+      appliedTotal: 30000,
+      safetyValveActive: true,
+      sourceType: "safety-valve",
       monthOffset: 1,
     });
   });

--- a/packages/backend/src/routes/dashboard.integration.test.ts
+++ b/packages/backend/src/routes/dashboard.integration.test.ts
@@ -504,7 +504,7 @@ describe("dashboard routes", () => {
     );
   });
 
-  it("uses assumptions instead of low actuals for credit card billings from two months ahead onward", async () => {
+  it("uses assumptions instead of low actuals for credit card billings from next month onward", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
 
@@ -521,7 +521,7 @@ describe("dashboard routes", () => {
       sortOrder: 1,
     });
     await createBilling(testPrisma, {
-      yearMonth: "2026-05",
+      yearMonth: "2026-04",
       items: [{ creditCardId: card.id, amount: 5000 }],
     });
 
@@ -534,9 +534,9 @@ describe("dashboard routes", () => {
     expect(body.forecast).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: `credit-card:${card.id}:2026-05`,
+          id: `credit-card:${card.id}:2026-04`,
           amount: 15000,
-          description: "Future Card 仮定値 (2026-05)",
+          description: "Future Card 仮定値 (2026-04)",
         }),
       ]),
     );

--- a/packages/backend/src/services/billings.ts
+++ b/packages/backend/src/services/billings.ts
@@ -24,7 +24,7 @@ export function resolveBillingAmount({
     };
   }
 
-  if (monthOffset >= 2 && actualAmount < assumptionAmount) {
+  if (monthOffset >= 1 && actualAmount < assumptionAmount) {
     return {
       amount: assumptionAmount,
       sourceType: "safety-valve" as const,

--- a/packages/frontend/src/routes/credit-cards.tsx
+++ b/packages/frontend/src/routes/credit-cards.tsx
@@ -55,7 +55,7 @@ function resolveAppliedCardAmount({
     };
   }
 
-  if (monthOffset >= 2 && actualAmount < assumptionAmount) {
+  if (monthOffset >= 1 && actualAmount < assumptionAmount) {
     return {
       amount: assumptionAmount,
       usesActual: false,


### PR DESCRIPTION
## Summary
- apply the credit card safety valve from next month onward when actual billing is below the assumption
- keep current-month low actual billing treated as actual
- update billing, dashboard, and credit-card E2E expectations for the new rule

## Validation
- make lint
- make typecheck
- make test-unit
- make test-integration
- make test-e2e

Fixes #181