### PR TITLE
[codex] Allow one-sided transfer transactions

### DIFF
--- a/e2e/helpers/db-runner.ts
+++ b/e2e/helpers/db-runner.ts
@@ -84,7 +84,7 @@ type DbCommand =
   | {
     action: "seedTransaction";
     payload: {
-      accountId: string;
+      accountId: string | null;
       transferToAccountId?: string | null;
       forecastEventId?: string | null;
       date?: string;
@@ -96,7 +96,7 @@ type DbCommand =
   | {
     action: "seedTransactions";
     payload: Array<{
-      accountId: string;
+      accountId: string | null;
       transferToAccountId?: string | null;
       forecastEventId?: string | null;
       date?: string;

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -86,7 +86,7 @@ type DbCommand =
   | {
     action: "seedTransaction";
     payload: {
-      accountId: string;
+      accountId: string | null;
       transferToAccountId?: string | null;
       forecastEventId?: string | null;
       date?: string;
@@ -98,7 +98,7 @@ type DbCommand =
   | {
     action: "seedTransactions";
     payload: Array<{
-      accountId: string;
+      accountId: string | null;
       transferToAccountId?: string | null;
       forecastEventId?: string | null;
       date?: string;
@@ -367,7 +367,7 @@ export async function seedBilling(
 }
 
 export async function seedTransaction(overrides: {
-  accountId: string;
+  accountId: string | null;
   transferToAccountId?: string | null;
   forecastEventId?: string | null;
   date?: Date;
@@ -391,7 +391,7 @@ export async function seedTransaction(overrides: {
 
 export async function seedTransactions(
   overridesList: Array<{
-    accountId: string;
+    accountId: string | null;
     transferToAccountId?: string | null;
     forecastEventId?: string | null;
     date?: Date;

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -120,6 +120,39 @@ test("records a transfer transaction and shows both account names", async ({ pag
   await expect(page.getByRole("row", { name: /Move/ })).toContainText("Account A -> Account B");
 });
 
+test("records transfers with an empty source or destination account", async ({ page }) => {
+  const source = await seedAccount({ name: "Account A", balance: 10000, sortOrder: 1 });
+  const destination = await seedAccount({ name: "Account B", balance: 5000, sortOrder: 2 });
+  const today = getFutureDate(0);
+
+  await navigateTo(page, "/transactions");
+
+  await page.getByRole("button", { name: "取引を追加" }).click();
+  await page.getByLabel("取引種別").selectOption("transfer");
+  await page.getByLabel("取引日").fill(today);
+  await page.getByLabel("振替先口座").selectOption(destination.id);
+  await page.getByPlaceholder("内容").fill("Inbound");
+  await page.getByPlaceholder("金額").fill("1000");
+  await page.getByRole("button", { name: "取引を記録" }).click();
+  await waitForReload(page);
+
+  await page.getByRole("button", { name: "取引を追加" }).click();
+  await page.getByLabel("取引口座").selectOption(source.id);
+  await page.getByLabel("取引種別").selectOption("transfer");
+  await page.getByLabel("取引日").fill(today);
+  await page.getByPlaceholder("内容").fill("Outbound");
+  await page.getByPlaceholder("金額").fill("1500");
+  await page.getByRole("button", { name: "取引を記録" }).click();
+  await waitForReload(page);
+
+  await expect(page.getByRole("row", { name: /Inbound/ })).toContainText("未指定 -> Account B");
+  await expect(page.getByRole("row", { name: /Outbound/ })).toContainText("Account A -> 未指定");
+
+  await navigateTo(page, "/accounts");
+  await expect(page.getByRole("row", { name: /Account A/ }).first()).toContainText(formatCurrency(8500));
+  await expect(page.getByRole("row", { name: /Account B/ }).first()).toContainText(formatCurrency(6000));
+});
+
 test("filters transactions by account", async ({ page }) => {
   const first = await seedAccount({ name: "First Account", balance: 10000, sortOrder: 1 });
   const second = await seedAccount({ name: "Second Account", balance: 10000, sortOrder: 2 });

--- a/packages/backend/src/routes/transactions.integration.test.ts
+++ b/packages/backend/src/routes/transactions.integration.test.ts
@@ -352,6 +352,52 @@ describe("transactions routes", () => {
     ]);
   });
 
+  it("returns balance history for one-sided transfers", async () => {
+    const checking = await createAccount(testPrisma, {
+      name: "Checking",
+      balance: 1050,
+      sortOrder: 1,
+    });
+
+    await createTransaction(testPrisma, {
+      accountId: null,
+      transferToAccountId: checking.id,
+      date: new Date("2026-03-01T00:00:00.000Z"),
+      description: "外部から入金",
+      amount: 100,
+      type: "transfer",
+    });
+    await createTransaction(testPrisma, {
+      accountId: checking.id,
+      transferToAccountId: null,
+      date: new Date("2026-03-02T00:00:00.000Z"),
+      description: "外部へ出金",
+      amount: 50,
+      type: "transfer",
+    });
+
+    const totalResponse = await client.get(
+      "/api/transactions/balance-history?startDate=2026-03-01&endDate=2026-03-02",
+    );
+    const accountResponse = await client.get(
+      `/api/transactions/balance-history?accountId=${checking.id}&startDate=2026-03-01&endDate=2026-03-02`,
+    );
+    const totalBody = await parseJson<{
+      points: Array<{ date: string; balance: number; description: string }>;
+    }>(totalResponse);
+    const accountBody = await parseJson<{
+      points: Array<{ date: string; balance: number; description: string }>;
+    }>(accountResponse);
+
+    expect(totalResponse.status).toBe(200);
+    expect(accountResponse.status).toBe(200);
+    expect(totalBody.points).toEqual([
+      expect.objectContaining({ date: "2026-03-01", balance: 1100, description: "外部から入金" }),
+      expect.objectContaining({ date: "2026-03-02", balance: 1050, description: "外部へ出金" }),
+    ]);
+    expect(accountBody.points).toEqual(totalBody.points);
+  });
+
   it("returns total balance history converted to JPY for foreign-currency accounts", async () => {
     const jpy = await createAccount(testPrisma, {
       name: "JPY Checking",
@@ -587,6 +633,58 @@ describe("transactions routes", () => {
     expect(updatedDestination.balance).toBe(550);
   });
 
+  it("creates transfers without a source account and increments only the destination balance", async () => {
+    const destination = await createAccount(testPrisma, {
+      name: "Destination",
+      balance: 300,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/transactions", {
+      transferToAccountId: destination.id,
+      date: "2026-03-14",
+      type: "transfer",
+      description: "External deposit",
+      amount: 250,
+    });
+    const body = await parseJson<{ accountId: string | null; transferToAccountId: string | null }>(response);
+
+    expect(response.status).toBe(201);
+    expect(body).toMatchObject({
+      accountId: null,
+      transferToAccountId: destination.id,
+    });
+
+    const updatedDestination = await testPrisma.account.findUniqueOrThrow({ where: { id: destination.id } });
+    expect(updatedDestination.balance).toBe(550);
+  });
+
+  it("creates transfers without a destination account and decrements only the source balance", async () => {
+    const source = await createAccount(testPrisma, {
+      name: "Source",
+      balance: 1000,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/transactions", {
+      accountId: source.id,
+      date: "2026-03-14",
+      type: "transfer",
+      description: "External withdrawal",
+      amount: 250,
+    });
+    const body = await parseJson<{ accountId: string | null; transferToAccountId: string | null }>(response);
+
+    expect(response.status).toBe(201);
+    expect(body).toMatchObject({
+      accountId: source.id,
+      transferToAccountId: null,
+    });
+
+    const updatedSource = await testPrisma.account.findUniqueOrThrow({ where: { id: source.id } });
+    expect(updatedSource.balance).toBe(750);
+  });
+
   it("rejects cross-currency transfers without changing balances", async () => {
     const source = await createAccount(testPrisma, {
       name: "JPY Source",
@@ -623,15 +721,8 @@ describe("transactions routes", () => {
     expect(updatedDestination.balance).toBe(30000);
   });
 
-  it("rejects transfers without a destination account", async () => {
-    const account = await createAccount(testPrisma, {
-      name: "Main",
-      balance: 1000,
-      sortOrder: 1,
-    });
-
+  it("rejects transfers without either source or destination account", async () => {
     const response = await client.post("/api/transactions", {
-      accountId: account.id,
       date: "2026-03-14",
       type: "transfer",
       description: "Invalid transfer",
@@ -640,7 +731,7 @@ describe("transactions routes", () => {
 
     expect(response.status).toBe(400);
     expect(await parseJson(response)).toEqual({
-      error: "transferToAccountId is required for transfer",
+      error: "accountId or transferToAccountId is required for transfer",
     });
   });
 
@@ -799,6 +890,49 @@ describe("transactions routes", () => {
     expect(updatedSecondDestination.balance).toBe(700);
   });
 
+  it("updates a transfer to remove the source account and recalculates balances", async () => {
+    const source = await createAccount(testPrisma, {
+      name: "Source",
+      balance: 700,
+      sortOrder: 1,
+    });
+    const destination = await createAccount(testPrisma, {
+      name: "Destination",
+      balance: 500,
+      sortOrder: 2,
+    });
+    const existing = await createTransaction(testPrisma, {
+      accountId: source.id,
+      transferToAccountId: destination.id,
+      date: new Date("2026-03-14T00:00:00.000Z"),
+      description: "Move funds",
+      amount: 300,
+      type: "transfer",
+    });
+
+    const response = await client.put(`/api/transactions/${existing.id}`, {
+      transferToAccountId: destination.id,
+      date: "2026-03-14",
+      type: "transfer",
+      description: "External deposit",
+      amount: 300,
+    });
+    const body = await parseJson<{ accountId: string | null; transferToAccountId: string | null }>(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      accountId: null,
+      transferToAccountId: destination.id,
+    });
+
+    const [updatedSource, updatedDestination] = await Promise.all([
+      testPrisma.account.findUniqueOrThrow({ where: { id: source.id } }),
+      testPrisma.account.findUniqueOrThrow({ where: { id: destination.id } }),
+    ]);
+    expect(updatedSource.balance).toBe(1000);
+    expect(updatedDestination.balance).toBe(500);
+  });
+
   it("returns 404 when updating a missing transaction", async () => {
     const account = await createAccount(testPrisma, {
       name: "Main",
@@ -899,6 +1033,29 @@ describe("transactions routes", () => {
       testPrisma.account.findUniqueOrThrow({ where: { id: destination.id } }),
     ]);
     expect(updatedSource.balance).toBe(1000);
+    expect(updatedDestination.balance).toBe(500);
+  });
+
+  it("deletes a source-less transfer transaction and restores only the destination balance", async () => {
+    const destination = await createAccount(testPrisma, {
+      name: "Destination",
+      balance: 800,
+      sortOrder: 1,
+    });
+    const existing = await createTransaction(testPrisma, {
+      accountId: null,
+      transferToAccountId: destination.id,
+      date: new Date("2026-03-14T00:00:00.000Z"),
+      description: "External deposit",
+      amount: 300,
+      type: "transfer",
+    });
+
+    const response = await client.delete(`/api/transactions/${existing.id}`);
+
+    expect(response.status).toBe(204);
+
+    const updatedDestination = await testPrisma.account.findUniqueOrThrow({ where: { id: destination.id } });
     expect(updatedDestination.balance).toBe(500);
   });
 

--- a/packages/backend/src/routes/transactions.ts
+++ b/packages/backend/src/routes/transactions.ts
@@ -8,8 +8,8 @@ import { badRequest, handleRouteError, notFound } from "../lib/http";
 import { positiveInt32Schema } from "../lib/validation";
 
 const payloadSchema = z.object({
-  accountId: z.string().uuid(),
-  transferToAccountId: z.string().uuid().optional(),
+  accountId: z.string().uuid().nullish(),
+  transferToAccountId: z.string().uuid().nullish(),
   date: z.string(),
   type: z.enum(["income", "expense", "transfer"]),
   description: z.string().min(1).max(200),
@@ -96,18 +96,60 @@ const balanceHistoryQuerySchema = z
   });
 
 type BalanceHistoryTransaction = {
-  accountId: string;
+  accountId: string | null;
   transferToAccountId: string | null;
   date: Date;
   type: TransactionType;
   description: string;
   amount: number;
   createdAt: Date;
-  account: {
-    currencyCode: string;
-    exchangeRateToJpy: number;
-  };
+  account: CurrencyAccount | null;
+  transferToAccount: CurrencyAccount | null;
 };
+
+type CurrencyAccount = {
+  currencyCode: string;
+  exchangeRateToJpy: number;
+};
+
+type TransactionPayload = z.infer<typeof payloadSchema>;
+
+const fallbackCurrencyAccount: CurrencyAccount = {
+  currencyCode: "JPY",
+  exchangeRateToJpy: 1,
+};
+
+function getTransactionCurrencyAccount(transaction: {
+  account?: CurrencyAccount | null;
+  transferToAccount?: CurrencyAccount | null;
+}) {
+  return transaction.account ?? transaction.transferToAccount ?? fallbackCurrencyAccount;
+}
+
+function validatePayload(body: TransactionPayload) {
+  if (!isDateString(body.date)) {
+    return "date must be YYYY-MM-DD";
+  }
+
+  if (body.type === "transfer") {
+    if (!body.accountId && !body.transferToAccountId) {
+      return "accountId or transferToAccountId is required for transfer";
+    }
+  } else {
+    if (!body.accountId) {
+      return "accountId is required";
+    }
+    if (body.transferToAccountId) {
+      return "transferToAccountId is only allowed for transfer";
+    }
+  }
+
+  if (body.accountId && body.accountId === body.transferToAccountId) {
+    return "transfer accounts must be different";
+  }
+
+  return null;
+}
 
 function buildBalanceHistoryScope(accountId?: string): Prisma.TransactionWhereInput {
   if (!accountId) {
@@ -127,7 +169,9 @@ function revertBalanceFromTransaction(
   transaction: BalanceHistoryTransaction,
   accountId?: string,
 ) {
-  const amount = accountId ? transaction.amount : toJpy(transaction.amount, transaction.account);
+  const amount = accountId
+    ? transaction.amount
+    : toJpy(transaction.amount, getTransactionCurrencyAccount(transaction));
 
   if (!accountId) {
     if (transaction.type === "income") {
@@ -135,6 +179,14 @@ function revertBalanceFromTransaction(
     }
 
     if (transaction.type === "expense") {
+      return balance + amount;
+    }
+
+    if (!transaction.accountId) {
+      return balance - amount;
+    }
+
+    if (!transaction.transferToAccountId) {
       return balance + amount;
     }
 
@@ -193,13 +245,16 @@ async function ensureActiveAccount(
 async function applyBalanceEffect(
   tx: Prisma.TransactionClient,
   transaction: {
-    accountId: string;
+    accountId?: string | null;
     transferToAccountId?: string | null;
     type: TransactionType;
     amount: number;
   },
 ) {
   if (transaction.type === "income") {
+    if (!transaction.accountId) {
+      throw new Error("Source account not found");
+    }
     await tx.account.update({
       where: { id: transaction.accountId },
       data: { balance: { increment: transaction.amount } },
@@ -208,6 +263,9 @@ async function applyBalanceEffect(
   }
 
   if (transaction.type === "expense") {
+    if (!transaction.accountId) {
+      throw new Error("Source account not found");
+    }
     await tx.account.update({
       where: { id: transaction.accountId },
       data: { balance: { decrement: transaction.amount } },
@@ -215,30 +273,34 @@ async function applyBalanceEffect(
     return;
   }
 
-  if (!transaction.transferToAccountId) {
-    throw new Error("Destination account not found");
+  if (transaction.accountId) {
+    await tx.account.update({
+      where: { id: transaction.accountId },
+      data: { balance: { decrement: transaction.amount } },
+    });
   }
 
-  await tx.account.update({
-    where: { id: transaction.accountId },
-    data: { balance: { decrement: transaction.amount } },
-  });
-  await tx.account.update({
-    where: { id: transaction.transferToAccountId },
-    data: { balance: { increment: transaction.amount } },
-  });
+  if (transaction.transferToAccountId) {
+    await tx.account.update({
+      where: { id: transaction.transferToAccountId },
+      data: { balance: { increment: transaction.amount } },
+    });
+  }
 }
 
 async function revertBalanceEffect(
   tx: Prisma.TransactionClient,
   transaction: {
-    accountId: string;
+    accountId?: string | null;
     transferToAccountId?: string | null;
     type: TransactionType;
     amount: number;
   },
 ) {
   if (transaction.type === "income") {
+    if (!transaction.accountId) {
+      throw new Error("Source account not found");
+    }
     await tx.account.update({
       where: { id: transaction.accountId },
       data: { balance: { decrement: transaction.amount } },
@@ -247,6 +309,9 @@ async function revertBalanceEffect(
   }
 
   if (transaction.type === "expense") {
+    if (!transaction.accountId) {
+      throw new Error("Source account not found");
+    }
     await tx.account.update({
       where: { id: transaction.accountId },
       data: { balance: { increment: transaction.amount } },
@@ -254,18 +319,19 @@ async function revertBalanceEffect(
     return;
   }
 
-  if (!transaction.transferToAccountId) {
-    throw new Error("Destination account not found");
+  if (transaction.accountId) {
+    await tx.account.update({
+      where: { id: transaction.accountId },
+      data: { balance: { increment: transaction.amount } },
+    });
   }
 
-  await tx.account.update({
-    where: { id: transaction.accountId },
-    data: { balance: { increment: transaction.amount } },
-  });
-  await tx.account.update({
-    where: { id: transaction.transferToAccountId },
-    data: { balance: { decrement: transaction.amount } },
-  });
+  if (transaction.transferToAccountId) {
+    await tx.account.update({
+      where: { id: transaction.transferToAccountId },
+      data: { balance: { decrement: transaction.amount } },
+    });
+  }
 }
 
 export const transactionsRoutes = new Hono()
@@ -312,9 +378,9 @@ export const transactionsRoutes = new Hono()
           ...item,
           date: item.date.toISOString().slice(0, 10),
           createdAt: item.createdAt.toISOString(),
-          currencyCode: normalizeCurrencyCode(item.account.currencyCode),
-          amountJpy: toJpy(item.amount, item.account),
-          accountName: item.account.name,
+          currencyCode: normalizeCurrencyCode(getTransactionCurrencyAccount(item).currencyCode),
+          amountJpy: toJpy(item.amount, getTransactionCurrencyAccount(item)),
+          accountName: item.account?.name ?? null,
           transferToAccountCurrencyCode: item.transferToAccount
             ? normalizeCurrencyCode(item.transferToAccount.currencyCode)
             : null,
@@ -393,6 +459,12 @@ export const transactionsRoutes = new Hono()
                 exchangeRateToJpy: true,
               },
             },
+            transferToAccount: {
+              select: {
+                currencyCode: true,
+                exchangeRateToJpy: true,
+              },
+            },
           },
           orderBy: [{ date: "desc" }, { createdAt: "desc" }],
         }),
@@ -414,6 +486,12 @@ export const transactionsRoutes = new Hono()
             amount: true,
             createdAt: true,
             account: {
+              select: {
+                currencyCode: true,
+                exchangeRateToJpy: true,
+              },
+            },
+            transferToAccount: {
               select: {
                 currencyCode: true,
                 exchangeRateToJpy: true,
@@ -485,29 +563,21 @@ export const transactionsRoutes = new Hono()
   .post("/", async (c) => {
     try {
       const body = payloadSchema.parse(await c.req.json());
-      if (!isDateString(body.date)) {
-        return badRequest(c, "date must be YYYY-MM-DD");
-      }
-      if (body.type === "transfer" && !body.transferToAccountId) {
-        return badRequest(c, "transferToAccountId is required for transfer");
-      }
-      if (body.type !== "transfer" && body.transferToAccountId) {
-        return badRequest(c, "transferToAccountId is only allowed for transfer");
-      }
-      if (body.accountId === body.transferToAccountId) {
-        return badRequest(c, "transfer accounts must be different");
+      const validationError = validatePayload(body);
+      if (validationError) {
+        return badRequest(c, validationError);
       }
 
       const date = new Date(`${body.date}T00:00:00.000Z`);
 
       const transaction = await prisma.$transaction(async (tx) => {
-        const sourceAccount = await ensureActiveAccount(tx, body.accountId, "Source account not found");
-        if (body.type === "transfer") {
-          const destinationAccount = await ensureActiveAccount(
-            tx,
-            body.transferToAccountId,
-            "Destination account not found",
-          );
+        const sourceAccount = body.accountId
+          ? await ensureActiveAccount(tx, body.accountId, "Source account not found")
+          : null;
+        const destinationAccount = body.transferToAccountId
+          ? await ensureActiveAccount(tx, body.transferToAccountId, "Destination account not found")
+          : null;
+        if (body.type === "transfer" && sourceAccount && destinationAccount) {
           if (
             normalizeCurrencyCode(sourceAccount.currencyCode) !==
             normalizeCurrencyCode(destinationAccount.currencyCode)
@@ -520,8 +590,8 @@ export const transactionsRoutes = new Hono()
 
         return tx.transaction.create({
           data: {
-            accountId: body.accountId,
-            transferToAccountId: body.transferToAccountId,
+            accountId: body.accountId ?? null,
+            transferToAccountId: body.transferToAccountId ?? null,
             date,
             type: body.type,
             description: body.description,
@@ -545,29 +615,21 @@ export const transactionsRoutes = new Hono()
       }
 
       const body = payloadSchema.parse(await c.req.json());
-      if (!isDateString(body.date)) {
-        return badRequest(c, "date must be YYYY-MM-DD");
-      }
-      if (body.type === "transfer" && !body.transferToAccountId) {
-        return badRequest(c, "transferToAccountId is required for transfer");
-      }
-      if (body.type !== "transfer" && body.transferToAccountId) {
-        return badRequest(c, "transferToAccountId is only allowed for transfer");
-      }
-      if (body.accountId === body.transferToAccountId) {
-        return badRequest(c, "transfer accounts must be different");
+      const validationError = validatePayload(body);
+      if (validationError) {
+        return badRequest(c, validationError);
       }
 
       const date = new Date(`${body.date}T00:00:00.000Z`);
 
       const transaction = await prisma.$transaction(async (tx) => {
-        const sourceAccount = await ensureActiveAccount(tx, body.accountId, "Source account not found");
-        if (body.type === "transfer") {
-          const destinationAccount = await ensureActiveAccount(
-            tx,
-            body.transferToAccountId,
-            "Destination account not found",
-          );
+        const sourceAccount = body.accountId
+          ? await ensureActiveAccount(tx, body.accountId, "Source account not found")
+          : null;
+        const destinationAccount = body.transferToAccountId
+          ? await ensureActiveAccount(tx, body.transferToAccountId, "Destination account not found")
+          : null;
+        if (body.type === "transfer" && sourceAccount && destinationAccount) {
           if (
             normalizeCurrencyCode(sourceAccount.currencyCode) !==
             normalizeCurrencyCode(destinationAccount.currencyCode)
@@ -582,8 +644,8 @@ export const transactionsRoutes = new Hono()
         return tx.transaction.update({
           where: { id: existing.id },
           data: {
-            accountId: body.accountId,
-            transferToAccountId: body.transferToAccountId,
+            accountId: body.accountId ?? null,
+            transferToAccountId: body.transferToAccountId ?? null,
             date,
             type: body.type,
             description: body.description,

--- a/packages/db/prisma/migrations/20260613000000_allow_empty_transfer_accounts/migration.sql
+++ b/packages/db/prisma/migrations/20260613000000_allow_empty_transfer_accounts/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "transactions" ALTER COLUMN "account_id" DROP NOT NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -149,7 +149,7 @@ model Loan {
 
 model Transaction {
   id                  String          @id @default(uuid()) @db.Uuid
-  accountId           String          @map("account_id") @db.Uuid
+  accountId           String?         @map("account_id") @db.Uuid
   transferToAccountId String?         @map("transfer_to_account_id") @db.Uuid
   forecastEventId     String?         @unique @map("forecast_event_id") @db.VarChar(100)
   date                DateTime        @db.Date
@@ -158,7 +158,7 @@ model Transaction {
   amount              Int
   deletedAt           DateTime?       @map("deleted_at")
   createdAt           DateTime        @default(now()) @map("created_at")
-  account             Account         @relation("account_transactions", fields: [accountId], references: [id])
+  account             Account?        @relation("account_transactions", fields: [accountId], references: [id])
   transferToAccount   Account?        @relation("transfer_account_transactions", fields: [transferToAccountId], references: [id])
 
   @@map("transactions")

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -166,7 +166,7 @@ export async function createLoan(
 export async function createTransaction(
   prisma: TestPrisma,
   data: {
-    accountId: string;
+    accountId: string | null;
     transferToAccountId?: string | null;
     forecastEventId?: string | null;
     date?: Date;

--- a/packages/frontend/src/routes/transactions.tsx
+++ b/packages/frontend/src/routes/transactions.tsx
@@ -34,6 +34,8 @@ const transactionTypeLabels = {
   transfer: "振替",
 } as const;
 
+const unspecifiedAccountLabel = "未指定";
+
 type TransactionForm = {
   accountId: string;
   transferToAccountId: string;
@@ -182,18 +184,22 @@ const emptyForm: TransactionForm = {
 };
 
 function canSubmitTransaction(form: TransactionForm) {
+  const hasAccount = form.accountId !== "";
+  const hasTransferToAccount = form.transferToAccountId !== "";
+
   return !(
-    form.accountId === "" ||
     form.date === "" ||
     form.description.trim() === "" ||
     form.amount <= 0 ||
-    (form.type === "transfer" && form.transferToAccountId === "")
+    (form.type !== "transfer" && !hasAccount) ||
+    (form.type === "transfer" && !hasAccount && !hasTransferToAccount) ||
+    (hasAccount && form.accountId === form.transferToAccountId)
   );
 }
 
 function toTransactionPayload(form: TransactionForm) {
   return {
-    accountId: form.accountId,
+    accountId: form.accountId || undefined,
     transferToAccountId: form.transferToAccountId || undefined,
     date: form.date,
     type: form.type,
@@ -212,6 +218,17 @@ function getTransactionTypeClassName(type: Transaction["type"]) {
   }
 
   return "text-amber-300";
+}
+
+function formatTransactionAccounts(transaction: Transaction) {
+  const sourceName = transaction.accountName ?? unspecifiedAccountLabel;
+  const destinationName = transaction.transferToAccountName ?? unspecifiedAccountLabel;
+
+  if (transaction.type === "transfer") {
+    return `${sourceName} -> ${destinationName}`;
+  }
+
+  return sourceName;
 }
 
 function getAccountBalanceJpy(account: Account, applyOffset: boolean) {
@@ -309,7 +326,7 @@ export function TransactionsPage() {
   const openEdit = (transaction: Transaction) => {
     setEditingTransaction(transaction);
     setEditForm({
-      accountId: transaction.accountId,
+      accountId: transaction.accountId ?? "",
       transferToAccountId: transaction.transferToAccountId ?? "",
       date: transaction.date,
       type: transaction.type,
@@ -592,10 +609,7 @@ export function TransactionsPage() {
               <div className="flex items-center justify-between gap-3">
                 <span className="text-white/60">対象口座</span>
                 <span className="min-w-0 break-words text-right">
-                  {deletingTransaction.accountName}
-                  {deletingTransaction.transferToAccountName
-                    ? ` -> ${deletingTransaction.transferToAccountName}`
-                    : ""}
+                  {formatTransactionAccounts(deletingTransaction)}
                 </span>
               </div>
             </div>
@@ -661,7 +675,8 @@ function TransactionFormFields({
   onChange: (next: TransactionForm) => void;
 }) {
   const sourceAccount = accounts.find((account) => account.id === form.accountId) ?? null;
-  const currencyCode: SupportedCurrencyCode = sourceAccount?.currencyCode ?? "JPY";
+  const destinationAccount = accounts.find((account) => account.id === form.transferToAccountId) ?? null;
+  const currencyCode: SupportedCurrencyCode = sourceAccount?.currencyCode ?? destinationAccount?.currencyCode ?? "JPY";
   const amountStep = currencyCode === "JPY" ? 1 : 0.01;
   const transferDestinationAccounts = accounts.filter(
     (account) =>
@@ -687,7 +702,7 @@ function TransactionFormFields({
           });
         }}
       >
-        <option value="">対象口座</option>
+        <option value="">{form.type === "transfer" ? "送金元口座なし" : "対象口座"}</option>
         {accounts.map((account) => (
           <option key={account.id} value={account.id}>
             {account.name}
@@ -720,7 +735,7 @@ function TransactionFormFields({
           value={form.transferToAccountId}
           onChange={(event) => onChange({ ...form, transferToAccountId: event.target.value })}
         >
-          <option value="">振替先口座</option>
+          <option value="">振替先口座なし</option>
           {transferDestinationAccounts.map((account) => (
             <option key={account.id} value={account.id}>
               {account.name}
@@ -771,8 +786,7 @@ function TransactionRow({
         {formatCurrencyWithJpy(transaction.amount, transaction.currencyCode, transaction.amountJpy)}
       </td>
       <td className="px-3 py-3">
-        {transaction.accountName}
-        {transaction.transferToAccountName ? ` -> ${transaction.transferToAccountName}` : ""}
+        {formatTransactionAccounts(transaction)}
       </td>
       <td className="px-3 py-3 text-right">
         <div className="flex justify-end gap-2">

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -20,27 +20,42 @@ import {
 import { z } from "zod";
 
 const transactionPayload = {
-  accountId: uuidSchema.describe("対象口座の ID"),
+  accountId: uuidSchema.optional().describe("対象口座の ID（振替では省略可）"),
   date: dateSchema.describe("取引日（YYYY-MM-DD）"),
   type: z.enum(["income", "expense", "transfer"]).describe("取引種別"),
   description: z.string().min(1).max(200).describe("取引の説明"),
   amount: positiveMoneySchema.describe("金額（正の整数、円単位）"),
-  transferToAccountId: uuidSchema.optional().describe("振替先口座の ID"),
+  transferToAccountId: uuidSchema.optional().describe("振替先口座の ID（振替では省略可）"),
 };
 
 const transactionPayloadSchema = z.object({
-  accountId: uuidSchema,
+  accountId: uuidSchema.optional(),
   date: dateSchema,
   type: z.enum(["income", "expense", "transfer"]),
   description: z.string().min(1).max(200),
   amount: positiveMoneySchema,
   transferToAccountId: uuidSchema.optional(),
 }).superRefine((value, ctx) => {
-  if (value.type === "transfer" && !value.transferToAccountId) {
+  if (value.type === "transfer") {
+    if (!value.accountId && !value.transferToAccountId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["accountId"],
+        message: "type が transfer の場合は accountId または transferToAccountId が必須です",
+      });
+    }
+    if (value.accountId && value.accountId === value.transferToAccountId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["transferToAccountId"],
+        message: "振替元口座と振替先口座は別の口座を指定してください",
+      });
+    }
+  } else if (!value.accountId) {
     ctx.addIssue({
       code: "custom",
-      path: ["transferToAccountId"],
-      message: "type が transfer の場合は transferToAccountId が必須です",
+      path: ["accountId"],
+      message: "accountId は必須です",
     });
   }
   if (value.type !== "transfer" && value.transferToAccountId) {

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -132,8 +132,8 @@ export interface BalanceHistoryResponse {
 }
 
 export interface CreateTransactionPayload {
-  accountId: string;
-  transferToAccountId?: string;
+  accountId?: string | null;
+  transferToAccountId?: string | null;
   date: string;
   type: TransactionType;
   description: string;

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -102,7 +102,7 @@ export interface BillingMonth {
 
 export interface Transaction {
   id: string;
-  accountId: string;
+  accountId: string | null;
   transferToAccountId: string | null;
   forecastEventId: string | null;
   date: string;
@@ -112,7 +112,7 @@ export interface Transaction {
   amountJpy: number;
   createdAt: string;
   currencyCode: SupportedCurrencyCode;
-  accountName?: string;
+  accountName?: string | null;
   transferToAccountCurrencyCode?: SupportedCurrencyCode | null;
   transferToAccountName?: string | null;
 }


### PR DESCRIPTION
## Summary

- Allow transfer transactions to omit either the source account or the destination account.
- Apply balance effects only to the specified side: source-only transfers decrement the source, destination-only transfers increment the destination.
- Make `transactions.account_id` nullable and update API, shared types, MCP tooling, and the transactions UI to represent empty transfer accounts.
- Add integration and E2E coverage for one-sided transfer creation, update, delete, balance history, and UI entry.

Closes #217

## Validation

- `make typecheck`
- `make lint`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `make build`