### PR TITLE
[codex] Require explicit confirmation for overdue forecasts

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -31,6 +31,15 @@ function getYearMonth(offsetMonths = 0) {
   return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
+function getDateString(offsetDays = 0) {
+  const now = new Date();
+  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000 + offsetDays * 24 * 60 * 60 * 1000);
+  const year = jst.getUTCFullYear();
+  const month = String(jst.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(jst.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 function getLastDayOfMonth(offsetMonths = 0) {
   const { year, month } = getJstDateParts();
   return new Date(Date.UTC(year, month + offsetMonths + 1, 0)).getUTCDate();
@@ -135,6 +144,36 @@ test("confirms a forecast event from the dialog", async ({ page }) => {
   await waitForReload(page);
 
   await expect(page.locator("table").last().getByRole("cell", { name: "Salary" })).toHaveCount(beforeCount - 1);
+});
+
+test("forces overdue forecast confirmation from the dashboard", async ({ page }) => {
+  const account = await seedAccount({ name: "Main Account", balance: 100000, sortOrder: 1 });
+  const card = await seedCreditCard({
+    name: "Past Card",
+    accountId: account.id,
+    settlementDay: getFutureDayOfMonth(),
+    assumptionAmount: 0,
+    sortOrder: 1,
+  });
+  await seedBilling(
+    getYearMonth(0),
+    [{ creditCardId: card.id, amount: 12000 }],
+    new Date(`${getDateString(-1)}T00:00:00.000Z`),
+  );
+
+  await navigateTo(page, "/");
+
+  await expect(page.getByRole("heading", { name: "予測イベントを確定" })).toBeVisible();
+  await expect(page.getByText("過去の未確定イベントです")).toBeVisible();
+  await expect(page.getByRole("button", { name: "閉じる" })).toHaveCount(0);
+  await expect(page.getByText("Past Card 引き落とし").first()).toBeVisible();
+
+  await page.getByLabel("実際の金額").fill("9000");
+  await page.getByRole("button", { name: "確定する" }).click();
+  await waitForReload(page);
+
+  await expect(page.getByRole("heading", { name: "予測イベントを確定" })).toHaveCount(0);
+  await expect(page.getByText("総所持金").locator("..").first()).toContainText(formatCurrency(91000));
 });
 
 test("shows a red balance warning card", async ({ page }) => {

--- a/packages/backend/src/routes/dashboard.integration.test.ts
+++ b/packages/backend/src/routes/dashboard.integration.test.ts
@@ -611,7 +611,7 @@ describe("dashboard routes", () => {
     });
   });
 
-  it("auto-confirms past forecast events and reflects them in account balances", async () => {
+  it("returns overdue forecast events without creating transactions or changing balances", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-20T00:00:00.000Z"));
 
@@ -651,6 +651,7 @@ describe("dashboard routes", () => {
     const response = await client.get("/api/dashboard");
     const body = await parseJson<{
       totalBalance: number;
+      overdueForecast: Array<{ id: string; amount: number; description: string; balance: number }>;
       forecast: Array<{ id: string; amount: number; description: string }>;
     }>(response);
 
@@ -659,14 +660,27 @@ describe("dashboard routes", () => {
     // Past events should NOT appear in forecast
     expect(body.forecast.some((e) => e.id === `recurring:${rent.id}:2026-03`)).toBe(false);
     expect(body.forecast.some((e) => e.id === `recurring:${salary.id}:2026-03`)).toBe(false);
+    expect(body.overdueForecast).toEqual([
+      expect.objectContaining({
+        id: `recurring:${rent.id}:2026-03`,
+        amount: 80000,
+        description: "Rent",
+        balance: 420000,
+      }),
+      expect.objectContaining({
+        id: `recurring:${salary.id}:2026-03`,
+        amount: 300000,
+        description: "Salary",
+        balance: 720000,
+      }),
+    ]);
 
     // Future event should appear
     expect(body.forecast.some((e) => e.id === `recurring:${insurance.id}:2026-03`)).toBe(true);
 
-    // Account balance should reflect auto-confirmed events: 500000 - 80000 + 300000 = 720000
-    expect(body.totalBalance).toBe(720000);
+    // GET should not mutate the current account balance.
+    expect(body.totalBalance).toBe(500000);
 
-    // Transactions should have been created
     const autoConfirmedTransactions = await testPrisma.transaction.findMany({
       where: {
         forecastEventId: {
@@ -674,18 +688,72 @@ describe("dashboard routes", () => {
         },
       },
     });
-    expect(autoConfirmedTransactions).toHaveLength(2);
+    expect(autoConfirmedTransactions).toHaveLength(0);
 
-    // Account balance in DB should be updated
-    const updatedAccount = await testPrisma.account.findUniqueOrThrow({
+    const savedAccount = await testPrisma.account.findUniqueOrThrow({
       where: { id: account.id },
     });
-    expect(updatedAccount.balance).toBe(720000);
+    expect(savedAccount.balance).toBe(500000);
 
-    // Calling again should be idempotent
-    const response2 = await client.get("/api/dashboard");
-    const body2 = await parseJson<{ totalBalance: number }>(response2);
-    expect(body2.totalBalance).toBe(720000);
+    const eventsResponse = await client.get("/api/dashboard/events?months=1");
+    const eventsBody = await parseJson<{ forecast: Array<{ id: string }> }>(eventsResponse);
+    expect(eventsBody.forecast.some((e) => e.id === `recurring:${rent.id}:2026-03`)).toBe(false);
+    expect(eventsBody.forecast.some((e) => e.id === `recurring:${salary.id}:2026-03`)).toBe(false);
+  });
+
+  it("confirms an overdue forecast event with an edited amount and account", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-20T00:00:00.000Z"));
+
+    const sourceAccount = await createAccount(testPrisma, {
+      name: "Source",
+      balance: 500000,
+      sortOrder: 1,
+    });
+    const targetAccount = await createAccount(testPrisma, {
+      name: "Target",
+      balance: 100000,
+      sortOrder: 2,
+    });
+    const rent = await createRecurringItem(testPrisma, {
+      name: "Rent",
+      type: "expense",
+      amount: 80000,
+      dayOfMonth: 10,
+      accountId: sourceAccount.id,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/dashboard/confirm", {
+      forecastEventId: `recurring:${rent.id}:2026-03`,
+      amount: 75000,
+      accountId: targetAccount.id,
+    });
+
+    expect(response.status).toBe(201);
+
+    const savedTransaction = await testPrisma.transaction.findFirstOrThrow({
+      where: { forecastEventId: `recurring:${rent.id}:2026-03` },
+    });
+    expect(savedTransaction.accountId).toBe(targetAccount.id);
+    expect(savedTransaction.amount).toBe(75000);
+    expect(savedTransaction.date.toISOString().slice(0, 10)).toBe("2026-03-10");
+
+    const savedSourceAccount = await testPrisma.account.findUniqueOrThrow({
+      where: { id: sourceAccount.id },
+    });
+    const savedTargetAccount = await testPrisma.account.findUniqueOrThrow({
+      where: { id: targetAccount.id },
+    });
+    expect(savedSourceAccount.balance).toBe(500000);
+    expect(savedTargetAccount.balance).toBe(25000);
+
+    const second = await client.post("/api/dashboard/confirm", {
+      forecastEventId: `recurring:${rent.id}:2026-03`,
+      amount: 75000,
+      accountId: targetAccount.id,
+    });
+    expect(second.status).toBe(409);
   });
 
   it("returns 404 when the forecast event does not exist", async () => {

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -52,7 +52,9 @@ export const dashboardRoutes = new Hono()
     try {
       const body = payloadSchema.parse(await c.req.json());
       const dashboard = await buildDashboard(prisma);
-      const event = dashboard.forecast.find((item) => item.id === body.forecastEventId);
+      const event =
+        dashboard.forecast.find((item) => item.id === body.forecastEventId) ??
+        dashboard.overdueForecast.find((item) => item.id === body.forecastEventId);
 
       if (!event) {
         const existingTransaction = await prisma.transaction.findUnique({

--- a/packages/backend/src/services/forecast.ts
+++ b/packages/backend/src/services/forecast.ts
@@ -216,44 +216,24 @@ export async function buildDashboard(
 
   const sortedEvents = sortEvents(rawEvents).filter((event) => !confirmedEventIds.has(event.id));
 
-  const activeAccountIds = new Set(accounts.map((a) => a.id));
-  const pastEvents = sortedEvents.filter(
-    (event) => event.date < today && event.accountId && activeAccountIds.has(event.accountId),
-  );
+  const totalBalance = accounts.reduce((sum, account) => sum + getEffectiveBalance(account, applyOffset), 0);
+  const pastEvents = sortedEvents.filter((event) => event.date < today);
+  const overdueForecast: ForecastEvent[] = [];
+  let runningOverdueBalance = totalBalance;
 
   for (const event of pastEvents) {
-    try {
-      await prisma.$transaction(async (tx) => {
-        await tx.account.update({
-          where: { id: event.accountId! },
-          data: {
-            balance:
-              event.type === "income"
-                ? { increment: event.amount }
-                : { decrement: event.amount },
-          },
-        });
-        await tx.transaction.create({
-          data: {
-            accountId: event.accountId!,
-            forecastEventId: event.id,
-            date: new Date(`${event.date}T00:00:00.000Z`),
-            type: event.type,
-            description: event.description,
-            amount: event.amount,
-          },
-        });
-      });
-      const account = accounts.find((a) => a.id === event.accountId);
-      if (account) {
-        account.balance = applyEvent(account.balance, event);
-      }
-    } catch {
-      // Skip if already confirmed (race condition)
-    }
+    runningOverdueBalance = applyEvent(runningOverdueBalance, event);
+    overdueForecast.push({
+      id: event.id,
+      date: event.date,
+      type: event.type,
+      description: event.description,
+      amount: event.amount,
+      balance: runningOverdueBalance,
+      accountId: event.accountId,
+    });
   }
 
-  const totalBalance = accounts.reduce((sum, account) => sum + getEffectiveBalance(account, applyOffset), 0);
   const futureEvents = sortedEvents.filter((event) => event.date >= today);
 
   const forecast: ForecastEvent[] = [];
@@ -340,6 +320,7 @@ export async function buildDashboard(
     minBalance,
     nextIncome: forecast.find((event) => event.type === "income") ?? null,
     nextExpense: forecast.find((event) => event.type === "expense") ?? null,
+    overdueForecast,
     forecast,
     accountForecasts,
   };

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -55,9 +55,13 @@ export function DashboardPage() {
   const [selectedAccountId, setSelectedAccountId] = useState<string | "total">("total");
   const [periodPreset, setPeriodPreset] = useState<DashboardPeriodPreset>(DEFAULT_DASHBOARD_PERIOD);
   const [applyOffset, setApplyOffset] = useState(true);
-  const [selectedEvent, setSelectedEvent] = useState<ForecastEvent | null>(null);
-  const [confirmAmount, setConfirmAmount] = useState(0);
-  const [accountId, setAccountId] = useState("");
+  const [manualSelectedEvent, setManualSelectedEvent] = useState<ForecastEvent | null>(null);
+  const [confirmedOverdueIds, setConfirmedOverdueIds] = useState<string[]>([]);
+  const [confirmDraft, setConfirmDraft] = useState<{
+    eventId: string;
+    amount: number;
+    accountId: string;
+  } | null>(null);
   const months = presetToMonths[periodPreset];
 
   const {
@@ -120,11 +124,40 @@ export function DashboardPage() {
       accountName: forecast.accountName,
       firstNegativeDate: forecast.events.find((event) => event.balance < 0)?.date ?? forecast.minBalanceDate,
     }));
+  const pendingOverdueEvent = dashboardData?.dashboard.overdueForecast.find(
+    (event) => !confirmedOverdueIds.includes(event.id),
+  ) ?? null;
+  const selectedEvent = pendingOverdueEvent ?? manualSelectedEvent;
+  const isOverdueConfirm = Boolean(pendingOverdueEvent);
+  const defaultAccountId = selectedEvent?.accountId ?? accounts[0]?.id ?? "";
+  const activeDraft = confirmDraft?.eventId === selectedEvent?.id ? confirmDraft : null;
+  const confirmAmount = activeDraft?.amount ?? selectedEvent?.amount ?? 0;
+  const accountId = activeDraft?.accountId ?? defaultAccountId;
+
+  const updateConfirmDraft = (draft: { amount?: number; accountId?: string }) => {
+    if (!selectedEvent) {
+      return;
+    }
+
+    setConfirmDraft({
+      eventId: selectedEvent.id,
+      amount: draft.amount ?? confirmAmount,
+      accountId: draft.accountId ?? accountId,
+    });
+  };
 
   const openConfirm = (event: ForecastEvent) => {
-    setSelectedEvent(event);
-    setConfirmAmount(event.amount);
-    setAccountId(event.accountId ?? accounts[0]?.id ?? "");
+    setManualSelectedEvent(event);
+    setConfirmDraft({
+      eventId: event.id,
+      amount: event.amount,
+      accountId: event.accountId ?? accounts[0]?.id ?? "",
+    });
+  };
+
+  const closeConfirm = () => {
+    setManualSelectedEvent(null);
+    setConfirmDraft(null);
   };
 
   const handleConfirm = async () => {
@@ -141,7 +174,12 @@ export function DashboardPage() {
       }),
     });
 
-    setSelectedEvent(null);
+    if (isOverdueConfirm) {
+      setConfirmedOverdueIds((ids) => (
+        ids.includes(selectedEvent.id) ? ids : [...ids, selectedEvent.id]
+      ));
+    }
+    closeConfirm();
     startTransition(() => setReloadKey((value) => value + 1));
   };
 
@@ -310,11 +348,21 @@ export function DashboardPage() {
         )}
       </Card>
 
-      <Dialog open={Boolean(selectedEvent)} onOpenChange={(open) => !open && setSelectedEvent(null)}>
+      <Dialog
+        open={Boolean(selectedEvent)}
+        onOpenChange={(open) => {
+          if (open || isOverdueConfirm) {
+            return;
+          }
+          closeConfirm();
+        }}
+      >
         <DialogContent>
           <DialogTitle className="text-lg font-semibold">予測イベントを確定</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
-            アイテムに設定された口座を初期値として表示します。必要なら変更できます。
+            {isOverdueConfirm
+              ? "過去の未確定イベントです。金額と対象口座を確認して確定してください。"
+              : "アイテムに設定された口座を初期値として表示します。必要なら変更できます。"}
           </DialogDescription>
           <div className="mt-6 grid gap-4">
             <div className="rounded-2xl bg-black/20 p-4 text-sm">
@@ -329,11 +377,15 @@ export function DashboardPage() {
             </div>
             <label className="grid gap-2 text-sm">
               <span>実際の金額</span>
-              <Input type="number" value={confirmAmount} onChange={(event) => setConfirmAmount(Number(event.target.value))} />
+              <Input
+                type="number"
+                value={confirmAmount}
+                onChange={(event) => updateConfirmDraft({ amount: Number(event.target.value) })}
+              />
             </label>
             <label className="grid gap-2 text-sm">
               <span>対象口座</span>
-              <Select value={accountId} onChange={(event) => setAccountId(event.target.value)}>
+              <Select value={accountId} onChange={(event) => updateConfirmDraft({ accountId: event.target.value })}>
                 <option value="">イベント設定口座を使用</option>
                 {accounts.map((account) => (
                   <option key={account.id} value={account.id}>
@@ -343,9 +395,11 @@ export function DashboardPage() {
               </Select>
             </label>
             <div className="flex justify-end gap-3">
-              <DialogClose asChild>
-                <Button variant="ghost">閉じる</Button>
-              </DialogClose>
+              {isOverdueConfirm ? null : (
+                <DialogClose asChild>
+                  <Button variant="ghost">閉じる</Button>
+                </DialogClose>
+              )}
               <Button onClick={handleConfirm}>確定する</Button>
             </div>
           </div>

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -17,6 +17,7 @@ export interface DashboardResponse {
   minBalance: number;
   nextIncome: Pick<ForecastEvent, "id" | "date" | "description" | "amount"> | null;
   nextExpense: Pick<ForecastEvent, "id" | "date" | "description" | "amount"> | null;
+  overdueForecast: ForecastEvent[];
   forecast: ForecastEvent[];
   accountForecasts: AccountForecast[];
 }


### PR DESCRIPTION
Fixes #180. Removes dashboard GET-side auto-confirmation, returns overdueForecast for past unconfirmed events, and lets POST /api/dashboard/confirm resolve both future and overdue forecast event IDs. The dashboard now forces confirmation of overdue events with editable amount and account before normal use resumes. Validated with make lint, make typecheck, make test-unit, make test-integration, make test-e2e, and make build.