### PR TITLE
[codex] Suggest credit card assumptions from billing history

### DIFF
--- a/e2e/credit-cards.spec.ts
+++ b/e2e/credit-cards.spec.ts
@@ -67,6 +67,36 @@ test("edits and deletes a credit card", async ({ page }) => {
   await expect(page.getByText("Master Gold")).toHaveCount(0);
 });
 
+test("suggests and applies an assumption amount from past billing medians", async ({ page }) => {
+  const account = await seedAccount({ name: "Settlement Account" });
+  const card = await seedCreditCard({
+    name: "Median Card",
+    accountId: account.id,
+    assumptionAmount: 10000,
+    sortOrder: 1,
+  });
+  await seedBilling(toYearMonth(getJstDate(-3)), [{ creditCardId: card.id, amount: 10000 }]);
+  await seedBilling(toYearMonth(getJstDate(-2)), [{ creditCardId: card.id, amount: 30000 }]);
+  await seedBilling(toYearMonth(getJstDate(-1)), [{ creditCardId: card.id, amount: 20000 }]);
+
+  await navigateTo(page, "/credit-cards");
+
+  await page.getByRole("row", { name: /Median Card/ }).getByRole("button", { name: "編集" }).click();
+  await page.getByRole("button", { name: "過去実績から提案" }).click();
+
+  await expect(page.getByText(`提案額 ${formatCurrency(20000)}`)).toBeVisible();
+  await expect(page.getByText("3 件")).toBeVisible();
+
+  await page.getByRole("button", { name: "反映" }).click();
+  await expect(page.getByLabel("月間仮定額 *").last()).toHaveValue("20000");
+
+  await page.getByLabel("月間仮定額 *").last().fill("21000");
+  await page.getByRole("button", { name: "保存" }).click();
+  await waitForReload(page);
+
+  await expect(page.getByRole("row", { name: /Median Card/ })).toContainText(formatCurrency(21000));
+});
+
 test("saves monthly billing and switches the badge to actual", async ({ page }) => {
   const account = await seedAccount({ name: "Settlement Account" });
   await seedCreditCard({

--- a/packages/backend/src/routes/credit-cards.integration.test.ts
+++ b/packages/backend/src/routes/credit-cards.integration.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createTestClient, parseJson } from "../test-helpers/app";
-import { createAccount, createCreditCard } from "../test-helpers/fixtures";
+import { createAccount, createBilling, createCreditCard } from "../test-helpers/fixtures";
 import { testPrisma } from "../test-helpers/db";
 
 const client = createTestClient();
@@ -100,5 +100,115 @@ describe("credit cards routes", () => {
     });
     const updated = await parseJson<{ dateShiftPolicy: string }>(update);
     expect(updated.dateShiftPolicy).toBe("next");
+  });
+
+  it("suggests the median actual amount from the past six months", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T00:00:00.000Z"));
+
+    const account = await createAccount(testPrisma, { name: "Settlement" });
+    const card = await createCreditCard(testPrisma, {
+      name: "Visa",
+      accountId: account.id,
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-01",
+      items: [{ creditCardId: card.id, amount: 10000 }],
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-02",
+      items: [{ creditCardId: card.id, amount: 30000 }],
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-03",
+      items: [{ creditCardId: card.id, amount: 20000 }],
+    });
+
+    const response = await client.get(`/api/credit-cards/${card.id}/assumption-suggestion?months=6`);
+
+    expect(response.status).toBe(200);
+    expect(await parseJson(response)).toEqual({
+      creditCardId: card.id,
+      method: "median",
+      months: 6,
+      sampleCount: 3,
+      sourceYearMonths: ["2026-01", "2026-02", "2026-03"],
+      suggestedAmount: 20000,
+    });
+  });
+
+  it("rounds the average of the middle two samples and excludes zero, current, future, and older months", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T00:00:00.000Z"));
+
+    const account = await createAccount(testPrisma, { name: "Settlement" });
+    const card = await createCreditCard(testPrisma, {
+      name: "Visa",
+      accountId: account.id,
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2025-11",
+      items: [{ creditCardId: card.id, amount: 999999 }],
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-02",
+      items: [{ creditCardId: card.id, amount: 10000 }],
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-03",
+      items: [{ creditCardId: card.id, amount: 0 }],
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-04",
+      items: [{ creditCardId: card.id, amount: 20001 }],
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-06",
+      items: [{ creditCardId: card.id, amount: 30000 }],
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-07",
+      items: [{ creditCardId: card.id, amount: 40000 }],
+    });
+
+    const response = await client.get(`/api/credit-cards/${card.id}/assumption-suggestion?months=6`);
+
+    expect(response.status).toBe(200);
+    expect(await parseJson(response)).toMatchObject({
+      sampleCount: 2,
+      sourceYearMonths: ["2026-02", "2026-04"],
+      suggestedAmount: 15001,
+    });
+  });
+
+  it("returns null when there are no suggestion samples", async () => {
+    const account = await createAccount(testPrisma, { name: "Settlement" });
+    const card = await createCreditCard(testPrisma, {
+      name: "Visa",
+      accountId: account.id,
+    });
+
+    const response = await client.get(`/api/credit-cards/${card.id}/assumption-suggestion`);
+
+    expect(response.status).toBe(200);
+    expect(await parseJson(response)).toMatchObject({
+      creditCardId: card.id,
+      sampleCount: 0,
+      sourceYearMonths: [],
+      suggestedAmount: null,
+    });
+  });
+
+  it("returns 404 for deleted cards when suggesting an assumption amount", async () => {
+    const account = await createAccount(testPrisma, { name: "Settlement" });
+    const deleted = await createCreditCard(testPrisma, {
+      name: "Deleted",
+      accountId: account.id,
+      deletedAt: new Date("2026-03-14T00:00:00.000Z"),
+    });
+
+    const response = await client.get(`/api/credit-cards/${deleted.id}/assumption-suggestion`);
+
+    expect(response.status).toBe(404);
   });
 });

--- a/packages/backend/src/routes/credit-cards.ts
+++ b/packages/backend/src/routes/credit-cards.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { prisma } from "../lib/db";
+import { getCurrentYearMonth, getJstToday } from "../lib/dates";
 import { handleRouteError, notFound } from "../lib/http";
 import { int32Schema, nonNegativeInt32Schema } from "../lib/validation";
+import { buildCreditCardAssumptionSuggestion } from "../services/credit-card-assumptions";
 
 const dateShiftPolicySchema = z.enum(["none", "previous", "next"]);
 
@@ -20,6 +22,10 @@ const createPayloadSchema = basePayloadSchema.extend({
 
 const updatePayloadSchema = basePayloadSchema.extend({
   dateShiftPolicy: dateShiftPolicySchema.optional(),
+});
+
+const suggestionQuerySchema = z.object({
+  months: z.coerce.number().int().min(1).max(60).optional().default(6),
 });
 
 function buildCreditCardData(
@@ -43,6 +49,30 @@ export const creditCardsRoutes = new Hono()
       orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
     });
     return c.json(cards);
+  })
+  .get("/:id/assumption-suggestion", async (c) => {
+    try {
+      const card = await prisma.creditCard.findFirst({
+        where: { id: c.req.param("id"), deletedAt: null },
+        select: { id: true },
+      });
+      if (!card) {
+        return notFound(c, "Credit card not found");
+      }
+
+      const query = suggestionQuerySchema.parse({
+        months: c.req.query("months") ?? undefined,
+      });
+      const suggestion = await buildCreditCardAssumptionSuggestion(prisma, {
+        creditCardId: card.id,
+        currentYearMonth: getCurrentYearMonth(getJstToday()),
+        months: query.months,
+      });
+
+      return c.json(suggestion);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
   })
   .post("/", async (c) => {
     try {

--- a/packages/backend/src/services/credit-card-assumptions.ts
+++ b/packages/backend/src/services/credit-card-assumptions.ts
@@ -1,0 +1,68 @@
+import type { PrismaClient } from "@sui/db";
+import type { CreditCardAssumptionSuggestionResponse } from "@sui/shared";
+import { addMonthsToYearMonth } from "../lib/dates";
+
+function median(values: number[]) {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? null;
+  }
+
+  return Math.round(((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2);
+}
+
+export async function buildCreditCardAssumptionSuggestion(
+  prisma: PrismaClient,
+  {
+    creditCardId,
+    currentYearMonth,
+    months,
+  }: {
+    creditCardId: string;
+    currentYearMonth: string;
+    months: number;
+  },
+): Promise<CreditCardAssumptionSuggestionResponse> {
+  const fromYearMonth = addMonthsToYearMonth(currentYearMonth, -months);
+  const billings = await prisma.creditCardBilling.findMany({
+    where: {
+      yearMonth: {
+        gte: fromYearMonth,
+        lt: currentYearMonth,
+      },
+      items: {
+        some: {
+          creditCardId,
+          amount: { gt: 0 },
+        },
+      },
+    },
+    include: {
+      items: {
+        where: {
+          creditCardId,
+          amount: { gt: 0 },
+        },
+        select: { amount: true },
+      },
+    },
+    orderBy: { yearMonth: "asc" },
+  });
+
+  const samples = billings.flatMap((billing) => billing.items.map((item) => item.amount));
+
+  return {
+    creditCardId,
+    method: "median",
+    months,
+    sampleCount: samples.length,
+    sourceYearMonths: billings.map((billing) => billing.yearMonth),
+    suggestedAmount: median(samples),
+  };
+}

--- a/packages/frontend/src/routes/credit-cards.tsx
+++ b/packages/frontend/src/routes/credit-cards.tsx
@@ -1,4 +1,11 @@
-import { INT4_MAX, type Account, type BillingResponse, type CreditCard, type DateShiftPolicy } from "@sui/shared";
+import {
+  INT4_MAX,
+  type Account,
+  type BillingResponse,
+  type CreditCard,
+  type CreditCardAssumptionSuggestionResponse,
+  type DateShiftPolicy,
+} from "@sui/shared";
 import { useMemo, useState, startTransition } from "react";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
@@ -75,6 +82,9 @@ export function CreditCardsPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editingCard, setEditingCard] = useState<CreditCard | null>(null);
   const [editForm, setEditForm] = useState<CreditCardForm>(emptyCard);
+  const [assumptionSuggestion, setAssumptionSuggestion] = useState<CreditCardAssumptionSuggestionResponse | null>(null);
+  const [assumptionSuggestionLoading, setAssumptionSuggestionLoading] = useState(false);
+  const [assumptionSuggestionError, setAssumptionSuggestionError] = useState<string | null>(null);
   const [editedAmounts, setEditedAmounts] = useState<Record<string, number>>({});
   const [editedYearMonth, setEditedYearMonth] = useState<string | null>(null);
 
@@ -166,6 +176,8 @@ export function CreditCardsPage() {
 
   const openEdit = (card: CreditCard) => {
     setEditingCard(card);
+    setAssumptionSuggestion(null);
+    setAssumptionSuggestionError(null);
     setEditForm({
       name: card.name,
       settlementDay: card.settlementDay,
@@ -176,9 +188,27 @@ export function CreditCardsPage() {
     });
   };
 
+  const loadAssumptionSuggestion = async (cardId: string) => {
+    setAssumptionSuggestionLoading(true);
+    setAssumptionSuggestionError(null);
+    try {
+      const suggestion = await apiFetch<CreditCardAssumptionSuggestionResponse>(
+        `/api/credit-cards/${cardId}/assumption-suggestion?months=6`,
+      );
+      setAssumptionSuggestion(suggestion);
+    } catch (error) {
+      setAssumptionSuggestion(null);
+      setAssumptionSuggestionError(error instanceof Error ? error.message : "提案を取得できませんでした");
+    } finally {
+      setAssumptionSuggestionLoading(false);
+    }
+  };
+
   const closeEdit = () => {
     setEditingCard(null);
     setEditForm(emptyCard);
+    setAssumptionSuggestion(null);
+    setAssumptionSuggestionError(null);
   };
 
   const saveEdit = async () => {
@@ -342,6 +372,11 @@ export function CreditCardsPage() {
             form={editForm}
             onChange={setEditForm}
             canSave={canSaveEdit}
+            suggestion={assumptionSuggestion}
+            suggestionLoading={assumptionSuggestionLoading}
+            suggestionError={assumptionSuggestionError}
+            onRequestSuggestion={() => editingCard && loadAssumptionSuggestion(editingCard.id)}
+            onApplySuggestion={(amount) => setEditForm((current) => ({ ...current, assumptionAmount: amount }))}
             onCancel={closeEdit}
             onSave={saveEdit}
           />
@@ -356,6 +391,11 @@ function CreditCardEditModal({
   form,
   onChange,
   canSave,
+  suggestion,
+  suggestionLoading = false,
+  suggestionError,
+  onRequestSuggestion,
+  onApplySuggestion,
   onCancel,
   onSave,
   actionLabel = "保存",
@@ -364,6 +404,11 @@ function CreditCardEditModal({
   form: CreditCardForm;
   onChange: (next: CreditCardForm) => void;
   canSave: boolean;
+  suggestion?: CreditCardAssumptionSuggestionResponse | null;
+  suggestionLoading?: boolean;
+  suggestionError?: string | null;
+  onRequestSuggestion?: () => void;
+  onApplySuggestion?: (amount: number) => void;
   onCancel: () => void;
   onSave: () => void;
   actionLabel?: string;
@@ -373,7 +418,16 @@ function CreditCardEditModal({
       <section className="grid gap-4">
         <div className="text-xs uppercase tracking-[0.18em] text-white/45">基本情報</div>
         <div className="grid gap-4 md:grid-cols-2">
-          <CreditCardFormFields accounts={accounts} form={form} onChange={onChange} />
+          <CreditCardFormFields
+            accounts={accounts}
+            form={form}
+            onChange={onChange}
+            suggestion={suggestion}
+            suggestionLoading={suggestionLoading}
+            suggestionError={suggestionError}
+            onRequestSuggestion={onRequestSuggestion}
+            onApplySuggestion={onApplySuggestion}
+          />
         </div>
       </section>
       <div className="flex justify-end gap-3 border-t border-white/10 pt-4">
@@ -392,10 +446,20 @@ function CreditCardFormFields({
   accounts,
   form,
   onChange,
+  suggestion,
+  suggestionLoading = false,
+  suggestionError,
+  onRequestSuggestion,
+  onApplySuggestion,
 }: {
   accounts: Account[];
   form: CreditCardForm;
   onChange: (next: CreditCardForm) => void;
+  suggestion?: CreditCardAssumptionSuggestionResponse | null;
+  suggestionLoading?: boolean;
+  suggestionError?: string | null;
+  onRequestSuggestion?: () => void;
+  onApplySuggestion?: (amount: number) => void;
 }) {
   return (
     <>
@@ -422,10 +486,42 @@ function CreditCardFormFields({
         <span>土日祝の扱い</span>
         <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
       </label>
-      <label className="grid gap-2 text-sm">
-        <span>月間仮定額 *</span>
-        <Input type="number" min={0} max={INT4_MAX} value={form.assumptionAmount} onChange={(event) => onChange({ ...form, assumptionAmount: Number(event.target.value) })} />
-      </label>
+      <div className="grid gap-2 text-sm">
+        <label className="grid gap-2">
+          <span>月間仮定額 *</span>
+          <Input type="number" min={0} max={INT4_MAX} value={form.assumptionAmount} onChange={(event) => onChange({ ...form, assumptionAmount: Number(event.target.value) })} />
+        </label>
+        {onRequestSuggestion ? (
+          <div className="grid gap-2 rounded-xl border border-white/10 bg-white/5 p-3 text-xs text-white/60">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="font-medium text-white/75">過去実績の提案</span>
+              <Button type="button" variant="ghost" className="min-h-9 px-3 py-1.5 text-xs" disabled={suggestionLoading} onClick={onRequestSuggestion}>
+                {suggestionLoading ? "取得中..." : "過去実績から提案"}
+              </Button>
+            </div>
+            {suggestionError ? <div className="break-words text-pink-300">{suggestionError}</div> : null}
+            {suggestion ? (
+              suggestion.suggestedAmount === null ? (
+                <div className="break-words">提案できる過去実額がありません。</div>
+              ) : (
+                <div className="grid gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge tone="success">中央値</Badge>
+                    <span className="font-medium text-white">提案額 {formatCurrency(suggestion.suggestedAmount)}</span>
+                    <span>{suggestion.sampleCount} 件</span>
+                  </div>
+                  <div className="break-words">対象月: {suggestion.sourceYearMonths.join(", ")}</div>
+                  <div className="flex justify-end">
+                    <Button type="button" variant="ghost" className="min-h-9 px-3 py-1.5 text-xs" onClick={() => onApplySuggestion?.(suggestion.suggestedAmount ?? 0)}>
+                      反映
+                    </Button>
+                  </div>
+                </div>
+              )
+            ) : null}
+          </div>
+        ) : null}
+      </div>
       <label className="grid gap-2 text-sm md:col-span-2">
         <span>表示順</span>
         <Input type="number" value={form.sortOrder} onChange={(event) => onChange({ ...form, sortOrder: Number(event.target.value) })} />

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -67,6 +67,15 @@ export interface CreateCreditCardPayload {
 
 export type UpdateCreditCardPayload = CreateCreditCardPayload;
 
+export interface CreditCardAssumptionSuggestionResponse {
+  creditCardId: string;
+  method: "median";
+  months: number;
+  sampleCount: number;
+  sourceYearMonths: string[];
+  suggestedAmount: number | null;
+}
+
 export interface CreateSubscriptionPayload {
   name: string;
   amount: number;


### PR DESCRIPTION
## Summary
- add an assumption suggestion API for credit cards using the median of prior actual billings
- expose the shared response type and validate missing/deleted cards
- add an edit-dialog flow to fetch, display, apply, and manually override the suggested amount

## Validation
- make lint
- make typecheck
- make test-unit
- make test-integration
- make test-e2e

Fixes #182