### PR TITLE
Add personal debt and split bill tracking

### DIFF
--- a/e2e/personal-debts.spec.ts
+++ b/e2e/personal-debts.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+import { navigateTo, waitForReload } from "./helpers/actions";
+import { resetDatabase, seedAccount } from "./helpers/db";
+import { formatCurrency, getFutureDate } from "./helpers/scenario";
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test("creates and settles a one-to-one lent debt", async ({ page }) => {
+  const account = await seedAccount({ name: "Wallet", balance: 10000, sortOrder: 1 });
+
+  await navigateTo(page, "/personal-debts");
+  await page.getByLabel("貸し借り種別").selectOption("lent");
+  await page.getByLabel("相手").fill("A");
+  await page.getByLabel("タイトル").fill("Lunch loan");
+  await page.getByLabel("元金").fill("3000");
+  await page.getByLabel("入出金口座").selectOption(account.id);
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  const row = page.getByRole("row", { name: /Lunch loan/ }).first();
+  await expect(row).toContainText("貸した");
+  await expect(row).toContainText(formatCurrency(3000));
+
+  await row.getByRole("button", { name: "返済登録" }).click();
+  await page.getByLabel("精算額").fill("1000");
+  await page.getByRole("button", { name: "登録" }).click();
+  await waitForReload(page);
+
+  const updatedRow = page.getByRole("row", { name: /Lunch loan/ }).first();
+  await expect(updatedRow).toContainText(formatCurrency(1000));
+  await expect(updatedRow).toContainText(formatCurrency(2000));
+
+  await navigateTo(page, "/transactions");
+  await page.getByLabel("期間プリセット").selectOption("all");
+  await waitForReload(page);
+  await expect(page.getByRole("row", { name: /貸し借り: Lunch loan/ })).toContainText("支出");
+  await expect(page.getByRole("row", { name: /精算: Lunch loan/ })).toContainText("収入");
+});
+
+test("creates a self-paid split bill and settles generated participant debts", async ({ page }) => {
+  const account = await seedAccount({ name: "Wallet", balance: 20000, sortOrder: 1 });
+
+  await navigateTo(page, "/personal-debts");
+  await page.getByRole("button", { name: "割り勘" }).click();
+  await page.getByLabel("割り勘タイトル").fill("Dinner");
+  await page.getByLabel("総額").fill("12000");
+  await page.getByLabel("精算口座").selectOption(account.id);
+  await expect(page.getByText(`Aさん: ${formatCurrency(4000)}`)).toBeVisible();
+  await expect(page.getByText(`Bさん: ${formatCurrency(4000)}`)).toBeVisible();
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  await expect(page.getByText("総額 " + formatCurrency(12000))).toBeVisible();
+  await expect(page.getByRole("row", { name: /Aさん/ })).toContainText(formatCurrency(4000));
+  await expect(page.getByRole("row", { name: /Bさん/ })).toContainText(formatCurrency(4000));
+
+  for (const name of ["Aさん", "Bさん"]) {
+    await page.getByRole("row", { name: new RegExp(name) }).getByRole("button", { name: "返済登録" }).click();
+    await expect(page.getByLabel("精算額")).toHaveValue("4000");
+    await page.getByRole("button", { name: "登録" }).click();
+    await waitForReload(page);
+  }
+
+  await page.getByLabel("ステータス").selectOption("all");
+  await waitForReload(page);
+  await expect(page.getByText("自分が支払った / 完済")).toBeVisible();
+});
+
+test("confirms a due debt forecast from the dashboard", async ({ page }) => {
+  const account = await seedAccount({ name: "Wallet", balance: 10000, sortOrder: 1 });
+
+  await navigateTo(page, "/personal-debts");
+  await page.getByLabel("貸し借り種別").selectOption("lent");
+  await page.getByLabel("相手").fill("A");
+  await page.getByLabel("タイトル").fill("Due loan");
+  await page.getByLabel("元金").fill("5000");
+  await page.getByLabel("返済予定日").fill(getFutureDate(7));
+  await page.getByLabel("入出金口座").selectOption(account.id);
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  await navigateTo(page, "/");
+  await expect(page.getByText("精算予定: Due loan (A)").first()).toBeVisible();
+  await page.getByRole("button", { name: "確定" }).first().click();
+  await expect(page.getByLabel("実際の金額")).toHaveValue("5000");
+  await page.getByRole("button", { name: "確定する" }).click();
+  await waitForReload(page);
+  await expect(page.getByText("精算予定: Due loan (A)")).toHaveCount(0);
+
+  await navigateTo(page, "/personal-debts");
+  await page.getByLabel("ステータス").selectOption("all");
+  await waitForReload(page);
+  await expect(page.getByRole("row", { name: /Due loan/ })).toContainText("完済");
+});

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -7,7 +7,9 @@ import { billingsRoutes } from "./routes/billings";
 import { creditCardsRoutes } from "./routes/credit-cards";
 import { dashboardRoutes } from "./routes/dashboard";
 import { loansRoutes } from "./routes/loans";
+import { personalDebtsRoutes } from "./routes/personal-debts";
 import { recurringItemsRoutes } from "./routes/recurring-items";
+import { splitBillsRoutes } from "./routes/split-bills";
 import { subscriptionsRoutes } from "./routes/subscriptions";
 import { transactionsRoutes } from "./routes/transactions";
 
@@ -50,6 +52,8 @@ export function createApp({
   app.route("/api/credit-cards", creditCardsRoutes);
   app.route("/api/billings", billingsRoutes);
   app.route("/api/loans", loansRoutes);
+  app.route("/api/personal-debts", personalDebtsRoutes);
+  app.route("/api/split-bills", splitBillsRoutes);
   app.route("/api/transactions", transactionsRoutes);
 
   if (!enableStaticFallback) {

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/db";
 import { handleRouteError, notFound } from "../lib/http";
 import { positiveInt32Schema } from "../lib/validation";
 import { buildDashboard } from "../services/forecast";
+import { settlePersonalDebt } from "../services/personal-debts";
 
 const payloadSchema = z.object({
   forecastEventId: z.string().min(1),
@@ -27,6 +28,11 @@ function isPrismaUniqueConstraintError(error: unknown): error is { code: string 
     "code" in error &&
     typeof (error as { code?: unknown }).code === "string"
   );
+}
+
+function parsePersonalDebtForecastEventId(id: string) {
+  const match = /^personal-debt:([0-9a-f-]{36}):(\d{4}-\d{2}-\d{2})$/.exec(id);
+  return match ? { debtId: match[1], dueDate: match[2] } : null;
 }
 
 export const dashboardRoutes = new Hono()
@@ -66,6 +72,30 @@ export const dashboardRoutes = new Hono()
       const resolvedAccountId = body.accountId ?? event.accountId ?? undefined;
       if (!resolvedAccountId) {
         return c.json({ error: "Account is required for this forecast event" }, 400);
+      }
+
+      const personalDebtEvent = parsePersonalDebtForecastEventId(event.id);
+      if (personalDebtEvent) {
+        if (body.amount !== event.amount) {
+          return c.json({ error: "Debt forecast confirmation must settle the full remaining amount" }, 400);
+        }
+
+        const result = await settlePersonalDebt(
+          prisma,
+          personalDebtEvent.debtId,
+          {
+            date: event.date,
+            amount: body.amount,
+            accountId: resolvedAccountId,
+            memo: "Forecast confirmation",
+          },
+          { forecastEventId: event.id },
+        );
+        if (!result) {
+          return notFound(c, "Personal debt not found");
+        }
+
+        return c.json(result.transaction, 201);
       }
 
       const transaction = await prisma.$transaction(async (tx) => {

--- a/packages/backend/src/routes/personal-debts.integration.test.ts
+++ b/packages/backend/src/routes/personal-debts.integration.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestClient, parseJson } from "../test-helpers/app";
+import { createAccount } from "../test-helpers/fixtures";
+import { testPrisma } from "../test-helpers/db";
+
+const client = createTestClient();
+
+describe("personal debt and split bill routes", () => {
+  it("creates a lent cash loan as an expense and records repayment as income", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Wallet",
+      balance: 10000,
+      sortOrder: 1,
+    });
+
+    const createResponse = await client.post("/api/personal-debts", {
+      direction: "lent",
+      counterpartyName: "A",
+      title: "Lunch loan",
+      principalAmount: 3000,
+      openedDate: "2026-03-10",
+      dueDate: "2026-03-20",
+      accountId: account.id,
+    });
+    const debt = await parseJson<{
+      id: string;
+      openingTransactionId: string;
+      remainingAmount: number;
+    }>(createResponse);
+
+    expect(createResponse.status).toBe(201);
+    expect(debt.remainingAmount).toBe(3000);
+
+    const afterCreate = await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } });
+    expect(afterCreate.balance).toBe(7000);
+
+    const opening = await testPrisma.transaction.findUniqueOrThrow({
+      where: { id: debt.openingTransactionId },
+    });
+    expect(opening.type).toBe("expense");
+    expect(opening.amount).toBe(3000);
+
+    const settlementResponse = await client.post(`/api/personal-debts/${debt.id}/settlements`, {
+      date: "2026-03-15",
+      amount: 1000,
+      accountId: account.id,
+    });
+    const settledDebt = await parseJson<{
+      remainingAmount: number;
+      settledAmount: number;
+      settlements: Array<{ transactionId: string }>;
+    }>(settlementResponse);
+
+    expect(settlementResponse.status).toBe(201);
+    expect(settledDebt.settledAmount).toBe(1000);
+    expect(settledDebt.remainingAmount).toBe(2000);
+
+    const afterSettlement = await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } });
+    expect(afterSettlement.balance).toBe(8000);
+
+    const settlementTransaction = await testPrisma.transaction.findUniqueOrThrow({
+      where: { id: settledDebt.settlements[0].transactionId },
+    });
+    expect(settlementTransaction.type).toBe("income");
+    expect(settlementTransaction.amount).toBe(1000);
+
+    const blockedEdit = await client.put(`/api/transactions/${settlementTransaction.id}`, {
+      accountId: account.id,
+      date: "2026-03-16",
+      type: "income",
+      description: "Manual edit",
+      amount: 1000,
+    });
+    const blockedDelete = await client.delete(`/api/transactions/${settlementTransaction.id}`);
+
+    expect(blockedEdit.status).toBe(403);
+    expect(blockedDelete.status).toBe(403);
+  });
+
+  it("creates borrowed cash loans as income and repayments as expenses", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Wallet",
+      balance: 10000,
+      sortOrder: 1,
+    });
+
+    const createResponse = await client.post("/api/personal-debts", {
+      direction: "borrowed",
+      counterpartyName: "B",
+      title: "Cash help",
+      principalAmount: 5000,
+      openedDate: "2026-03-10",
+      accountId: account.id,
+    });
+    const debt = await parseJson<{ id: string; openingTransactionId: string }>(createResponse);
+
+    expect(createResponse.status).toBe(201);
+    expect((await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } })).balance).toBe(15000);
+    expect((await testPrisma.transaction.findUniqueOrThrow({ where: { id: debt.openingTransactionId } })).type).toBe(
+      "income",
+    );
+
+    const settlementResponse = await client.post(`/api/personal-debts/${debt.id}/settlements`, {
+      date: "2026-03-15",
+      amount: 5000,
+      accountId: account.id,
+    });
+    const settledDebt = await parseJson<{ status: string; remainingAmount: number }>(settlementResponse);
+
+    expect(settlementResponse.status).toBe(201);
+    expect(settledDebt.status).toBe("settled");
+    expect(settledDebt.remainingAmount).toBe(0);
+    expect((await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } })).balance).toBe(10000);
+  });
+
+  it("previews equal split remainders by sort order", async () => {
+    const response = await client.post("/api/split-bills/preview", {
+      totalAmount: 10000,
+      splitMethod: "equal",
+      participants: [
+        { name: "自分", isSelf: true, sortOrder: 0 },
+        { name: "A", sortOrder: 1 },
+        { name: "B", sortOrder: 2 },
+      ],
+    });
+    const body = await parseJson<{ participants: Array<{ name: string; shareAmount: number }> }>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.participants.map((participant) => [participant.name, participant.shareAmount])).toEqual([
+      ["自分", 3334],
+      ["A", 3333],
+      ["B", 3333],
+    ]);
+  });
+
+  it("creates self-paid split bills with one payment transaction and participant debts", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Wallet",
+      balance: 20000,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/split-bills", {
+      title: "Dinner",
+      totalAmount: 12000,
+      paidDate: "2026-03-10",
+      payerType: "self",
+      accountId: account.id,
+      splitMethod: "equal",
+      dueDate: "2026-03-20",
+      participants: [
+        { name: "自分", isSelf: true, sortOrder: 0 },
+        { name: "A", sortOrder: 1 },
+        { name: "B", sortOrder: 2 },
+      ],
+    });
+    const splitBill = await parseJson<{
+      id: string;
+      paymentTransactionId: string;
+      participants: Array<{ name: string; shareAmount: number; personalDebt: { id: string; direction: string; remainingAmount: number } | null }>;
+    }>(response);
+
+    expect(response.status).toBe(201);
+    expect((await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } })).balance).toBe(8000);
+    expect((await testPrisma.transaction.findUniqueOrThrow({ where: { id: splitBill.paymentTransactionId } })).amount).toBe(12000);
+    expect(splitBill.participants.map((participant) => [participant.name, participant.shareAmount])).toEqual([
+      ["自分", 4000],
+      ["A", 4000],
+      ["B", 4000],
+    ]);
+    expect(splitBill.participants.filter((participant) => participant.personalDebt)).toHaveLength(2);
+    expect(splitBill.participants.find((participant) => participant.name === "A")?.personalDebt).toMatchObject({
+      direction: "lent",
+      remainingAmount: 4000,
+    });
+
+    const generatedDebts = splitBill.participants.flatMap((participant) =>
+      participant.personalDebt ? [participant.personalDebt] : [],
+    );
+    for (const debt of generatedDebts) {
+      const settlement = await client.post(`/api/personal-debts/${debt.id}/settlements`, {
+        date: "2026-03-15",
+        amount: 4000,
+        accountId: account.id,
+      });
+      expect(settlement.status).toBe(201);
+    }
+
+    const refreshed = await client.get(`/api/split-bills/${splitBill.id}`);
+    expect(await parseJson<{ status: string; outstandingAmount: number }>(refreshed)).toMatchObject({
+      status: "settled",
+      outstandingAmount: 0,
+    });
+    expect((await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } })).balance).toBe(16000);
+  });
+
+  it("creates other-paid split bills without an opening transaction and tracks only self debt", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Wallet",
+      balance: 9000,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/split-bills", {
+      title: "Taxi",
+      totalAmount: 9000,
+      paidDate: "2026-03-10",
+      payerType: "other",
+      payerName: "Mika",
+      accountId: account.id,
+      participants: [
+        { name: "自分", isSelf: true, sortOrder: 0 },
+        { name: "A", sortOrder: 1 },
+        { name: "B", sortOrder: 2 },
+      ],
+    });
+    const splitBill = await parseJson<{
+      paymentTransactionId: string | null;
+      participants: Array<{ name: string; personalDebt: { id: string; direction: string; remainingAmount: number } | null }>;
+    }>(response);
+
+    expect(response.status).toBe(201);
+    expect(splitBill.paymentTransactionId).toBeNull();
+    expect((await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } })).balance).toBe(9000);
+
+    const generatedDebts = splitBill.participants.filter((participant) => participant.personalDebt);
+    expect(generatedDebts).toHaveLength(1);
+    expect(generatedDebts[0]?.personalDebt).toMatchObject({
+      direction: "borrowed",
+      remainingAmount: 3000,
+    });
+
+    const settlement = await client.post(`/api/personal-debts/${generatedDebts[0]!.personalDebt!.id}/settlements`, {
+      date: "2026-03-15",
+      amount: 3000,
+      accountId: account.id,
+    });
+
+    expect(settlement.status).toBe(201);
+    expect((await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } })).balance).toBe(6000);
+  });
+
+  it("projects due debts into the dashboard and confirms them as settlements", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const account = await createAccount(testPrisma, {
+      name: "Wallet",
+      balance: 10000,
+      sortOrder: 1,
+    });
+    const createResponse = await client.post("/api/personal-debts", {
+      direction: "lent",
+      counterpartyName: "A",
+      title: "Due loan",
+      principalAmount: 5000,
+      openedDate: "2026-03-10",
+      dueDate: "2026-03-20",
+      accountId: account.id,
+    });
+    const debt = await parseJson<{ id: string }>(createResponse);
+
+    const dashboard = await client.get("/api/dashboard");
+    const body = await parseJson<{
+      forecast: Array<{ id: string; type: string; amount: number; description: string }>;
+    }>(dashboard);
+    const event = body.forecast.find((item) => item.id.startsWith(`personal-debt:${debt.id}:`));
+
+    expect(event).toMatchObject({
+      type: "income",
+      amount: 5000,
+      description: "精算予定: Due loan (A)",
+    });
+
+    const confirm = await client.post("/api/dashboard/confirm", {
+      forecastEventId: event!.id,
+      amount: 5000,
+      accountId: account.id,
+    });
+    expect(confirm.status).toBe(201);
+
+    const settledDebt = await client.get(`/api/personal-debts/${debt.id}`);
+    expect(await parseJson<{ status: string; remainingAmount: number }>(settledDebt)).toMatchObject({
+      status: "settled",
+      remainingAmount: 0,
+    });
+    expect((await testPrisma.account.findUniqueOrThrow({ where: { id: account.id } })).balance).toBe(10000);
+
+    const duplicate = await client.post("/api/dashboard/confirm", {
+      forecastEventId: event!.id,
+      amount: 5000,
+      accountId: account.id,
+    });
+    expect(duplicate.status).toBe(409);
+  });
+
+  it("rejects changing split bill core fields after a settlement exists", async () => {
+    const account = await createAccount(testPrisma, {
+      name: "Wallet",
+      balance: 12000,
+      sortOrder: 1,
+    });
+    const response = await client.post("/api/split-bills", {
+      title: "Dinner",
+      totalAmount: 6000,
+      paidDate: "2026-03-10",
+      payerType: "self",
+      accountId: account.id,
+      participants: [
+        { name: "自分", isSelf: true, sortOrder: 0 },
+        { name: "A", sortOrder: 1 },
+      ],
+    });
+    const splitBill = await parseJson<{
+      id: string;
+      participants: Array<{ personalDebt: { id: string } | null }>;
+    }>(response);
+    const generatedDebt = splitBill.participants.find((participant) => participant.personalDebt)?.personalDebt;
+    await client.post(`/api/personal-debts/${generatedDebt!.id}/settlements`, {
+      date: "2026-03-15",
+      amount: 3000,
+      accountId: account.id,
+    });
+
+    const update = await client.put(`/api/split-bills/${splitBill.id}`, {
+      title: "Changed",
+      totalAmount: 6000,
+      paidDate: "2026-03-10",
+      payerType: "self",
+      accountId: account.id,
+      participants: [
+        { name: "自分", isSelf: true, sortOrder: 0 },
+        { name: "A", sortOrder: 1 },
+      ],
+    });
+
+    expect(update.status).toBe(400);
+  });
+});

--- a/packages/backend/src/routes/personal-debts.ts
+++ b/packages/backend/src/routes/personal-debts.ts
@@ -1,0 +1,141 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { prisma } from "../lib/db";
+import { handleRouteError, notFound } from "../lib/http";
+import { positiveInt32Schema } from "../lib/validation";
+import {
+  cancelPersonalDebt,
+  createPersonalDebt,
+  deletePersonalDebtSettlement,
+  getPersonalDebt,
+  listPersonalDebts,
+  settlePersonalDebt,
+  updatePersonalDebt,
+  updatePersonalDebtSettlement,
+} from "../services/personal-debts";
+
+const payloadSchema = z.object({
+  direction: z.enum(["lent", "borrowed"]),
+  origin: z.enum(["cash_loan", "reimbursement"]).default("cash_loan"),
+  counterpartyName: z.string().min(1).max(100),
+  title: z.string().min(1).max(100),
+  principalAmount: positiveInt32Schema(),
+  openedDate: z.string(),
+  dueDate: z.string().nullable().optional(),
+  accountId: z.string().uuid(),
+  memo: z.string().nullable().optional(),
+});
+
+const updatePayloadSchema = payloadSchema.extend({
+  status: z.enum(["open", "settled", "canceled"]).optional(),
+});
+
+const settlementPayloadSchema = z.object({
+  date: z.string(),
+  amount: positiveInt32Schema(),
+  accountId: z.string().uuid().optional(),
+  memo: z.string().nullable().optional(),
+});
+
+const listQuerySchema = z.object({
+  status: z.enum(["all", "open", "settled", "canceled"]).default("all"),
+});
+
+export const personalDebtsRoutes = new Hono()
+  .get("/", async (c) => {
+    try {
+      const { status } = listQuerySchema.parse({ status: c.req.query("status") });
+      return c.json(await listPersonalDebts(prisma, status));
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .post("/", async (c) => {
+    try {
+      const body = payloadSchema.parse(await c.req.json());
+      const debt = await createPersonalDebt(prisma, body);
+      return c.json(debt, 201);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .get("/:id", async (c) => {
+    const debt = await getPersonalDebt(prisma, c.req.param("id"));
+    if (!debt) {
+      return notFound(c, "Personal debt not found");
+    }
+
+    return c.json(debt);
+  })
+  .put("/:id", async (c) => {
+    try {
+      const body = updatePayloadSchema.parse(await c.req.json());
+      const debt = await updatePersonalDebt(prisma, c.req.param("id"), body);
+      if (!debt) {
+        return notFound(c, "Personal debt not found");
+      }
+
+      return c.json(debt);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .delete("/:id", async (c) => {
+    try {
+      const debt = await cancelPersonalDebt(prisma, c.req.param("id"));
+      if (!debt) {
+        return notFound(c, "Personal debt not found");
+      }
+
+      return c.body(null, 204);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .post("/:id/settlements", async (c) => {
+    try {
+      const body = settlementPayloadSchema.parse(await c.req.json());
+      const result = await settlePersonalDebt(prisma, c.req.param("id"), body);
+      if (!result) {
+        return notFound(c, "Personal debt not found");
+      }
+
+      return c.json(result.debt, 201);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .put("/:id/settlements/:settlementId", async (c) => {
+    try {
+      const body = settlementPayloadSchema.parse(await c.req.json());
+      const debt = await updatePersonalDebtSettlement(
+        prisma,
+        c.req.param("id"),
+        c.req.param("settlementId"),
+        body,
+      );
+      if (!debt) {
+        return notFound(c, "Settlement not found");
+      }
+
+      return c.json(debt);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .delete("/:id/settlements/:settlementId", async (c) => {
+    try {
+      const debt = await deletePersonalDebtSettlement(
+        prisma,
+        c.req.param("id"),
+        c.req.param("settlementId"),
+      );
+      if (!debt) {
+        return notFound(c, "Settlement not found");
+      }
+
+      return c.json(debt);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  });

--- a/packages/backend/src/routes/split-bills.ts
+++ b/packages/backend/src/routes/split-bills.ts
@@ -1,0 +1,106 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { prisma } from "../lib/db";
+import { handleRouteError, notFound } from "../lib/http";
+import { positiveInt32Schema } from "../lib/validation";
+import {
+  cancelSplitBill,
+  createSplitBill,
+  getSplitBill,
+  listSplitBills,
+  previewEqualSplit,
+  updateSplitBill,
+} from "../services/personal-debts";
+
+const participantSchema = z.object({
+  name: z.string().min(1).max(100),
+  isSelf: z.boolean().optional(),
+  sortOrder: z.number().int().optional(),
+});
+
+const payloadSchema = z.object({
+  title: z.string().min(1).max(100),
+  totalAmount: positiveInt32Schema(),
+  paidDate: z.string(),
+  payerType: z.enum(["self", "other"]),
+  payerName: z.string().nullable().optional(),
+  accountId: z.string().uuid(),
+  splitMethod: z.enum(["equal"]).default("equal"),
+  dueDate: z.string().nullable().optional(),
+  memo: z.string().nullable().optional(),
+  participants: z.array(participantSchema).min(2),
+});
+
+const updatePayloadSchema = payloadSchema.extend({
+  status: z.enum(["open", "settled", "canceled"]).optional(),
+});
+
+const previewPayloadSchema = z.object({
+  totalAmount: positiveInt32Schema(),
+  splitMethod: z.enum(["equal"]).default("equal"),
+  participants: z.array(participantSchema).min(2),
+});
+
+const listQuerySchema = z.object({
+  status: z.enum(["all", "open", "settled", "canceled"]).default("all"),
+});
+
+export const splitBillsRoutes = new Hono()
+  .get("/", async (c) => {
+    try {
+      const { status } = listQuerySchema.parse({ status: c.req.query("status") });
+      return c.json(await listSplitBills(prisma, status));
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .post("/preview", async (c) => {
+    try {
+      const body = previewPayloadSchema.parse(await c.req.json());
+      return c.json({ participants: previewEqualSplit(body.totalAmount, body.participants) });
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .post("/", async (c) => {
+    try {
+      const body = payloadSchema.parse(await c.req.json());
+      const splitBill = await createSplitBill(prisma, body);
+      return c.json(splitBill, 201);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .get("/:id", async (c) => {
+    const splitBill = await getSplitBill(prisma, c.req.param("id"));
+    if (!splitBill) {
+      return notFound(c, "Split bill not found");
+    }
+
+    return c.json(splitBill);
+  })
+  .put("/:id", async (c) => {
+    try {
+      const body = updatePayloadSchema.parse(await c.req.json());
+      const splitBill = await updateSplitBill(prisma, c.req.param("id"), body);
+      if (!splitBill) {
+        return notFound(c, "Split bill not found");
+      }
+
+      return c.json(splitBill);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  })
+  .delete("/:id", async (c) => {
+    try {
+      const splitBill = await cancelSplitBill(prisma, c.req.param("id"));
+      if (!splitBill) {
+        return notFound(c, "Split bill not found");
+      }
+
+      return c.body(null, 204);
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  });

--- a/packages/backend/src/routes/transactions.ts
+++ b/packages/backend/src/routes/transactions.ts
@@ -261,6 +261,16 @@ async function revertBalanceEffect(
   });
 }
 
+async function isDebtManagedTransaction(transactionId: string) {
+  const [openingCount, settlementCount, splitBillCount] = await Promise.all([
+    prisma.personalDebt.count({ where: { openingTransactionId: transactionId } }),
+    prisma.personalDebtSettlement.count({ where: { transactionId } }),
+    prisma.splitBill.count({ where: { paymentTransactionId: transactionId } }),
+  ]);
+
+  return openingCount + settlementCount + splitBillCount > 0;
+}
+
 export const transactionsRoutes = new Hono()
   .get("/", async (c) => {
     try {
@@ -493,6 +503,9 @@ export const transactionsRoutes = new Hono()
       if (!existing) {
         return notFound(c, "Transaction not found");
       }
+      if (await isDebtManagedTransaction(existing.id)) {
+        return c.json({ error: "Debt-linked transactions must be edited from the debt screen" }, 403);
+      }
 
       const body = payloadSchema.parse(await c.req.json());
       if (!isDateString(body.date)) {
@@ -551,6 +564,9 @@ export const transactionsRoutes = new Hono()
       }
       if (existing.forecastEventId !== null) {
         return c.json({ error: "Forecast-confirmed transactions cannot be deleted" }, 403);
+      }
+      if (await isDebtManagedTransaction(existing.id)) {
+        return c.json({ error: "Debt-linked transactions must be deleted from the debt screen" }, 403);
       }
 
       await prisma.$transaction(async (tx) => {

--- a/packages/backend/src/services/forecast.ts
+++ b/packages/backend/src/services/forecast.ts
@@ -11,6 +11,7 @@ import {
 import { adjustToBusinessDay } from "../lib/business-day";
 import { resolveBillingAmount } from "./billings";
 import { buildLoanForecastEvents } from "./loans";
+import { getDebtDueForecastEvents } from "./personal-debts";
 
 interface RawForecastEvent {
   id: string;
@@ -21,6 +22,7 @@ interface RawForecastEvent {
   accountId: string | null;
   sourcePriority: number;
   sortOrder: number;
+  autoConfirm?: boolean;
 }
 
 function createRecurringId(id: string, yearMonth: string) {
@@ -76,7 +78,7 @@ export async function buildDashboard(
   const currentYearMonth = getCurrentYearMonth(today);
   const applyOffset = options?.applyOffset ?? true;
 
-  const [accounts, recurringItems, creditCards, billings, loans, confirmedTransactions] =
+  const [accounts, recurringItems, creditCards, billings, loans, confirmedTransactions, debtDueEvents] =
     await Promise.all([
       prisma.account.findMany({
         where: { deletedAt: null },
@@ -104,6 +106,7 @@ export async function buildDashboard(
         where: { forecastEventId: { not: null } },
         select: { forecastEventId: true, amount: true },
       }),
+      getDebtDueForecastEvents(prisma),
     ]);
 
   const defaultSettlementDay = Number(DEFAULT_SETTINGS.credit_card_settlement_day);
@@ -214,11 +217,34 @@ export async function buildDashboard(
     }
   }
 
+  const forecastEndYearMonth = addMonthsToYearMonth(currentYearMonth, forecastMonths - 1);
+  for (const event of debtDueEvents) {
+    if (event.date.slice(0, 7) > forecastEndYearMonth) {
+      continue;
+    }
+
+    rawEvents.push({
+      id: event.id,
+      date: event.date,
+      type: event.type,
+      description: event.description,
+      amount: event.amount,
+      accountId: event.accountId,
+      sourcePriority: 40,
+      sortOrder: 0,
+      autoConfirm: false,
+    });
+  }
+
   const sortedEvents = sortEvents(rawEvents).filter((event) => !confirmedEventIds.has(event.id));
 
   const activeAccountIds = new Set(accounts.map((a) => a.id));
   const pastEvents = sortedEvents.filter(
-    (event) => event.date < today && event.accountId && activeAccountIds.has(event.accountId),
+    (event) =>
+      (event.autoConfirm ?? true) &&
+      event.date < today &&
+      event.accountId &&
+      activeAccountIds.has(event.accountId),
   );
 
   for (const event of pastEvents) {

--- a/packages/backend/src/services/personal-debts.ts
+++ b/packages/backend/src/services/personal-debts.ts
@@ -1,0 +1,859 @@
+import type {
+  PersonalDebtDirection,
+  PersonalDebtOrigin,
+  PersonalDebtStatus,
+  PersonalDebtSourceType,
+  SplitBillMethod,
+  SplitBillPayerType,
+  SplitBillStatus,
+} from "@sui/db";
+import type { Prisma, PrismaClient, TransactionType } from "@sui/db";
+import { fromDateOnlyString, isDateString, toDateOnlyString } from "../lib/dates";
+
+type Db = PrismaClient | Prisma.TransactionClient;
+
+const debtInclude = {
+  account: true,
+  settlements: {
+    orderBy: [{ date: "asc" }, { createdAt: "asc" }],
+  },
+} satisfies Prisma.PersonalDebtInclude;
+
+const splitBillInclude = {
+  account: true,
+  participants: {
+    orderBy: [{ sortOrder: "asc" }],
+    include: {
+      personalDebt: {
+        include: debtInclude,
+      },
+    },
+  },
+} satisfies Prisma.SplitBillInclude;
+
+type DebtWithRelations = Prisma.PersonalDebtGetPayload<{ include: typeof debtInclude }>;
+type SplitBillWithRelations = Prisma.SplitBillGetPayload<{ include: typeof splitBillInclude }>;
+
+export type ParticipantInput = {
+  name: string;
+  isSelf?: boolean;
+  sortOrder?: number;
+};
+
+export type CreatePersonalDebtInput = {
+  direction: PersonalDebtDirection;
+  origin?: PersonalDebtOrigin;
+  counterpartyName: string;
+  title: string;
+  principalAmount: number;
+  openedDate: string;
+  dueDate?: string | null;
+  accountId: string;
+  memo?: string | null;
+};
+
+export type CreateSettlementInput = {
+  date: string;
+  amount: number;
+  accountId?: string;
+  memo?: string | null;
+};
+
+export type CreateSplitBillInput = {
+  title: string;
+  totalAmount: number;
+  paidDate: string;
+  payerType: SplitBillPayerType;
+  payerName?: string | null;
+  accountId: string;
+  splitMethod?: SplitBillMethod;
+  dueDate?: string | null;
+  memo?: string | null;
+  participants: ParticipantInput[];
+};
+
+function assertDate(value: string, fieldName: string) {
+  if (!isDateString(value)) {
+    throw new Error(`${fieldName} must be YYYY-MM-DD`);
+  }
+}
+
+function serializeDate(value: Date | null) {
+  return value ? toDateOnlyString(value) : null;
+}
+
+function sumSettlements(debt: { settlements: Array<{ amount: number }> }) {
+  return debt.settlements.reduce((sum, settlement) => sum + settlement.amount, 0);
+}
+
+export function getDebtRemainingAmount(debt: { principalAmount: number; settlements: Array<{ amount: number }> }) {
+  return Math.max(debt.principalAmount - sumSettlements(debt), 0);
+}
+
+function serializeSettlement(settlement: DebtWithRelations["settlements"][number]) {
+  return {
+    ...settlement,
+    date: serializeDate(settlement.date),
+    createdAt: settlement.createdAt.toISOString(),
+    updatedAt: settlement.updatedAt.toISOString(),
+  };
+}
+
+export function serializeDebt(debt: DebtWithRelations) {
+  const settledAmount = sumSettlements(debt);
+
+  return {
+    ...debt,
+    openedDate: serializeDate(debt.openedDate),
+    dueDate: serializeDate(debt.dueDate),
+    createdAt: debt.createdAt.toISOString(),
+    updatedAt: debt.updatedAt.toISOString(),
+    settledAmount,
+    remainingAmount: Math.max(debt.principalAmount - settledAmount, 0),
+    settlements: debt.settlements.map(serializeSettlement),
+  };
+}
+
+export function serializeSplitBill(splitBill: SplitBillWithRelations) {
+  const participants = splitBill.participants.map((participant) => ({
+    ...participant,
+    personalDebt: participant.personalDebt ? serializeDebt(participant.personalDebt) : null,
+  }));
+  const selfShareAmount = participants.find((participant) => participant.isSelf)?.shareAmount ?? 0;
+  const outstandingAmount = participants.reduce(
+    (sum, participant) => sum + (participant.personalDebt?.remainingAmount ?? 0),
+    0,
+  );
+
+  return {
+    ...splitBill,
+    paidDate: serializeDate(splitBill.paidDate),
+    dueDate: serializeDate(splitBill.dueDate),
+    createdAt: splitBill.createdAt.toISOString(),
+    updatedAt: splitBill.updatedAt.toISOString(),
+    selfShareAmount,
+    outstandingAmount,
+    participants,
+  };
+}
+
+async function ensureAccount(tx: Db, accountId: string) {
+  const account = await tx.account.findFirst({ where: { id: accountId, deletedAt: null } });
+  if (!account) {
+    throw new Error("Account not found");
+  }
+
+  return account;
+}
+
+function openingTransactionType(direction: PersonalDebtDirection): TransactionType {
+  return direction === "lent" ? "expense" : "income";
+}
+
+function settlementTransactionType(direction: PersonalDebtDirection): TransactionType {
+  return direction === "lent" ? "income" : "expense";
+}
+
+async function applyTransactionEffect(
+  tx: Db,
+  transaction: { accountId: string; type: TransactionType; amount: number },
+) {
+  await tx.account.update({
+    where: { id: transaction.accountId },
+    data: {
+      balance:
+        transaction.type === "income"
+          ? { increment: transaction.amount }
+          : { decrement: transaction.amount },
+    },
+  });
+}
+
+async function revertTransactionEffect(
+  tx: Db,
+  transaction: { accountId: string; type: TransactionType; amount: number },
+) {
+  await tx.account.update({
+    where: { id: transaction.accountId },
+    data: {
+      balance:
+        transaction.type === "income"
+          ? { decrement: transaction.amount }
+          : { increment: transaction.amount },
+    },
+  });
+}
+
+async function createAccountingTransaction(
+  tx: Db,
+  input: {
+    accountId: string;
+    date: string;
+    type: TransactionType;
+    description: string;
+    amount: number;
+    forecastEventId?: string | null;
+  },
+) {
+  await ensureAccount(tx, input.accountId);
+  await applyTransactionEffect(tx, input);
+
+  return tx.transaction.create({
+    data: {
+      accountId: input.accountId,
+      forecastEventId: input.forecastEventId ?? null,
+      date: fromDateOnlyString(input.date),
+      type: input.type,
+      description: input.description,
+      amount: input.amount,
+    },
+  });
+}
+
+function debtTransactionDescription(input: { title: string; counterpartyName: string }) {
+  return `貸し借り: ${input.title} (${input.counterpartyName})`;
+}
+
+function settlementTransactionDescription(debt: { title: string; counterpartyName: string }) {
+  return `精算: ${debt.title} (${debt.counterpartyName})`;
+}
+
+export function previewEqualSplit(totalAmount: number, participants: ParticipantInput[]) {
+  if (totalAmount <= 0) {
+    throw new Error("totalAmount must be positive");
+  }
+
+  const normalized = normalizeParticipants(participants);
+  const base = Math.floor(totalAmount / normalized.length);
+  let remainder = totalAmount % normalized.length;
+
+  return normalized.map((participant) => {
+    const extra = remainder > 0 ? 1 : 0;
+    remainder -= extra;
+    return {
+      ...participant,
+      shareAmount: base + extra,
+    };
+  });
+}
+
+function normalizeParticipants(participants: ParticipantInput[]) {
+  const trimmed = participants
+    .map((participant, index) => ({
+      name: participant.name.trim(),
+      isSelf: participant.isSelf ?? false,
+      sortOrder: participant.sortOrder ?? index,
+    }))
+    .filter((participant) => participant.name.length > 0);
+
+  if (!trimmed.some((participant) => participant.isSelf)) {
+    trimmed.unshift({ name: "自分", isSelf: true, sortOrder: -1 });
+  }
+
+  const selfCount = trimmed.filter((participant) => participant.isSelf).length;
+  if (selfCount !== 1) {
+    throw new Error("participants must include exactly one self participant");
+  }
+
+  if (trimmed.length < 2) {
+    throw new Error("participants must include at least two people");
+  }
+
+  return [...trimmed].sort((left, right) => left.sortOrder - right.sortOrder);
+}
+
+export async function listPersonalDebts(prisma: PrismaClient, status?: string) {
+  const where: Prisma.PersonalDebtWhereInput = { deletedAt: null };
+  if (status && status !== "all") {
+    where.status = status as PersonalDebtStatus;
+  }
+
+  const debts = await prisma.personalDebt.findMany({
+    where,
+    include: debtInclude,
+    orderBy: [{ status: "asc" }, { dueDate: "asc" }, { openedDate: "desc" }, { createdAt: "desc" }],
+  });
+
+  return debts.map(serializeDebt);
+}
+
+export async function getPersonalDebt(prisma: PrismaClient, id: string) {
+  const debt = await prisma.personalDebt.findFirst({
+    where: { id, deletedAt: null },
+    include: debtInclude,
+  });
+
+  return debt ? serializeDebt(debt) : null;
+}
+
+export async function createPersonalDebt(prisma: PrismaClient, input: CreatePersonalDebtInput) {
+  assertDate(input.openedDate, "openedDate");
+  if (input.dueDate) {
+    assertDate(input.dueDate, "dueDate");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const origin = input.origin ?? "cash_loan";
+    const openingTransaction = origin === "cash_loan"
+      ? await createAccountingTransaction(tx, {
+          accountId: input.accountId,
+          date: input.openedDate,
+          type: openingTransactionType(input.direction),
+          description: debtTransactionDescription(input),
+          amount: input.principalAmount,
+        })
+      : null;
+
+    const debt = await tx.personalDebt.create({
+      data: {
+        direction: input.direction,
+        origin,
+        counterpartyName: input.counterpartyName,
+        title: input.title,
+        principalAmount: input.principalAmount,
+        openedDate: fromDateOnlyString(input.openedDate),
+        dueDate: input.dueDate ? fromDateOnlyString(input.dueDate) : null,
+        accountId: input.accountId,
+        sourceType: "manual",
+        openingTransactionId: openingTransaction?.id ?? null,
+        memo: input.memo ?? null,
+      },
+      include: debtInclude,
+    });
+
+    return serializeDebt(debt);
+  });
+}
+
+export async function updatePersonalDebt(prisma: PrismaClient, id: string, input: CreatePersonalDebtInput & { status?: string }) {
+  assertDate(input.openedDate, "openedDate");
+  if (input.dueDate) {
+    assertDate(input.dueDate, "dueDate");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.personalDebt.findFirst({
+      where: { id, deletedAt: null },
+      include: debtInclude,
+    });
+    if (!existing) {
+      return null;
+    }
+
+    if (existing.settlements.length > 0) {
+      const coreChanged =
+        existing.direction !== input.direction ||
+        existing.principalAmount !== input.principalAmount ||
+        existing.accountId !== input.accountId ||
+        serializeDate(existing.openedDate) !== input.openedDate;
+      if (coreChanged) {
+        throw new Error("Cannot change amount, direction, account, or opened date after settlements");
+      }
+    }
+
+    if (existing.openingTransactionId && existing.settlements.length === 0) {
+      const opening = await tx.transaction.findUnique({ where: { id: existing.openingTransactionId } });
+      if (opening) {
+        await revertTransactionEffect(tx, opening);
+        const nextOpening = {
+          accountId: input.accountId,
+          type: openingTransactionType(input.direction),
+          amount: input.principalAmount,
+        };
+        await applyTransactionEffect(tx, nextOpening);
+        await tx.transaction.update({
+          where: { id: opening.id },
+          data: {
+            accountId: nextOpening.accountId,
+            date: fromDateOnlyString(input.openedDate),
+            type: nextOpening.type,
+            description: debtTransactionDescription(input),
+            amount: nextOpening.amount,
+          },
+        });
+      }
+    }
+
+    const updated = await tx.personalDebt.update({
+      where: { id },
+      data: {
+        direction: input.direction,
+        origin: input.origin ?? existing.origin,
+        counterpartyName: input.counterpartyName,
+        title: input.title,
+        principalAmount: input.principalAmount,
+        openedDate: fromDateOnlyString(input.openedDate),
+        dueDate: input.dueDate ? fromDateOnlyString(input.dueDate) : null,
+        accountId: input.accountId,
+        status: (input.status ?? existing.status) as PersonalDebtStatus,
+        memo: input.memo ?? null,
+      },
+      include: debtInclude,
+    });
+
+    return serializeDebt(updated);
+  });
+}
+
+export async function cancelPersonalDebt(prisma: PrismaClient, id: string) {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.personalDebt.findFirst({
+      where: { id, deletedAt: null },
+      include: debtInclude,
+    });
+    if (!existing) {
+      return null;
+    }
+    if (existing.settlements.length > 0) {
+      throw new Error("Cannot cancel a debt with settlements");
+    }
+
+    if (existing.openingTransactionId) {
+      const opening = await tx.transaction.findUnique({ where: { id: existing.openingTransactionId } });
+      if (opening && !opening.deletedAt) {
+        await revertTransactionEffect(tx, opening);
+        await tx.transaction.update({
+          where: { id: opening.id },
+          data: { deletedAt: new Date() },
+        });
+      }
+    }
+
+    const canceled = await tx.personalDebt.update({
+      where: { id },
+      data: { status: "canceled", deletedAt: new Date() },
+      include: debtInclude,
+    });
+    return serializeDebt(canceled);
+  });
+}
+
+export async function settlePersonalDebt(
+  prisma: PrismaClient,
+  debtId: string,
+  input: CreateSettlementInput,
+  options?: { forecastEventId?: string | null },
+) {
+  assertDate(input.date, "date");
+
+  return prisma.$transaction(async (tx) => {
+    const debt = await tx.personalDebt.findFirst({
+      where: { id: debtId, deletedAt: null },
+      include: debtInclude,
+    });
+    if (!debt) {
+      return null;
+    }
+    if (debt.status === "canceled") {
+      throw new Error("Cannot settle a canceled debt");
+    }
+
+    const remainingAmount = getDebtRemainingAmount(debt);
+    if (input.amount > remainingAmount) {
+      throw new Error("Settlement amount exceeds remaining amount");
+    }
+
+    const accountId = input.accountId ?? debt.accountId;
+    const transaction = await createAccountingTransaction(tx, {
+      accountId,
+      date: input.date,
+      type: settlementTransactionType(debt.direction),
+      description: settlementTransactionDescription(debt),
+      amount: input.amount,
+      forecastEventId: options?.forecastEventId ?? null,
+    });
+
+    await tx.personalDebtSettlement.create({
+      data: {
+        debtId: debt.id,
+        date: fromDateOnlyString(input.date),
+        amount: input.amount,
+        accountId,
+        transactionId: transaction.id,
+        memo: input.memo ?? null,
+      },
+    });
+
+    await tx.personalDebt.update({
+      where: { id: debt.id },
+      data: { status: input.amount === remainingAmount ? "settled" : "open" },
+    });
+
+    if (debt.splitBillId) {
+      await refreshSplitBillStatus(tx, debt.splitBillId);
+    }
+
+    const updatedDebt = await tx.personalDebt.findUniqueOrThrow({
+      where: { id: debt.id },
+      include: debtInclude,
+    });
+    return { debt: serializeDebt(updatedDebt), transaction };
+  });
+}
+
+export async function updatePersonalDebtSettlement(
+  prisma: PrismaClient,
+  debtId: string,
+  settlementId: string,
+  input: CreateSettlementInput,
+) {
+  assertDate(input.date, "date");
+
+  return prisma.$transaction(async (tx) => {
+    const settlement = await tx.personalDebtSettlement.findFirst({
+      where: { id: settlementId, debtId },
+      include: { debt: { include: debtInclude }, transaction: true },
+    });
+    if (!settlement) {
+      return null;
+    }
+
+    const available = getDebtRemainingAmount(settlement.debt) + settlement.amount;
+    if (input.amount > available) {
+      throw new Error("Settlement amount exceeds remaining amount");
+    }
+
+    const accountId = input.accountId ?? settlement.debt.accountId;
+    const nextTransaction = {
+      accountId,
+      type: settlementTransactionType(settlement.debt.direction),
+      amount: input.amount,
+    };
+
+    await revertTransactionEffect(tx, settlement.transaction);
+    await applyTransactionEffect(tx, nextTransaction);
+    await tx.transaction.update({
+      where: { id: settlement.transactionId },
+      data: {
+        accountId,
+        date: fromDateOnlyString(input.date),
+        type: nextTransaction.type,
+        description: settlementTransactionDescription(settlement.debt),
+        amount: input.amount,
+      },
+    });
+
+    await tx.personalDebtSettlement.update({
+      where: { id: settlement.id },
+      data: {
+        date: fromDateOnlyString(input.date),
+        amount: input.amount,
+        accountId,
+        memo: input.memo ?? null,
+      },
+    });
+
+    const updatedDebt = await refreshDebtStatus(tx, debtId);
+    if (updatedDebt?.splitBillId) {
+      await refreshSplitBillStatus(tx, updatedDebt.splitBillId);
+    }
+
+    return updatedDebt ? serializeDebt(updatedDebt) : null;
+  });
+}
+
+export async function deletePersonalDebtSettlement(prisma: PrismaClient, debtId: string, settlementId: string) {
+  return prisma.$transaction(async (tx) => {
+    const settlement = await tx.personalDebtSettlement.findFirst({
+      where: { id: settlementId, debtId },
+      include: { debt: true, transaction: true },
+    });
+    if (!settlement) {
+      return null;
+    }
+
+    await revertTransactionEffect(tx, settlement.transaction);
+    await tx.transaction.update({
+      where: { id: settlement.transactionId },
+      data: { deletedAt: new Date() },
+    });
+    await tx.personalDebtSettlement.delete({ where: { id: settlement.id } });
+
+    const updatedDebt = await refreshDebtStatus(tx, debtId);
+    if (updatedDebt?.splitBillId) {
+      await refreshSplitBillStatus(tx, updatedDebt.splitBillId);
+    }
+
+    return updatedDebt ? serializeDebt(updatedDebt) : null;
+  });
+}
+
+async function refreshDebtStatus(tx: Db, debtId: string) {
+  const debt = await tx.personalDebt.findUnique({
+    where: { id: debtId },
+    include: debtInclude,
+  });
+  if (!debt || debt.status === "canceled") {
+    return debt;
+  }
+
+  return tx.personalDebt.update({
+    where: { id: debt.id },
+    data: { status: getDebtRemainingAmount(debt) === 0 ? "settled" : "open" },
+    include: debtInclude,
+  });
+}
+
+async function refreshSplitBillStatus(tx: Db, splitBillId: string) {
+  const splitBill = await tx.splitBill.findUnique({
+    where: { id: splitBillId },
+    include: {
+      personalDebts: {
+        where: { deletedAt: null },
+        include: { settlements: true },
+      },
+    },
+  });
+  if (!splitBill || splitBill.status === "canceled") {
+    return;
+  }
+
+  const isSettled =
+    splitBill.personalDebts.length === 0 ||
+    splitBill.personalDebts.every((debt) => getDebtRemainingAmount(debt) === 0);
+  await tx.splitBill.update({
+    where: { id: splitBillId },
+    data: { status: isSettled ? "settled" : "open" },
+  });
+}
+
+export async function listSplitBills(prisma: PrismaClient, status?: string) {
+  const where: Prisma.SplitBillWhereInput = { deletedAt: null };
+  if (status && status !== "all") {
+    where.status = status as SplitBillStatus;
+  }
+
+  const splitBills = await prisma.splitBill.findMany({
+    where,
+    include: splitBillInclude,
+    orderBy: [{ status: "asc" }, { paidDate: "desc" }, { createdAt: "desc" }],
+  });
+
+  return splitBills.map(serializeSplitBill);
+}
+
+export async function getSplitBill(prisma: PrismaClient, id: string) {
+  const splitBill = await prisma.splitBill.findFirst({
+    where: { id, deletedAt: null },
+    include: splitBillInclude,
+  });
+
+  return splitBill ? serializeSplitBill(splitBill) : null;
+}
+
+export async function createSplitBill(prisma: PrismaClient, input: CreateSplitBillInput) {
+  assertDate(input.paidDate, "paidDate");
+  if (input.dueDate) {
+    assertDate(input.dueDate, "dueDate");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const splitMethod = input.splitMethod ?? "equal";
+    if (splitMethod !== "equal") {
+      throw new Error("Only equal split is supported");
+    }
+    const shares = previewEqualSplit(input.totalAmount, input.participants);
+    const selfShare = shares.find((participant) => participant.isSelf);
+    if (!selfShare) {
+      throw new Error("Self participant is required");
+    }
+    if (input.payerType === "other" && !input.payerName?.trim()) {
+      throw new Error("payerName is required when another person paid");
+    }
+
+    const paymentTransaction = input.payerType === "self"
+      ? await createAccountingTransaction(tx, {
+          accountId: input.accountId,
+          date: input.paidDate,
+          type: "expense",
+          description: `割り勘: ${input.title}`,
+          amount: input.totalAmount,
+        })
+      : null;
+
+    const splitBill = await tx.splitBill.create({
+      data: {
+        title: input.title,
+        totalAmount: input.totalAmount,
+        paidDate: fromDateOnlyString(input.paidDate),
+        payerType: input.payerType,
+        payerName: input.payerType === "other" ? input.payerName?.trim() : null,
+        accountId: input.accountId,
+        splitMethod,
+        dueDate: input.dueDate ? fromDateOnlyString(input.dueDate) : null,
+        paymentTransactionId: paymentTransaction?.id ?? null,
+        memo: input.memo ?? null,
+      },
+    });
+
+    for (const participant of shares) {
+      let personalDebtId: string | null = null;
+      if (input.payerType === "self" && !participant.isSelf) {
+        const debt = await tx.personalDebt.create({
+          data: splitGeneratedDebtData({
+            direction: "lent",
+            counterpartyName: participant.name,
+            title: input.title,
+            principalAmount: participant.shareAmount,
+            openedDate: input.paidDate,
+            dueDate: input.dueDate ?? null,
+            accountId: input.accountId,
+            splitBillId: splitBill.id,
+          }),
+        });
+        personalDebtId = debt.id;
+      }
+      if (input.payerType === "other" && participant.isSelf) {
+        const debt = await tx.personalDebt.create({
+          data: splitGeneratedDebtData({
+            direction: "borrowed",
+            counterpartyName: input.payerName!.trim(),
+            title: input.title,
+            principalAmount: participant.shareAmount,
+            openedDate: input.paidDate,
+            dueDate: input.dueDate ?? null,
+            accountId: input.accountId,
+            splitBillId: splitBill.id,
+          }),
+        });
+        personalDebtId = debt.id;
+      }
+
+      await tx.splitBillParticipant.create({
+        data: {
+          splitBillId: splitBill.id,
+          name: participant.name,
+          isSelf: participant.isSelf,
+          sortOrder: participant.sortOrder,
+          shareAmount: participant.shareAmount,
+          personalDebtId,
+        },
+      });
+    }
+
+    await refreshSplitBillStatus(tx, splitBill.id);
+    const created = await tx.splitBill.findUniqueOrThrow({
+      where: { id: splitBill.id },
+      include: splitBillInclude,
+    });
+    return serializeSplitBill(created);
+  });
+}
+
+function splitGeneratedDebtData(input: {
+  direction: PersonalDebtDirection;
+  counterpartyName: string;
+  title: string;
+  principalAmount: number;
+  openedDate: string;
+  dueDate: string | null;
+  accountId: string;
+  splitBillId: string;
+}): Prisma.PersonalDebtUncheckedCreateInput {
+  return {
+    direction: input.direction,
+    origin: "reimbursement",
+    counterpartyName: input.counterpartyName,
+    title: input.title,
+    principalAmount: input.principalAmount,
+    openedDate: fromDateOnlyString(input.openedDate),
+    dueDate: input.dueDate ? fromDateOnlyString(input.dueDate) : null,
+    accountId: input.accountId,
+    sourceType: "split_bill" satisfies PersonalDebtSourceType,
+    splitBillId: input.splitBillId,
+  };
+}
+
+export async function updateSplitBill(prisma: PrismaClient, id: string, input: CreateSplitBillInput & { status?: string }) {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.splitBill.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        personalDebts: { include: { settlements: true } },
+      },
+    });
+    if (!existing) {
+      return null;
+    }
+
+    const hasSettlements = existing.personalDebts.some((debt) => debt.settlements.length > 0);
+    if (hasSettlements) {
+      throw new Error("Cannot update a split bill after settlements have been recorded");
+    }
+
+    const updated = await tx.splitBill.update({
+      where: { id },
+      data: {
+        title: input.title,
+        dueDate: input.dueDate ? fromDateOnlyString(input.dueDate) : null,
+        memo: input.memo ?? null,
+        status: (input.status ?? existing.status) as SplitBillStatus,
+      },
+      include: splitBillInclude,
+    });
+    return serializeSplitBill(updated);
+  });
+}
+
+export async function cancelSplitBill(prisma: PrismaClient, id: string) {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.splitBill.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        personalDebts: { include: { settlements: true } },
+      },
+    });
+    if (!existing) {
+      return null;
+    }
+    if (existing.personalDebts.some((debt) => debt.settlements.length > 0)) {
+      throw new Error("Cannot cancel a split bill after settlements have been recorded");
+    }
+
+    if (existing.paymentTransactionId) {
+      const payment = await tx.transaction.findUnique({ where: { id: existing.paymentTransactionId } });
+      if (payment && !payment.deletedAt) {
+        await revertTransactionEffect(tx, payment);
+        await tx.transaction.update({
+          where: { id: payment.id },
+          data: { deletedAt: new Date() },
+        });
+      }
+    }
+
+    await tx.personalDebt.updateMany({
+      where: { splitBillId: id },
+      data: { status: "canceled", deletedAt: new Date() },
+    });
+    const canceled = await tx.splitBill.update({
+      where: { id },
+      data: { status: "canceled", deletedAt: new Date() },
+      include: splitBillInclude,
+    });
+    return serializeSplitBill(canceled);
+  });
+}
+
+export async function getDebtDueForecastEvents(prisma: PrismaClient) {
+  const debts = await prisma.personalDebt.findMany({
+    where: {
+      deletedAt: null,
+      status: "open",
+      dueDate: { not: null },
+    },
+    include: debtInclude,
+    orderBy: [{ dueDate: "asc" }, { createdAt: "asc" }],
+  });
+
+  return debts
+    .map((debt) => ({
+      id: `personal-debt:${debt.id}:${serializeDate(debt.dueDate)}`,
+      date: serializeDate(debt.dueDate)!,
+      type: debt.direction === "lent" ? "income" as const : "expense" as const,
+      description: `精算予定: ${debt.title} (${debt.counterpartyName})`,
+      amount: getDebtRemainingAmount(debt),
+      accountId: debt.accountId,
+      debtId: debt.id,
+    }))
+    .filter((event) => event.amount > 0);
+}

--- a/packages/db/prisma/migrations/20260611010000_add_personal_debts_split_bills/migration.sql
+++ b/packages/db/prisma/migrations/20260611010000_add_personal_debts_split_bills/migration.sql
@@ -1,0 +1,87 @@
+CREATE TYPE "PersonalDebtDirection" AS ENUM ('lent', 'borrowed');
+CREATE TYPE "PersonalDebtOrigin" AS ENUM ('cash_loan', 'reimbursement');
+CREATE TYPE "PersonalDebtStatus" AS ENUM ('open', 'settled', 'canceled');
+CREATE TYPE "PersonalDebtSourceType" AS ENUM ('manual', 'split_bill');
+CREATE TYPE "SplitBillPayerType" AS ENUM ('self', 'other');
+CREATE TYPE "SplitBillMethod" AS ENUM ('equal');
+CREATE TYPE "SplitBillStatus" AS ENUM ('open', 'settled', 'canceled');
+
+CREATE TABLE "personal_debts" (
+  "id" UUID NOT NULL,
+  "direction" "PersonalDebtDirection" NOT NULL,
+  "origin" "PersonalDebtOrigin" NOT NULL DEFAULT 'cash_loan',
+  "counterparty_name" VARCHAR(100) NOT NULL,
+  "title" VARCHAR(100) NOT NULL,
+  "principal_amount" INTEGER NOT NULL,
+  "opened_date" DATE NOT NULL,
+  "due_date" DATE,
+  "account_id" UUID NOT NULL,
+  "status" "PersonalDebtStatus" NOT NULL DEFAULT 'open',
+  "source_type" "PersonalDebtSourceType" NOT NULL DEFAULT 'manual',
+  "split_bill_id" UUID,
+  "opening_transaction_id" UUID,
+  "memo" TEXT,
+  "deleted_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "personal_debts_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "personal_debt_settlements" (
+  "id" UUID NOT NULL,
+  "debt_id" UUID NOT NULL,
+  "date" DATE NOT NULL,
+  "amount" INTEGER NOT NULL,
+  "account_id" UUID NOT NULL,
+  "transaction_id" UUID NOT NULL,
+  "memo" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "personal_debt_settlements_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "split_bills" (
+  "id" UUID NOT NULL,
+  "title" VARCHAR(100) NOT NULL,
+  "total_amount" INTEGER NOT NULL,
+  "paid_date" DATE NOT NULL,
+  "payer_type" "SplitBillPayerType" NOT NULL,
+  "payer_name" VARCHAR(100),
+  "account_id" UUID NOT NULL,
+  "split_method" "SplitBillMethod" NOT NULL DEFAULT 'equal',
+  "due_date" DATE,
+  "payment_transaction_id" UUID,
+  "status" "SplitBillStatus" NOT NULL DEFAULT 'open',
+  "memo" TEXT,
+  "deleted_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "split_bills_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "split_bill_participants" (
+  "id" UUID NOT NULL,
+  "split_bill_id" UUID NOT NULL,
+  "name" VARCHAR(100) NOT NULL,
+  "is_self" BOOLEAN NOT NULL,
+  "sort_order" INTEGER NOT NULL,
+  "share_amount" INTEGER NOT NULL,
+  "personal_debt_id" UUID,
+  CONSTRAINT "split_bill_participants_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "personal_debts_opening_transaction_id_key" ON "personal_debts"("opening_transaction_id");
+CREATE UNIQUE INDEX "personal_debt_settlements_transaction_id_key" ON "personal_debt_settlements"("transaction_id");
+CREATE UNIQUE INDEX "split_bills_payment_transaction_id_key" ON "split_bills"("payment_transaction_id");
+CREATE UNIQUE INDEX "split_bill_participants_personal_debt_id_key" ON "split_bill_participants"("personal_debt_id");
+
+ALTER TABLE "personal_debts" ADD CONSTRAINT "personal_debts_account_id_fkey" FOREIGN KEY ("account_id") REFERENCES "accounts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "personal_debts" ADD CONSTRAINT "personal_debts_split_bill_id_fkey" FOREIGN KEY ("split_bill_id") REFERENCES "split_bills"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "personal_debts" ADD CONSTRAINT "personal_debts_opening_transaction_id_fkey" FOREIGN KEY ("opening_transaction_id") REFERENCES "transactions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "personal_debt_settlements" ADD CONSTRAINT "personal_debt_settlements_debt_id_fkey" FOREIGN KEY ("debt_id") REFERENCES "personal_debts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "personal_debt_settlements" ADD CONSTRAINT "personal_debt_settlements_account_id_fkey" FOREIGN KEY ("account_id") REFERENCES "accounts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "personal_debt_settlements" ADD CONSTRAINT "personal_debt_settlements_transaction_id_fkey" FOREIGN KEY ("transaction_id") REFERENCES "transactions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "split_bills" ADD CONSTRAINT "split_bills_account_id_fkey" FOREIGN KEY ("account_id") REFERENCES "accounts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "split_bills" ADD CONSTRAINT "split_bills_payment_transaction_id_fkey" FOREIGN KEY ("payment_transaction_id") REFERENCES "transactions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "split_bill_participants" ADD CONSTRAINT "split_bill_participants_split_bill_id_fkey" FOREIGN KEY ("split_bill_id") REFERENCES "split_bills"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "split_bill_participants" ADD CONSTRAINT "split_bill_participants_personal_debt_id_fkey" FOREIGN KEY ("personal_debt_id") REFERENCES "personal_debts"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,6 +32,42 @@ enum LoanPaymentMethod {
   credit_card
 }
 
+enum PersonalDebtDirection {
+  lent
+  borrowed
+}
+
+enum PersonalDebtOrigin {
+  cash_loan
+  reimbursement
+}
+
+enum PersonalDebtStatus {
+  open
+  settled
+  canceled
+}
+
+enum PersonalDebtSourceType {
+  manual
+  split_bill
+}
+
+enum SplitBillPayerType {
+  self
+  other
+}
+
+enum SplitBillMethod {
+  equal
+}
+
+enum SplitBillStatus {
+  open
+  settled
+  canceled
+}
+
 model Account {
   id                String        @id @default(uuid()) @db.Uuid
   name              String        @db.VarChar(100)
@@ -46,6 +82,9 @@ model Account {
   recurringItems    RecurringItem[]
   creditCards       CreditCard[]
   loans             Loan[]
+  personalDebts     PersonalDebt[]
+  debtSettlements   PersonalDebtSettlement[]
+  splitBills        SplitBill[]
 
   @@map("accounts")
 }
@@ -157,8 +196,93 @@ model Transaction {
   createdAt           DateTime        @default(now()) @map("created_at")
   account             Account         @relation("account_transactions", fields: [accountId], references: [id])
   transferToAccount   Account?        @relation("transfer_account_transactions", fields: [transferToAccountId], references: [id])
+  personalDebtOpenings PersonalDebt[]  @relation("personal_debt_opening_transaction")
+  personalDebtSettlements PersonalDebtSettlement[] @relation("personal_debt_settlement_transaction")
+  splitBillPayments   SplitBill[]      @relation("split_bill_payment_transaction")
 
   @@map("transactions")
+}
+
+model PersonalDebt {
+  id                   String                   @id @default(uuid()) @db.Uuid
+  direction            PersonalDebtDirection
+  origin               PersonalDebtOrigin       @default(cash_loan)
+  counterpartyName     String                   @map("counterparty_name") @db.VarChar(100)
+  title                String                   @db.VarChar(100)
+  principalAmount      Int                      @map("principal_amount")
+  openedDate           DateTime                 @map("opened_date") @db.Date
+  dueDate              DateTime?                @map("due_date") @db.Date
+  accountId            String                   @map("account_id") @db.Uuid
+  status               PersonalDebtStatus       @default(open)
+  sourceType           PersonalDebtSourceType   @default(manual) @map("source_type")
+  splitBillId          String?                  @map("split_bill_id") @db.Uuid
+  openingTransactionId String?                  @unique @map("opening_transaction_id") @db.Uuid
+  memo                 String?
+  deletedAt            DateTime?                @map("deleted_at")
+  createdAt            DateTime                 @default(now()) @map("created_at")
+  updatedAt            DateTime                 @updatedAt @map("updated_at")
+  account              Account                  @relation(fields: [accountId], references: [id])
+  splitBill            SplitBill?               @relation(fields: [splitBillId], references: [id])
+  openingTransaction   Transaction?             @relation("personal_debt_opening_transaction", fields: [openingTransactionId], references: [id])
+  settlements          PersonalDebtSettlement[]
+  participant          SplitBillParticipant?
+
+  @@map("personal_debts")
+}
+
+model PersonalDebtSettlement {
+  id            String       @id @default(uuid()) @db.Uuid
+  debtId        String       @map("debt_id") @db.Uuid
+  date          DateTime     @db.Date
+  amount        Int
+  accountId     String       @map("account_id") @db.Uuid
+  transactionId String       @unique @map("transaction_id") @db.Uuid
+  memo          String?
+  createdAt     DateTime     @default(now()) @map("created_at")
+  updatedAt     DateTime     @updatedAt @map("updated_at")
+  debt          PersonalDebt @relation(fields: [debtId], references: [id])
+  account       Account      @relation(fields: [accountId], references: [id])
+  transaction   Transaction  @relation("personal_debt_settlement_transaction", fields: [transactionId], references: [id])
+
+  @@map("personal_debt_settlements")
+}
+
+model SplitBill {
+  id                   String                 @id @default(uuid()) @db.Uuid
+  title                String                 @db.VarChar(100)
+  totalAmount          Int                    @map("total_amount")
+  paidDate             DateTime               @map("paid_date") @db.Date
+  payerType            SplitBillPayerType     @map("payer_type")
+  payerName            String?                @map("payer_name") @db.VarChar(100)
+  accountId            String                 @map("account_id") @db.Uuid
+  splitMethod          SplitBillMethod        @default(equal) @map("split_method")
+  dueDate              DateTime?              @map("due_date") @db.Date
+  paymentTransactionId String?                @unique @map("payment_transaction_id") @db.Uuid
+  status               SplitBillStatus        @default(open)
+  memo                 String?
+  deletedAt            DateTime?              @map("deleted_at")
+  createdAt            DateTime               @default(now()) @map("created_at")
+  updatedAt            DateTime               @updatedAt @map("updated_at")
+  account              Account                @relation(fields: [accountId], references: [id])
+  paymentTransaction   Transaction?           @relation("split_bill_payment_transaction", fields: [paymentTransactionId], references: [id])
+  participants         SplitBillParticipant[]
+  personalDebts        PersonalDebt[]
+
+  @@map("split_bills")
+}
+
+model SplitBillParticipant {
+  id             String        @id @default(uuid()) @db.Uuid
+  splitBillId    String        @map("split_bill_id") @db.Uuid
+  name           String        @db.VarChar(100)
+  isSelf         Boolean       @map("is_self")
+  sortOrder      Int           @map("sort_order")
+  shareAmount    Int           @map("share_amount")
+  personalDebtId String?       @unique @map("personal_debt_id") @db.Uuid
+  splitBill      SplitBill     @relation(fields: [splitBillId], references: [id], onDelete: Cascade)
+  personalDebt   PersonalDebt? @relation(fields: [personalDebtId], references: [id])
+
+  @@map("split_bill_participants")
 }
 
 model Setting {

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -4,6 +4,7 @@ import { AccountsPage } from "./routes/accounts";
 import { CreditCardsPage } from "./routes/credit-cards";
 import { DashboardPage } from "./routes/dashboard";
 import { LoansPage } from "./routes/loans";
+import { PersonalDebtsPage } from "./routes/personal-debts";
 import { RecurringPage } from "./routes/recurring";
 import { SubscriptionsPage } from "./routes/subscriptions";
 import { TransactionsPage } from "./routes/transactions";
@@ -18,6 +19,7 @@ export function App() {
         <Route path="/subscriptions" element={<SubscriptionsPage />} />
         <Route path="/credit-cards" element={<CreditCardsPage />} />
         <Route path="/loans" element={<LoansPage />} />
+        <Route path="/personal-debts" element={<PersonalDebtsPage />} />
         <Route path="/transactions" element={<TransactionsPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/packages/frontend/src/components/layout.tsx
+++ b/packages/frontend/src/components/layout.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { to: "/transactions", label: "取引履歴" },
   // 資産
   { to: "/accounts", label: "口座管理" },
+  { to: "/personal-debts", label: "貸し借り" },
   // 負債
   { to: "/credit-cards", label: "クレカ管理" },
   { to: "/loans", label: "ローン管理" },

--- a/packages/frontend/src/routes/personal-debts.tsx
+++ b/packages/frontend/src/routes/personal-debts.tsx
@@ -1,0 +1,556 @@
+import type { Account, PersonalDebt, PersonalDebtsResponse, SplitBill, SplitBillsResponse } from "@sui/shared";
+import { useMemo, useState, startTransition } from "react";
+import { Button } from "../components/ui/button";
+import { Card } from "../components/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../components/ui/dialog";
+import { Input } from "../components/ui/input";
+import { Select } from "../components/ui/select";
+import { Table, TableWrapper } from "../components/ui/table";
+import { useResource } from "../hooks/use-resource";
+import { apiFetch } from "../lib/api";
+import { formatCurrency, formatDateWithYear } from "../lib/format";
+import { getTodayDate } from "../lib/utils";
+
+type Tab = "debts" | "splitBills";
+type StatusFilter = "all" | "open" | "settled" | "canceled";
+
+const statusLabels = {
+  open: "未精算",
+  settled: "完済",
+  canceled: "取消",
+} as const;
+
+const directionLabels = {
+  lent: "貸した",
+  borrowed: "借りた",
+} as const;
+
+type DebtForm = {
+  direction: "lent" | "borrowed";
+  counterpartyName: string;
+  title: string;
+  principalAmount: number;
+  openedDate: string;
+  dueDate: string;
+  accountId: string;
+  memo: string;
+};
+
+type SplitBillForm = {
+  title: string;
+  totalAmount: number;
+  paidDate: string;
+  payerType: "self" | "other";
+  payerName: string;
+  accountId: string;
+  dueDate: string;
+  participantsText: string;
+  memo: string;
+};
+
+function emptyDebtForm(today: string): DebtForm {
+  return {
+    direction: "lent",
+    counterpartyName: "",
+    title: "",
+    principalAmount: 0,
+    openedDate: today,
+    dueDate: "",
+    accountId: "",
+    memo: "",
+  };
+}
+
+function emptySplitBillForm(today: string): SplitBillForm {
+  return {
+    title: "",
+    totalAmount: 0,
+    paidDate: today,
+    payerType: "self",
+    payerName: "",
+    accountId: "",
+    dueDate: "",
+    participantsText: "Aさん, Bさん",
+    memo: "",
+  };
+}
+
+function parseParticipants(text: string) {
+  const names = text
+    .split(/\r?\n|,/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return [
+    { name: "自分", isSelf: true, sortOrder: 0 },
+    ...names.map((name, index) => ({ name, isSelf: false, sortOrder: index + 1 })),
+  ];
+}
+
+function previewShares(totalAmount: number, text: string) {
+  const participants = parseParticipants(text);
+  if (participants.length === 0) {
+    return [];
+  }
+
+  const base = Math.floor(totalAmount / participants.length);
+  let remainder = totalAmount % participants.length;
+  return participants.map((participant) => {
+    const extra = remainder > 0 ? 1 : 0;
+    remainder -= extra;
+    return { ...participant, shareAmount: base + extra };
+  });
+}
+
+export function PersonalDebtsPage() {
+  const today = getTodayDate();
+  const [reloadKey, setReloadKey] = useState(0);
+  const [tab, setTab] = useState<Tab>("debts");
+  const [status, setStatus] = useState<StatusFilter>("open");
+  const [debtForm, setDebtForm] = useState<DebtForm>(() => emptyDebtForm(today));
+  const [splitBillForm, setSplitBillForm] = useState<SplitBillForm>(() => emptySplitBillForm(today));
+  const [settlingDebt, setSettlingDebt] = useState<PersonalDebt | null>(null);
+  const [settlementAmount, setSettlementAmount] = useState(0);
+  const [settlementDate, setSettlementDate] = useState(today);
+  const [settlementAccountId, setSettlementAccountId] = useState("");
+
+  const { data, loading, error } = useResource(
+    () =>
+      Promise.all([
+        apiFetch<Account[]>("/api/accounts"),
+        apiFetch<PersonalDebtsResponse>(`/api/personal-debts?status=${status}`),
+        apiFetch<SplitBillsResponse>(`/api/split-bills?status=${status}`),
+      ]).then(([accounts, debts, splitBills]) => ({ accounts, debts, splitBills })),
+    [reloadKey, status],
+  );
+
+  const accounts = data?.accounts ?? [];
+  const debts = data?.debts ?? [];
+  const splitBills = data?.splitBills ?? [];
+  const sharePreview = useMemo(
+    () => previewShares(splitBillForm.totalAmount, splitBillForm.participantsText),
+    [splitBillForm.totalAmount, splitBillForm.participantsText],
+  );
+
+  const reload = () => startTransition(() => setReloadKey((value) => value + 1));
+
+  const createDebt = async () => {
+    await apiFetch("/api/personal-debts", {
+      method: "POST",
+      body: JSON.stringify({
+        ...debtForm,
+        dueDate: debtForm.dueDate || null,
+        memo: debtForm.memo || null,
+      }),
+    });
+    setDebtForm(emptyDebtForm(today));
+    reload();
+  };
+
+  const createSplitBill = async () => {
+    await apiFetch("/api/split-bills", {
+      method: "POST",
+      body: JSON.stringify({
+        title: splitBillForm.title,
+        totalAmount: splitBillForm.totalAmount,
+        paidDate: splitBillForm.paidDate,
+        payerType: splitBillForm.payerType,
+        payerName: splitBillForm.payerType === "other" ? splitBillForm.payerName : null,
+        accountId: splitBillForm.accountId,
+        splitMethod: "equal",
+        dueDate: splitBillForm.dueDate || null,
+        memo: splitBillForm.memo || null,
+        participants: parseParticipants(splitBillForm.participantsText),
+      }),
+    });
+    setSplitBillForm(emptySplitBillForm(today));
+    reload();
+  };
+
+  const openSettlement = (debt: PersonalDebt) => {
+    setSettlingDebt(debt);
+    setSettlementAmount(debt.remainingAmount);
+    setSettlementDate(today);
+    setSettlementAccountId(debt.accountId);
+  };
+
+  const closeSettlement = () => {
+    setSettlingDebt(null);
+    setSettlementAmount(0);
+    setSettlementDate(today);
+    setSettlementAccountId("");
+  };
+
+  const saveSettlement = async () => {
+    if (!settlingDebt) {
+      return;
+    }
+
+    await apiFetch(`/api/personal-debts/${settlingDebt.id}/settlements`, {
+      method: "POST",
+      body: JSON.stringify({
+        amount: settlementAmount,
+        date: settlementDate,
+        accountId: settlementAccountId || undefined,
+      }),
+    });
+    closeSettlement();
+    reload();
+  };
+
+  const canCreateDebt =
+    debtForm.counterpartyName.trim() &&
+    debtForm.title.trim() &&
+    debtForm.principalAmount > 0 &&
+    debtForm.accountId &&
+    debtForm.openedDate;
+  const canCreateSplitBill =
+    splitBillForm.title.trim() &&
+    splitBillForm.totalAmount > 0 &&
+    splitBillForm.accountId &&
+    splitBillForm.paidDate &&
+    sharePreview.length >= 2 &&
+    (splitBillForm.payerType === "self" || splitBillForm.payerName.trim());
+
+  return (
+    <div className="grid gap-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold">貸し借り</h2>
+          <p className="mt-2 text-sm text-white/60">個人間の貸し借りと割り勘精算を管理します。</p>
+        </div>
+        <Select
+          aria-label="ステータス"
+          className="w-auto min-w-36"
+          value={status}
+          onChange={(event) => setStatus(event.target.value as StatusFilter)}
+        >
+          <option value="open">未精算</option>
+          <option value="settled">完済</option>
+          <option value="canceled">取消</option>
+          <option value="all">すべて</option>
+        </Select>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button variant={tab === "debts" ? "primary" : "ghost"} onClick={() => setTab("debts")}>
+          貸し借り
+        </Button>
+        <Button variant={tab === "splitBills" ? "primary" : "ghost"} onClick={() => setTab("splitBills")}>
+          割り勘
+        </Button>
+      </div>
+
+      {tab === "debts" ? (
+        <>
+          <Card>
+            <h3 className="text-lg font-semibold">1 対 1 の貸し借りを追加</h3>
+            <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              <Select
+                aria-label="貸し借り種別"
+                value={debtForm.direction}
+                onChange={(event) => setDebtForm({ ...debtForm, direction: event.target.value as "lent" | "borrowed" })}
+              >
+                <option value="lent">貸した</option>
+                <option value="borrowed">借りた</option>
+              </Select>
+              <Input
+                aria-label="相手"
+                placeholder="相手"
+                value={debtForm.counterpartyName}
+                onChange={(event) => setDebtForm({ ...debtForm, counterpartyName: event.target.value })}
+              />
+              <Input
+                aria-label="タイトル"
+                placeholder="タイトル"
+                value={debtForm.title}
+                onChange={(event) => setDebtForm({ ...debtForm, title: event.target.value })}
+              />
+              <Input
+                aria-label="元金"
+                type="number"
+                inputMode="numeric"
+                value={debtForm.principalAmount}
+                onChange={(event) => setDebtForm({ ...debtForm, principalAmount: Number(event.target.value) })}
+              />
+              <Input
+                aria-label="発生日"
+                type="date"
+                value={debtForm.openedDate}
+                onChange={(event) => setDebtForm({ ...debtForm, openedDate: event.target.value })}
+              />
+              <Input
+                aria-label="返済予定日"
+                type="date"
+                value={debtForm.dueDate}
+                onChange={(event) => setDebtForm({ ...debtForm, dueDate: event.target.value })}
+              />
+              <Select
+                aria-label="入出金口座"
+                value={debtForm.accountId}
+                onChange={(event) => setDebtForm({ ...debtForm, accountId: event.target.value })}
+              >
+                <option value="">入出金口座</option>
+                {accounts.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.name}
+                  </option>
+                ))}
+              </Select>
+              <Button disabled={!canCreateDebt} onClick={createDebt}>
+                追加
+              </Button>
+            </div>
+          </Card>
+
+          <Card>
+            <ListHeader loading={loading} error={error} count={debts.length} />
+            <DebtTable debts={debts} onSettle={openSettlement} />
+          </Card>
+        </>
+      ) : (
+        <>
+          <Card>
+            <h3 className="text-lg font-semibold">割り勘を追加</h3>
+            <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              <Input
+                aria-label="割り勘タイトル"
+                placeholder="タイトル"
+                value={splitBillForm.title}
+                onChange={(event) => setSplitBillForm({ ...splitBillForm, title: event.target.value })}
+              />
+              <Input
+                aria-label="総額"
+                type="number"
+                inputMode="numeric"
+                value={splitBillForm.totalAmount}
+                onChange={(event) => setSplitBillForm({ ...splitBillForm, totalAmount: Number(event.target.value) })}
+              />
+              <Input
+                aria-label="支払日"
+                type="date"
+                value={splitBillForm.paidDate}
+                onChange={(event) => setSplitBillForm({ ...splitBillForm, paidDate: event.target.value })}
+              />
+              <Select
+                aria-label="支払者"
+                value={splitBillForm.payerType}
+                onChange={(event) => setSplitBillForm({ ...splitBillForm, payerType: event.target.value as "self" | "other" })}
+              >
+                <option value="self">自分が支払った</option>
+                <option value="other">他人が支払った</option>
+              </Select>
+              {splitBillForm.payerType === "other" ? (
+                <Input
+                  aria-label="立替者"
+                  placeholder="立替者"
+                  value={splitBillForm.payerName}
+                  onChange={(event) => setSplitBillForm({ ...splitBillForm, payerName: event.target.value })}
+                />
+              ) : null}
+              <Select
+                aria-label="精算口座"
+                value={splitBillForm.accountId}
+                onChange={(event) => setSplitBillForm({ ...splitBillForm, accountId: event.target.value })}
+              >
+                <option value="">精算口座</option>
+                {accounts.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.name}
+                  </option>
+                ))}
+              </Select>
+              <Input
+                aria-label="割り勘返済予定日"
+                type="date"
+                value={splitBillForm.dueDate}
+                onChange={(event) => setSplitBillForm({ ...splitBillForm, dueDate: event.target.value })}
+              />
+              <Input
+                aria-label="参加者"
+                placeholder="Aさん, Bさん"
+                value={splitBillForm.participantsText}
+                onChange={(event) => setSplitBillForm({ ...splitBillForm, participantsText: event.target.value })}
+              />
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              {sharePreview.map((participant) => (
+                <span key={`${participant.sortOrder}:${participant.name}`} className="rounded-full bg-white/10 px-3 py-1 text-sm">
+                  {participant.name}: {formatCurrency(participant.shareAmount)}
+                </span>
+              ))}
+              <Button disabled={!canCreateSplitBill} onClick={createSplitBill}>
+                追加
+              </Button>
+            </div>
+          </Card>
+
+          <Card>
+            <ListHeader loading={loading} error={error} count={splitBills.length} />
+            <SplitBillTable splitBills={splitBills} onSettle={openSettlement} />
+          </Card>
+        </>
+      )}
+
+      <Dialog open={Boolean(settlingDebt)} onOpenChange={(open) => !open && closeSettlement()}>
+        <DialogContent className="w-[min(92vw,32rem)]">
+          <DialogTitle className="text-lg font-semibold">返済・精算を登録</DialogTitle>
+          <DialogDescription className="mt-2 text-sm text-white/60">
+            精算額に応じて取引履歴と口座残高を更新します。
+          </DialogDescription>
+          {settlingDebt ? (
+            <div className="mt-6 grid gap-4">
+              <div className="rounded-2xl bg-white/5 p-4 text-sm">
+                <div>{settlingDebt.title}</div>
+                <div className="mt-1 text-white/60">残額 {formatCurrency(settlingDebt.remainingAmount)}</div>
+              </div>
+              <Input
+                aria-label="精算額"
+                type="number"
+                inputMode="numeric"
+                value={settlementAmount}
+                onChange={(event) => setSettlementAmount(Number(event.target.value))}
+              />
+              <Input
+                aria-label="精算日"
+                type="date"
+                value={settlementDate}
+                onChange={(event) => setSettlementDate(event.target.value)}
+              />
+              <Select
+                aria-label="精算入出金口座"
+                value={settlementAccountId}
+                onChange={(event) => setSettlementAccountId(event.target.value)}
+              >
+                {accounts.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.name}
+                  </option>
+                ))}
+              </Select>
+              <div className="flex justify-end gap-3">
+                <Button variant="ghost" onClick={closeSettlement}>
+                  キャンセル
+                </Button>
+                <Button disabled={settlementAmount <= 0} onClick={saveSettlement}>
+                  登録
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function ListHeader({ loading, error, count }: { loading: boolean; error: string | null; count: number }) {
+  return (
+    <div className="mb-4 flex items-center justify-between gap-3">
+      <h3 className="text-lg font-semibold">一覧</h3>
+      <div className="text-sm text-white/60">{loading ? "読み込み中..." : error ?? `${count} 件`}</div>
+    </div>
+  );
+}
+
+function DebtTable({ debts, onSettle }: { debts: PersonalDebt[]; onSettle: (debt: PersonalDebt) => void }) {
+  return (
+    <TableWrapper>
+      <Table className="min-w-[72rem]">
+        <thead>
+          <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] text-white/45">
+            <th className="px-3 py-3">種別</th>
+            <th className="px-3 py-3">相手</th>
+            <th className="px-3 py-3">タイトル</th>
+            <th className="px-3 py-3">元金</th>
+            <th className="px-3 py-3">返済済み</th>
+            <th className="px-3 py-3">残額</th>
+            <th className="px-3 py-3">期限</th>
+            <th className="px-3 py-3">ステータス</th>
+            <th className="px-3 py-3" />
+          </tr>
+        </thead>
+        <tbody>
+          {debts.map((debt) => (
+            <tr key={debt.id} className="border-b border-white/5">
+              <td className="px-3 py-3">{directionLabels[debt.direction]}</td>
+              <td className="px-3 py-3">{debt.counterpartyName}</td>
+              <td className="px-3 py-3">{debt.title}</td>
+              <td className="px-3 py-3">{formatCurrency(debt.principalAmount)}</td>
+              <td className="px-3 py-3">{formatCurrency(debt.settledAmount)}</td>
+              <td className="px-3 py-3">{formatCurrency(debt.remainingAmount)}</td>
+              <td className="px-3 py-3">{debt.dueDate ? formatDateWithYear(debt.dueDate) : "-"}</td>
+              <td className="px-3 py-3">{statusLabels[debt.status]}</td>
+              <td className="px-3 py-3 text-right">
+                <Button disabled={debt.remainingAmount <= 0 || debt.status !== "open"} variant="ghost" onClick={() => onSettle(debt)}>
+                  返済登録
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </TableWrapper>
+  );
+}
+
+function SplitBillTable({
+  splitBills,
+  onSettle,
+}: {
+  splitBills: SplitBill[];
+  onSettle: (debt: PersonalDebt) => void;
+}) {
+  return (
+    <div className="grid gap-4">
+      {splitBills.map((splitBill) => (
+        <div key={splitBill.id} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-lg font-semibold">{splitBill.title}</div>
+              <div className="mt-1 text-sm text-white/60">
+                総額 {formatCurrency(splitBill.totalAmount)} / 自分の負担 {formatCurrency(splitBill.selfShareAmount)} / 未精算{" "}
+                {formatCurrency(splitBill.outstandingAmount)}
+              </div>
+            </div>
+            <div className="text-sm text-white/60">
+              {splitBill.payerType === "self" ? "自分が支払った" : `${splitBill.payerName} が支払った`} / {statusLabels[splitBill.status]}
+            </div>
+          </div>
+          <TableWrapper className="mt-4">
+            <Table className="min-w-[48rem]">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] text-white/45">
+                  <th className="px-3 py-3">参加者</th>
+                  <th className="px-3 py-3">負担額</th>
+                  <th className="px-3 py-3">残額</th>
+                  <th className="px-3 py-3" />
+                </tr>
+              </thead>
+              <tbody>
+                {splitBill.participants.map((participant) => (
+                  <tr key={participant.id} className="border-b border-white/5">
+                    <td className="px-3 py-3">{participant.name}</td>
+                    <td className="px-3 py-3">{formatCurrency(participant.shareAmount)}</td>
+                    <td className="px-3 py-3">{formatCurrency(participant.personalDebt?.remainingAmount ?? 0)}</td>
+                    <td className="px-3 py-3 text-right">
+                      {participant.personalDebt ? (
+                        <Button
+                          disabled={participant.personalDebt.remainingAmount <= 0}
+                          variant="ghost"
+                          onClick={() => onSettle(participant.personalDebt!)}
+                        >
+                          返済登録
+                        </Button>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </TableWrapper>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -6,7 +6,14 @@ import type {
   ForecastEvent,
   Loan,
   LoanPaymentMethod,
+  PersonalDebt,
+  PersonalDebtDirection,
+  PersonalDebtOrigin,
+  PersonalDebtStatus,
   RecurringItem,
+  SplitBill,
+  SplitBillMethod,
+  SplitBillPayerType,
   Subscription,
   Transaction,
   TransactionType,
@@ -99,6 +106,69 @@ export interface CreateLoanPayload {
 
 export type UpdateLoanPayload = CreateLoanPayload;
 
+export interface CreatePersonalDebtPayload {
+  direction: PersonalDebtDirection;
+  origin?: PersonalDebtOrigin;
+  counterpartyName: string;
+  title: string;
+  principalAmount: number;
+  openedDate: string;
+  dueDate?: string | null;
+  accountId: string;
+  memo?: string | null;
+}
+
+export interface UpdatePersonalDebtPayload extends CreatePersonalDebtPayload {
+  status?: PersonalDebtStatus;
+}
+
+export interface CreatePersonalDebtSettlementPayload {
+  date: string;
+  amount: number;
+  accountId?: string;
+  memo?: string | null;
+}
+
+export type UpdatePersonalDebtSettlementPayload = CreatePersonalDebtSettlementPayload;
+
+export interface SplitBillParticipantPayload {
+  name: string;
+  isSelf?: boolean;
+  sortOrder?: number;
+}
+
+export interface CreateSplitBillPayload {
+  title: string;
+  totalAmount: number;
+  paidDate: string;
+  payerType: SplitBillPayerType;
+  payerName?: string | null;
+  accountId: string;
+  splitMethod?: SplitBillMethod;
+  dueDate?: string | null;
+  memo?: string | null;
+  participants: SplitBillParticipantPayload[];
+}
+
+export interface UpdateSplitBillPayload extends CreateSplitBillPayload {
+  status?: "open" | "settled" | "canceled";
+}
+
+export interface SplitBillPreviewPayload {
+  totalAmount: number;
+  splitMethod?: SplitBillMethod;
+  participants: SplitBillParticipantPayload[];
+}
+
+export interface SplitBillPreviewResponse {
+  participants: Array<{
+    name: string;
+    isSelf: boolean;
+    sortOrder: number;
+    shareAmount: number;
+  }>;
+}
+
 export interface TransactionsResponse {
   items: Transaction[];
   page: number;
@@ -132,6 +202,8 @@ export type RecurringItemsResponse = Array<RecurringItem>;
 export type CreditCardsResponse = Array<CreditCard>;
 export type SubscriptionsResponse = Array<Subscription>;
 export type LoansResponse = Array<Loan>;
+export type PersonalDebtsResponse = Array<PersonalDebt>;
+export type SplitBillsResponse = Array<SplitBill>;
 export type BillingResponse = BillingMonth;
 
 export interface AccountForecast {

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -2,6 +2,13 @@ export type TransactionType = "income" | "expense" | "transfer";
 export type RecurringItemType = "income" | "expense";
 export type DateShiftPolicy = "none" | "previous" | "next";
 export type LoanPaymentMethod = "account_withdrawal" | "credit_card";
+export type PersonalDebtDirection = "lent" | "borrowed";
+export type PersonalDebtOrigin = "cash_loan" | "reimbursement";
+export type PersonalDebtStatus = "open" | "settled" | "canceled";
+export type PersonalDebtSourceType = "manual" | "split_bill";
+export type SplitBillPayerType = "self" | "other";
+export type SplitBillMethod = "equal";
+export type SplitBillStatus = "open" | "settled" | "canceled";
 
 export interface Account {
   id: string;
@@ -73,6 +80,75 @@ export interface Loan {
   remainingBalance: number;
   remainingPayments: number;
   nextPaymentAmount: number;
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PersonalDebtSettlement {
+  id: string;
+  debtId: string;
+  date: string;
+  amount: number;
+  accountId: string;
+  transactionId: string;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PersonalDebt {
+  id: string;
+  direction: PersonalDebtDirection;
+  origin: PersonalDebtOrigin;
+  counterpartyName: string;
+  title: string;
+  principalAmount: number;
+  settledAmount: number;
+  remainingAmount: number;
+  openedDate: string;
+  dueDate: string | null;
+  accountId: string;
+  account: Account | null;
+  status: PersonalDebtStatus;
+  sourceType: PersonalDebtSourceType;
+  splitBillId: string | null;
+  openingTransactionId: string | null;
+  memo: string | null;
+  settlements: PersonalDebtSettlement[];
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SplitBillParticipant {
+  id: string;
+  splitBillId: string;
+  name: string;
+  isSelf: boolean;
+  sortOrder: number;
+  shareAmount: number;
+  personalDebtId: string | null;
+  personalDebt: PersonalDebt | null;
+}
+
+export interface SplitBill {
+  id: string;
+  title: string;
+  totalAmount: number;
+  paidDate: string;
+  payerType: SplitBillPayerType;
+  payerName: string | null;
+  accountId: string;
+  account: Account | null;
+  splitMethod: SplitBillMethod;
+  dueDate: string | null;
+  paymentTransactionId: string | null;
+  status: SplitBillStatus;
+  memo: string | null;
+  selfShareAmount: number;
+  outstandingAmount: number;
+  participants: SplitBillParticipant[];
   deletedAt: string | null;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Closes #45

## Summary
- Add personal debt and settlement domain models, APIs, and accounting behavior
- Add split bill preview/create/update flows with generated personal debts
- Surface due personal debts in forecast confirmation and protect managed transactions from direct edits
- Add the new 貸し借り frontend route with debt and split bill workflows

## Validation
- make typecheck
- make test-unit
- make test-integration
- make lint
- make test-e2e
- make build
