### PR TITLE
[codex] Improve mobile responsive layout

### DIFF
--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+import { navigateTo } from "./helpers/actions";
+import { resetDatabase, seedAccount, seedTransaction } from "./helpers/db";
+
+const viewports = [
+  { name: "mobile-375", width: 375, height: 667 },
+  { name: "mobile-390", width: 390, height: 844 },
+  { name: "tablet-768", width: 768, height: 1024 },
+  { name: "desktop-1440", width: 1440, height: 900 },
+];
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+async function expectNoDocumentHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const overflowingElements = Array.from(document.body.querySelectorAll<HTMLElement>("*"))
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          className: element.className.toString(),
+          tagName: element.tagName.toLowerCase(),
+          text: element.textContent?.trim().slice(0, 80) ?? "",
+          right: Math.round(rect.right),
+        };
+      })
+      .filter((element) => element.right > viewportWidth + 1)
+      .sort((left, right) => right.right - left.right)
+      .slice(0, 5);
+
+    return {
+      viewportWidth,
+      bodyOverflow: document.body.scrollWidth - viewportWidth,
+      documentOverflow: document.documentElement.scrollWidth - viewportWidth,
+      overflowingElements,
+    };
+  });
+
+  expect(Math.max(metrics.bodyOverflow, metrics.documentOverflow), JSON.stringify(metrics)).toBeLessThanOrEqual(1);
+}
+
+async function expectFirstTableScrollsLocally(page: Page) {
+  const tableWrapper = page.locator("table").first().locator("..");
+  await expect(tableWrapper).toBeVisible();
+
+  const metrics = await tableWrapper.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    overflowX: window.getComputedStyle(element).overflowX,
+    scrollWidth: element.scrollWidth,
+  }));
+
+  expect(metrics.overflowX).toBe("auto");
+  expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+}
+
+async function captureResponsiveScreenshot(page: Page, testInfo: TestInfo, name: string) {
+  await page.screenshot({
+    path: testInfo.outputPath(`${name}.png`),
+    fullPage: true,
+  });
+}
+
+test("keeps primary screens inside the viewport at responsive sizes", async ({ page }, testInfo) => {
+  const account = await seedAccount({
+    name: "とても長い口座名でもモバイル幅で本文を横スクロールさせない確認用口座",
+    balance: 1_234_567_890,
+    balanceOffset: 12_345,
+    sortOrder: 1,
+  });
+  await seedTransaction({
+    accountId: account.id,
+    date: new Date("2026-06-01T00:00:00+09:00"),
+    type: "expense",
+    description: "長い取引内容でもテーブル内スクロールに閉じ込める確認用の支出",
+    amount: 98_765,
+  });
+
+  for (const viewport of viewports) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+
+    await navigateTo(page, "/");
+    await expect(page.getByRole("heading", { name: "所持金推移" })).toBeVisible();
+    await expectNoDocumentHorizontalScroll(page);
+
+    if (viewport.width < 1024) {
+      await expect(page.getByRole("button", { name: "メニュー" })).toBeVisible();
+      const headerHeight = await page.locator("header").evaluate((element) => element.getBoundingClientRect().height);
+      expect(headerHeight).toBeLessThan(96);
+    }
+
+    await captureResponsiveScreenshot(page, testInfo, `${viewport.name}-dashboard`);
+
+    await navigateTo(page, "/transactions");
+    await expect(page.getByRole("heading", { name: "取引履歴" })).toBeVisible();
+    await expectNoDocumentHorizontalScroll(page);
+
+    if (viewport.width < 1024) {
+      await expectFirstTableScrollsLocally(page);
+    }
+
+    await captureResponsiveScreenshot(page, testInfo, `${viewport.name}-transactions`);
+  }
+});
+
+test("uses a compact mobile menu for navigation", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await navigateTo(page, "/");
+
+  await page.getByRole("button", { name: "メニュー" }).click();
+  await expect(page.locator("#mobile-nav")).toBeVisible();
+
+  await page.getByRole("link", { name: "クレカ管理" }).click();
+  await expect(page.getByRole("heading", { name: "クレジットカード管理" })).toBeVisible();
+  await expect(page.locator("#mobile-nav")).toHaveCount(0);
+  await expectNoDocumentHorizontalScroll(page);
+});

--- a/packages/frontend/src/components/account-selector.tsx
+++ b/packages/frontend/src/components/account-selector.tsx
@@ -11,17 +11,18 @@ export function AccountSelector({
   onChange: (id: string | "total") => void;
 }) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex max-w-full min-w-0 flex-wrap gap-2">
       <Button variant={selected === "total" ? "primary" : "ghost"} onClick={() => onChange("total")}>
         全体
       </Button>
       {accounts.map((account) => (
         <Button
           key={account.id}
+          className="max-w-full"
           variant={selected === account.id ? "primary" : "ghost"}
           onClick={() => onChange(account.id)}
         >
-          {account.name}
+          <span className="truncate">{account.name}</span>
         </Button>
       ))}
     </div>

--- a/packages/frontend/src/components/layout.tsx
+++ b/packages/frontend/src/components/layout.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from "react";
-import { NavLink } from "react-router-dom";
+import { useState } from "react";
+import { NavLink, useLocation } from "react-router-dom";
 import { cn } from "../lib/utils";
 
 const navItems = [
@@ -17,9 +18,50 @@ const navItems = [
 ];
 
 export function AppLayout({ children }: PropsWithChildren) {
+  const [navOpen, setNavOpen] = useState(false);
+  const { pathname } = useLocation();
+  const currentItem =
+    navItems.find((item) => (item.to === "/" ? pathname === "/" : pathname.startsWith(item.to))) ?? navItems[0];
+
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-6 px-4 py-6 lg:flex-row lg:px-6">
-      <aside className="w-full shrink-0 rounded-3xl border border-white/10 bg-black/20 p-5 backdrop-blur lg:w-72">
+    <div className="mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-4 px-3 py-3 sm:px-4 sm:py-4 lg:flex-row lg:gap-6 lg:px-6 lg:py-6">
+      <header className="rounded-2xl border border-white/10 bg-black/25 p-3 backdrop-blur lg:hidden">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-xs uppercase tracking-[0.24em] text-primary">sui</div>
+            <div className="mt-1 truncate text-base font-semibold">{currentItem.label}</div>
+          </div>
+          <button
+            type="button"
+            aria-controls="mobile-nav"
+            aria-expanded={navOpen}
+            className="shrink-0 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/85 transition hover:bg-white/10"
+            onClick={() => setNavOpen((value) => !value)}
+          >
+            メニュー
+          </button>
+        </div>
+        {navOpen ? (
+          <nav id="mobile-nav" className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                onClick={() => setNavOpen(false)}
+                className={({ isActive }) =>
+                  cn(
+                    "min-w-0 rounded-xl px-3 py-2 text-sm font-medium transition",
+                    isActive ? "bg-primary text-black" : "bg-white/5 text-white/75 hover:bg-white/10",
+                  )
+                }
+              >
+                <span className="block truncate">{item.label}</span>
+              </NavLink>
+            ))}
+          </nav>
+        ) : null}
+      </header>
+      <aside className="hidden w-72 shrink-0 rounded-3xl border border-white/10 bg-black/20 p-5 backdrop-blur lg:block">
         <div className="mb-8">
           <div className="text-xs uppercase tracking-[0.3em] text-primary">sui</div>
           <h1 className="mt-3 text-3xl font-semibold">可処分資産予測</h1>
@@ -32,12 +74,12 @@ export function AppLayout({ children }: PropsWithChildren) {
               to={item.to}
               className={({ isActive }) =>
                 cn(
-                  "rounded-2xl px-4 py-3 text-sm font-medium transition",
+                  "block min-w-0 rounded-2xl px-4 py-3 text-sm font-medium transition",
                   isActive ? "bg-primary text-black" : "bg-white/5 text-white/75 hover:bg-white/10",
                 )
               }
             >
-              {item.label}
+              <span className="block truncate">{item.label}</span>
             </NavLink>
           ))}
         </nav>

--- a/packages/frontend/src/components/offset-toggle.tsx
+++ b/packages/frontend/src/components/offset-toggle.tsx
@@ -6,14 +6,14 @@ export function OffsetToggle({
   onChange: (value: boolean) => void;
 }) {
   return (
-    <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-black/20 px-4 py-2 text-sm">
+    <label className="flex max-w-full min-w-0 cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-black/20 px-4 py-2 text-sm">
       <input
         type="checkbox"
-        className="h-4 w-4 accent-[var(--color-primary)]"
+        className="h-4 w-4 shrink-0 accent-[var(--color-primary)]"
         checked={checked}
         onChange={(event) => onChange(event.target.checked)}
       />
-      <span>残高オフセットを適用</span>
+      <span className="min-w-0 truncate">残高オフセットを適用</span>
     </label>
   );
 }

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ export function Button({
   return (
     <button
       className={cn(
-        "inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50",
+        "inline-flex max-w-full min-w-0 items-center justify-center rounded-xl px-4 py-2 text-center text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50",
         variant === "primary" && "bg-primary text-black hover:brightness-110",
         variant === "ghost" && "bg-muted text-foreground hover:bg-white/10",
         variant === "danger" && "bg-danger text-white hover:brightness-110",
@@ -21,4 +21,3 @@ export function Button({
     />
   );
 }
-

--- a/packages/frontend/src/components/ui/card.tsx
+++ b/packages/frontend/src/components/ui/card.tsx
@@ -5,11 +5,10 @@ export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        "rounded-2xl border border-white/10 bg-card/90 p-5 shadow-glow backdrop-blur",
+        "min-w-0 rounded-xl border border-white/10 bg-card/90 p-4 shadow-glow backdrop-blur sm:rounded-2xl sm:p-5",
         className,
       )}
       {...props}
     />
   );
 }
-

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -15,7 +15,7 @@ export function DialogContent({
       <DialogPrimitive.Overlay className="fixed inset-0 bg-black/70 backdrop-blur-sm" />
       <DialogPrimitive.Content
         className={cn(
-          "fixed left-1/2 top-1/2 max-h-[calc(100vh-2rem)] w-[min(92vw,32rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-2xl border border-white/10 bg-card p-6 shadow-glow",
+          "fixed left-1/2 top-1/2 max-h-[90dvh] w-[min(94vw,32rem)] min-w-0 -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-2xl border border-white/10 bg-card p-4 shadow-glow sm:p-6",
           className,
         )}
       >

--- a/packages/frontend/src/components/ui/input.tsx
+++ b/packages/frontend/src/components/ui/input.tsx
@@ -5,11 +5,10 @@ export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElem
   return (
     <input
       className={cn(
-        "h-11 w-full rounded-xl border border-white/10 bg-black/20 px-3 text-sm text-foreground outline-none transition focus:border-primary",
+        "h-11 max-w-full min-w-0 w-full rounded-xl border border-white/10 bg-black/20 px-3 text-sm text-foreground outline-none transition focus:border-primary",
         className,
       )}
       {...props}
     />
   );
 }
-

--- a/packages/frontend/src/components/ui/select.tsx
+++ b/packages/frontend/src/components/ui/select.tsx
@@ -5,11 +5,10 @@ export function Select({ className, ...props }: SelectHTMLAttributes<HTMLSelectE
   return (
     <select
       className={cn(
-        "h-11 w-full rounded-xl border border-white/10 bg-black/20 px-3 text-sm text-foreground outline-none transition focus:border-primary",
+        "h-11 max-w-full min-w-0 w-full rounded-xl border border-white/10 bg-black/20 px-3 text-sm text-foreground outline-none transition focus:border-primary",
         className,
       )}
       {...props}
     />
   );
 }
-

--- a/packages/frontend/src/components/ui/table.tsx
+++ b/packages/frontend/src/components/ui/table.tsx
@@ -2,10 +2,9 @@ import type { HTMLAttributes, TableHTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
 
 export function TableWrapper({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("overflow-x-auto", className)} {...props} />;
+  return <div className={cn("max-w-full overflow-x-auto overscroll-x-contain", className)} {...props} />;
 }
 
 export function Table({ className, ...props }: TableHTMLAttributes<HTMLTableElement>) {
   return <table className={cn("min-w-full border-collapse text-sm", className)} {...props} />;
 }
-

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -32,7 +32,14 @@
 }
 
 * {
+  box-sizing: border-box;
   border-color: hsl(var(--border));
+}
+
+html,
+body {
+  min-width: 0;
+  overflow-x: hidden;
 }
 
 body {
@@ -48,6 +55,19 @@ body {
 
 #root {
   min-height: 100vh;
+  min-width: 0;
+  max-width: 100vw;
+  overflow-x: clip;
+  width: 100%;
+}
+
+.recharts-tooltip-wrapper {
+  max-width: min(20rem, calc(100vw - 2rem));
+  overflow-wrap: anywhere;
+}
+
+.recharts-tooltip-wrapper[style*="visibility: hidden"] {
+  display: none;
 }
 
 input,

--- a/packages/frontend/src/routes/accounts.tsx
+++ b/packages/frontend/src/routes/accounts.tsx
@@ -142,7 +142,7 @@ export function AccountsPage() {
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(92vw,36rem)]">
+        <DialogContent className="w-[min(94vw,36rem)]">
           <DialogTitle className="text-lg font-semibold">口座を追加</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             口座情報を登録します。
@@ -159,7 +159,7 @@ export function AccountsPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingAccount)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(92vw,36rem)]">
+        <DialogContent className="w-[min(94vw,36rem)]">
           <DialogTitle className="text-lg font-semibold">口座を編集</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             口座情報を更新します。

--- a/packages/frontend/src/routes/credit-cards.tsx
+++ b/packages/frontend/src/routes/credit-cards.tsx
@@ -230,25 +230,25 @@ export function CreditCardsPage() {
                 });
 
                 return (
-                  <div key={card.id} className="grid gap-2 rounded-2xl border border-white/10 p-4 text-sm">
+                  <div key={card.id} className="grid min-w-0 gap-2 rounded-2xl border border-white/10 p-4 text-sm">
                     <div className="flex flex-wrap items-center justify-between gap-3">
-                      <span>{card.name}</span>
+                      <span className="min-w-0 break-words">{card.name}</span>
                       <Badge tone={resolvedAmount.usesActual ? "success" : "danger"}>
                         {resolvedAmount.usesActual ? "実額を使用" : "仮定値を使用"}
                       </Badge>
                     </div>
                     <div className="grid gap-2 text-xs text-white/60 sm:grid-cols-3">
-                      <div className="rounded-xl bg-white/5 px-3 py-2">
+                      <div className="min-w-0 rounded-xl bg-white/5 px-3 py-2">
                         <div className="text-[11px] uppercase tracking-[0.16em] text-white/40">口座</div>
-                        <div className="mt-1 text-sm text-white">{card.account?.name ?? "未設定"}</div>
+                        <div className="mt-1 break-words text-sm text-white">{card.account?.name ?? "未設定"}</div>
                       </div>
                       <div className="rounded-xl bg-white/5 px-3 py-2">
                         <div className="text-[11px] uppercase tracking-[0.16em] text-white/40">引落日</div>
                         <div className="mt-1 text-sm text-white">毎月 {card.settlementDay ?? 27} 日</div>
                       </div>
-                      <div className="rounded-xl bg-white/5 px-3 py-2">
+                      <div className="min-w-0 rounded-xl bg-white/5 px-3 py-2">
                         <div className="text-[11px] uppercase tracking-[0.16em] text-white/40">仮定額</div>
-                        <div className="mt-1 text-sm text-white">{formatCurrency(card.assumptionAmount)}</div>
+                        <div className="mt-1 break-words text-sm text-white">{formatCurrency(card.assumptionAmount)}</div>
                       </div>
                     </div>
                     <Input
@@ -264,7 +264,7 @@ export function CreditCardsPage() {
                         }));
                       }}
                     />
-                    <div className="text-white/55">今月予測へ反映される額: {formatCurrency(resolvedAmount.amount)}</div>
+                    <div className="break-words text-white/55">今月予測へ反映される額: {formatCurrency(resolvedAmount.amount)}</div>
                   </div>
                 );
               })}
@@ -275,8 +275,8 @@ export function CreditCardsPage() {
           </div>
           <div className="grid min-w-0 self-start gap-4 rounded-2xl border border-white/10 bg-black/20 p-4">
             <div>
-              <div className="text-sm uppercase tracking-[0.18em] text-white/45">請求月サマリー</div>
-              <div className="mt-3 text-3xl font-semibold">{formatCurrency(data?.billing.appliedTotal ?? 0)}</div>
+              <div className="break-words text-sm uppercase tracking-[0.18em] text-white/45">請求月サマリー</div>
+              <div className="mt-3 break-words text-2xl font-semibold sm:text-3xl">{formatCurrency(data?.billing.appliedTotal ?? 0)}</div>
               <div className="mt-1 text-xs text-white/40">実額 + 仮定値の合計</div>
             </div>
             <div className="break-words text-sm text-white/60">実額未入力のカードは仮定額で予測します。</div>
@@ -314,7 +314,7 @@ export function CreditCardsPage() {
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(92vw,36rem)]">
+        <DialogContent className="w-[min(94vw,36rem)]">
           <DialogTitle className="text-lg font-semibold">カードを追加</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             カード情報を登録します。
@@ -332,7 +332,7 @@ export function CreditCardsPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingCard)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(92vw,36rem)]">
+        <DialogContent className="w-[min(94vw,36rem)]">
           <DialogTitle className="text-lg font-semibold">カードを編集</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             カード情報を更新します。

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -149,7 +149,7 @@ export function DashboardPage() {
     <div className="grid gap-6">
       {redForecasts.length > 0 ? (
         <Card className="border-pink-400/30 bg-pink-900/70">
-          <div className="text-sm font-medium text-pink-100">
+          <div className="break-words text-sm font-medium text-pink-100">
             🔴 実残高がマイナスになる見込み:{" "}
             {redForecasts
               .map((forecast) => `${forecast.accountName}（${formatDateWithYear(forecast.firstNegativeDate)}）`)
@@ -159,7 +159,7 @@ export function DashboardPage() {
       ) : null}
       {yellowForecasts.length > 0 ? (
         <Card className="border-yellow-400/30 bg-yellow-900/70">
-          <div className="text-sm font-medium text-yellow-100">
+          <div className="break-words text-sm font-medium text-yellow-100">
             ⚠️ 可処分残高がマイナスになる見込み:{" "}
             {yellowForecasts
               .map((forecast) => `${forecast.accountName}（${formatDateWithYear(forecast.firstNegativeDate)}）`)
@@ -168,7 +168,7 @@ export function DashboardPage() {
         </Card>
       ) : null}
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <section className="grid min-w-0 grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <SummaryCard title="総所持金" value={formatCurrency(dashboardData?.dashboard.totalBalance ?? 0)} />
         <SummaryCard title="全体の最小残高" value={formatCurrency(dashboardData?.dashboard.minBalance ?? 0)} />
         <SummaryCard
@@ -199,15 +199,15 @@ export function DashboardPage() {
             onChange={(next) => setSelectedAccountId(next)}
           />
         </div>
-        <div className="ml-auto shrink-0">
+        <div className="ml-auto min-w-0 shrink">
           <OffsetToggle checked={applyOffset} onChange={setApplyOffset} />
         </div>
       </div>
 
-      <Card className="flex h-[450px] flex-col overflow-hidden px-5 pt-5 pb-2">
+      <Card className="flex h-[360px] flex-col overflow-hidden px-4 pt-4 pb-2 sm:h-[450px] sm:px-5 sm:pt-5">
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
-            <h2 className="text-xl font-semibold">
+            <h2 className="break-words text-xl font-semibold">
               {selectedAccountForecast ? `${selectedAccountForecast.accountName} の残高推移` : "所持金推移"}
             </h2>
             <p className="text-sm text-white/60">
@@ -238,7 +238,7 @@ export function DashboardPage() {
         ) : dashboardError ? (
           <StateMessage message={dashboardError} tone="danger" />
         ) : (
-          <div className="min-h-0 flex-1">
+          <div className="min-h-0 min-w-0 flex-1">
             <BalanceChart
               data={chartData}
               currentBalance={currentBalance}
@@ -250,12 +250,12 @@ export function DashboardPage() {
 
       <Card>
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-          <h2 className="text-xl font-semibold">
+          <h2 className="min-w-0 break-words text-xl font-semibold">
             {selectedAccountForecast ? `${selectedAccountForecast.accountName} の予測イベント` : "予測イベント"}
           </h2>
           <PeriodSelector
             ariaLabel="予測イベントの表示期間"
-            className="w-auto min-w-28"
+            className="w-full min-w-28 sm:w-auto"
             presets={dashboardPeriodOptions}
             selected={periodPreset}
             onChange={setPeriodPreset}
@@ -270,7 +270,7 @@ export function DashboardPage() {
           <StateMessage message="表示できる予測イベントがありません。" />
         ) : (
           <TableWrapper>
-            <Table>
+            <Table className="min-w-[60rem]">
               <thead>
                 <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] text-white/45">
                   <th className="px-3 py-3">日付</th>
@@ -366,9 +366,9 @@ function SummaryCard({
 }) {
   return (
     <Card>
-      <div className="text-sm uppercase tracking-[0.18em] text-white/45">{title}</div>
-      <div className="mt-3 text-3xl font-semibold">{value}</div>
-      {detail ? <div className="mt-2 text-sm text-white/60">{detail}</div> : null}
+      <div className="break-words text-sm uppercase tracking-[0.18em] text-white/45">{title}</div>
+      <div className="mt-3 min-w-0 break-all text-3xl font-semibold">{value}</div>
+      {detail ? <div className="mt-2 break-words text-sm text-white/60">{detail}</div> : null}
     </Card>
   );
 }

--- a/packages/frontend/src/routes/loans.tsx
+++ b/packages/frontend/src/routes/loans.tsx
@@ -180,7 +180,7 @@ export function LoansPage() {
       </Card>
 
       <Dialog open={Boolean(editingLoan)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(92vw,40rem)]">
+        <DialogContent className="w-[min(94vw,40rem)]">
           <DialogTitle className="text-lg font-semibold">ローンを編集</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             途中参入モードを含めてローン情報を更新します。
@@ -256,7 +256,7 @@ function LoanCreateModal({
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[min(92vw,40rem)]">
+      <DialogContent className="w-[min(94vw,40rem)]">
         <DialogTitle className="text-lg font-semibold">ローンを追加</DialogTitle>
         <DialogDescription className="mt-2 text-sm text-white/60">
           途中参入モードを含めてローン情報を登録します。
@@ -292,14 +292,14 @@ function LoanRow({
   onDelete: (loanId: string) => Promise<void>;
 }) {
   return (
-    <div className="grid gap-4 rounded-2xl border border-white/10 p-4">
+    <div className="grid min-w-0 gap-4 rounded-2xl border border-white/10 p-4">
       <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <div className="text-base font-semibold">{loan.name}</div>
-          <div className="text-sm text-white/55">
+        <div className="min-w-0">
+          <div className="break-words text-base font-semibold">{loan.name}</div>
+          <div className="break-words text-sm text-white/55">
             現在の残り残高 {formatCurrency(loan.remainingBalance)} / 残り {loan.remainingPayments} 回 / 次回 {formatCurrency(loan.nextPaymentAmount)}
           </div>
-          <div className="mt-2 text-sm text-white/55">
+          <div className="mt-2 break-words text-sm text-white/55">
             {loan.paymentMethod === "credit_card"
               ? "支払方法 クレカ分割"
               : `引き落とし口座 ${accounts.find((account) => account.id === loan.accountId)?.name ?? "未設定"}`}{" "}
@@ -315,7 +315,7 @@ function LoanRow({
           </Button>
         </div>
       </div>
-      <div className="text-sm text-white/60">
+      <div className="break-words text-sm text-white/60">
         {loan.paymentMethod === "credit_card"
           ? "クレカ分割のため、取引予測には反映しません。"
           : "予測ベースの次回支払額と残り回数を一覧表示しています。"}
@@ -509,9 +509,9 @@ function MidwayToggle({
   onChange: (value: boolean) => void;
 }) {
   return (
-    <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-black/20 px-4 py-2 text-sm">
-      <input type="checkbox" className="h-4 w-4 accent-[var(--color-primary)]" checked={enabled} onChange={(event) => onChange(event.target.checked)} />
-      <span>途中から入力する</span>
+    <label className="flex max-w-full min-w-0 cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-black/20 px-4 py-2 text-sm">
+      <input type="checkbox" className="h-4 w-4 shrink-0 accent-[var(--color-primary)]" checked={enabled} onChange={(event) => onChange(event.target.checked)} />
+      <span className="min-w-0 truncate">途中から入力する</span>
     </label>
   );
 }
@@ -524,7 +524,7 @@ function LoanPreview({
   paymentCount: number;
 }) {
   return (
-    <div className="rounded-r-2xl border-l-2 border-primary bg-white/5 p-4 text-sm text-white/70">
+    <div className="break-words rounded-r-2xl border-l-2 border-primary bg-white/5 p-4 text-sm text-white/70">
       月々の支払額プレビュー:{" "}
       <span className="font-semibold text-white">{formatCurrency(getPreviewAmount(totalAmount, paymentCount))}</span>
     </div>

--- a/packages/frontend/src/routes/recurring.tsx
+++ b/packages/frontend/src/routes/recurring.tsx
@@ -215,7 +215,7 @@ export function RecurringPage() {
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(92vw,36rem)]">
+        <DialogContent className="w-[min(94vw,36rem)]">
           <DialogTitle className="text-lg font-semibold">固定収支を追加</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             固定収支の内容を登録します。
@@ -233,7 +233,7 @@ export function RecurringPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingItem)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(92vw,36rem)]">
+        <DialogContent className="w-[min(94vw,36rem)]">
           <DialogTitle className="text-lg font-semibold">固定収支を編集</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             固定収支の内容を更新します。

--- a/packages/frontend/src/routes/subscriptions.tsx
+++ b/packages/frontend/src/routes/subscriptions.tsx
@@ -271,19 +271,19 @@ export function SubscriptionsPage() {
       </div>
 
       <Card className="grid gap-4 md:grid-cols-3">
-        <div className="rounded-lg border border-white/10 bg-black/20 p-4">
-          <div className="text-sm uppercase tracking-[0.18em] text-white/45">{yearMonth.slice(0, 4)}年の年間合計</div>
-          <div className="mt-3 text-4xl font-semibold">{formatCurrency(annualTotal)}</div>
+        <div className="min-w-0 rounded-lg border border-white/10 bg-black/20 p-4">
+          <div className="break-words text-sm uppercase tracking-[0.18em] text-white/45">{yearMonth.slice(0, 4)}年の年間合計</div>
+          <div className="mt-3 break-words text-2xl font-semibold sm:text-4xl">{formatCurrency(annualTotal)}</div>
           <div className="mt-2 text-sm text-white/60">合計額</div>
         </div>
-        <div className="rounded-lg border border-white/10 bg-black/20 p-4">
+        <div className="min-w-0 rounded-lg border border-white/10 bg-black/20 p-4">
           <div className="text-sm uppercase tracking-[0.18em] text-white/45">月あたり</div>
-          <div className="mt-3 text-3xl font-semibold">{formatCurrency(annualMonthlyAverage)}</div>
+          <div className="mt-3 break-words text-2xl font-semibold sm:text-3xl">{formatCurrency(annualMonthlyAverage)}</div>
           <div className="mt-2 text-sm text-white/60">年間合計の12分の1</div>
         </div>
-        <div className="rounded-lg border border-white/10 bg-black/20 p-4">
+        <div className="min-w-0 rounded-lg border border-white/10 bg-black/20 p-4">
           <div className="text-sm uppercase tracking-[0.18em] text-white/45">件数</div>
-          <div className="mt-3 text-3xl font-semibold">
+          <div className="mt-3 break-words text-2xl font-semibold sm:text-3xl">
             {loading ? "読み込み中..." : error ?? `${subscriptions.length}件`}
           </div>
           <div className="mt-2 text-sm text-white/60">登録済みサブスク</div>
@@ -304,9 +304,9 @@ export function SubscriptionsPage() {
           </div>
         </div>
         <div className="flex items-end justify-between gap-4 rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-          <div>
+          <div className="min-w-0">
             <div className="text-xs uppercase tracking-[0.18em] text-white/45">月合計</div>
-            <div className="mt-1 text-2xl font-semibold">{formatCurrency(monthlySummary.total)}</div>
+            <div className="mt-1 break-words text-2xl font-semibold">{formatCurrency(monthlySummary.total)}</div>
           </div>
           <div className="text-sm text-white/60">{monthlySummary.items.length} 件</div>
         </div>
@@ -378,7 +378,7 @@ export function SubscriptionsPage() {
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(92vw,40rem)]">
+        <DialogContent className="w-[min(94vw,40rem)]">
           <DialogTitle className="text-lg font-semibold">サブスクを追加</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             サブスク内容を登録します。
@@ -396,7 +396,7 @@ export function SubscriptionsPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingSubscription)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(92vw,40rem)]">
+        <DialogContent className="w-[min(94vw,40rem)]">
           <DialogTitle className="text-lg font-semibold">サブスクを編集</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             登録済みのサブスク内容を更新します。

--- a/packages/frontend/src/routes/transactions.tsx
+++ b/packages/frontend/src/routes/transactions.tsx
@@ -371,24 +371,24 @@ export function TransactionsPage() {
             }}
           />
         </div>
-        <div className="ml-auto shrink-0">
+        <div className="ml-auto min-w-0 shrink">
           <OffsetToggle checked={applyOffset} onChange={setApplyOffset} />
         </div>
       </div>
 
-      <Card className="flex h-[450px] flex-col overflow-hidden px-5 pt-5 pb-2">
+      <Card className="flex h-[360px] flex-col overflow-hidden px-4 pt-4 pb-2 sm:h-[450px] sm:px-5 sm:pt-5">
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
-            <h2 className="text-xl font-semibold">
+            <h2 className="break-words text-xl font-semibold">
               {selectedAccount ? `${selectedAccount.name} の残高推移` : "所持金推移"}
             </h2>
             <p className="text-sm text-white/60">
               {selectedAccount ? "選択した口座に関係する確定取引から過去残高を復元します。" : "全口座合算の過去実績を表示します。"}
             </p>
           </div>
-          <div className="text-right">
+          <div className="min-w-0 text-right">
             <div className="text-xs uppercase tracking-[0.18em] text-white/45">現在残高</div>
-            <div className="mt-1 text-lg font-semibold">{formatCurrency(currentBalance)}</div>
+            <div className="mt-1 break-words text-lg font-semibold">{formatCurrency(currentBalance)}</div>
           </div>
         </div>
         {loading ? (
@@ -396,7 +396,7 @@ export function TransactionsPage() {
         ) : error ? (
           <StateMessage message={error} tone="danger" />
         ) : (
-          <div className="min-h-0 flex-1">
+          <div className="min-h-0 min-w-0 flex-1">
             <BalanceChart
               data={chartData}
               currentBalance={currentBalance}
@@ -467,7 +467,7 @@ export function TransactionsPage() {
           ) : null}
         </div>
         <TableWrapper>
-          <Table>
+          <Table className="min-w-[56rem]">
             <thead>
               <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] text-white/45">
                 <th className="px-3 py-3">日付</th>
@@ -509,7 +509,7 @@ export function TransactionsPage() {
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(92vw,36rem)]">
+        <DialogContent className="w-[min(94vw,36rem)]">
           <DialogTitle className="text-lg font-semibold">取引を追加</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             手動取引を記録します。
@@ -527,7 +527,7 @@ export function TransactionsPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingTransaction)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(92vw,36rem)]">
+        <DialogContent className="w-[min(94vw,36rem)]">
           <DialogTitle className="text-lg font-semibold">取引を編集</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             取引内容を更新します。
@@ -544,7 +544,7 @@ export function TransactionsPage() {
       </Dialog>
 
       <Dialog open={Boolean(deletingTransaction)} onOpenChange={(open) => !open && closeDelete()}>
-        <DialogContent className="w-[min(92vw,32rem)]">
+        <DialogContent className="w-[min(94vw,32rem)]">
           <DialogTitle className="text-lg font-semibold">取引を削除</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
             この操作は取り消せません。削除すると口座残高が元に戻ります。
@@ -557,7 +557,7 @@ export function TransactionsPage() {
               </div>
               <div className="flex items-center justify-between gap-3">
                 <span className="text-white/60">内容</span>
-                <span>{deletingTransaction.description}</span>
+                <span className="min-w-0 break-words text-right">{deletingTransaction.description}</span>
               </div>
               <div className="flex items-center justify-between gap-3">
                 <span className="text-white/60">金額</span>
@@ -565,7 +565,7 @@ export function TransactionsPage() {
               </div>
               <div className="flex items-center justify-between gap-3">
                 <span className="text-white/60">対象口座</span>
-                <span>
+                <span className="min-w-0 break-words text-right">
                   {deletingTransaction.accountName}
                   {deletingTransaction.transferToAccountName
                     ? ` -> ${deletingTransaction.transferToAccountName}`


### PR DESCRIPTION
Closes #40

## Summary
- add a compact mobile header with collapsible navigation while preserving the desktop sidebar
- constrain shared UI primitives, dialogs, forms, cards, and tables so narrow screens avoid document-level horizontal scroll
- add responsive E2E coverage for 375x667, 390x844, 768x1024, and 1440x900 with screenshot artifacts

## Validation
- make lint
- make typecheck
- make test-unit
- make test-e2e
- make build

Note: the in-app Browser surface was unavailable in this session, so visual verification used the Playwright screenshots generated by the E2E test.