### PR TITLE
[codex] MCPとAPIの乖離を解消

### DIFF
--- a/packages/frontend/src/components/balance-chart.tsx
+++ b/packages/frontend/src/components/balance-chart.tsx
@@ -2,11 +2,11 @@ import {
   Line,
   LineChart,
   ReferenceLine,
-  ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
+import { useEffect, useRef, useState } from "react";
 import type { SupportedCurrencyCode } from "@sui/shared";
 import { formatChartDateWithYear, formatCurrency, formatDateWithYear } from "../lib/format";
 
@@ -15,6 +15,43 @@ type BalanceChartPoint = {
   balance: number;
   description?: string;
 };
+
+function useElementSize() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    const updateSize = () => {
+      const nextSize = {
+        width: element.clientWidth,
+        height: element.clientHeight,
+      };
+      setSize((current) =>
+        current.width === nextSize.width && current.height === nextSize.height
+          ? current
+          : nextSize,
+      );
+    };
+
+    updateSize();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateSize);
+      return () => window.removeEventListener("resize", updateSize);
+    }
+
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, size] as const;
+}
 
 export function BalanceChart({
   data,
@@ -27,8 +64,14 @@ export function BalanceChart({
   label: string;
   currencyCode?: SupportedCurrencyCode;
 }) {
+  const [chartRef, chartSize] = useElementSize();
+
   if (data.length === 0) {
-    return <div className="flex h-full items-center justify-center text-white/60">表示できる {label} の推移がありません。</div>;
+    return (
+      <div ref={chartRef} className="flex h-full min-h-0 min-w-0 items-center justify-center text-white/60">
+        表示できる {label} の推移がありません。
+      </div>
+    );
   }
 
   const balances = data.map((point) => point.balance);
@@ -47,48 +90,55 @@ export function BalanceChart({
   const showZeroLine = chartDomain[0] <= 0 && chartDomain[1] >= 0;
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <LineChart data={data} margin={{ left: 12, right: 12, top: 12, bottom: 8 }}>
-        {showZeroLine ? <ReferenceLine y={0} stroke="rgba(255,255,255,0.2)" strokeDasharray="4 4" /> : null}
-        <XAxis
-          dataKey="date"
-          stroke="rgba(255,255,255,0.28)"
-          height={28}
-          tick={{ fontSize: 10, fill: "rgba(255,255,255,0.58)" }}
-          tickLine={false}
-          tickMargin={6}
-          minTickGap={24}
-          interval="preserveStartEnd"
-          tickFormatter={formatChartDateWithYear}
-          padding={{ left: 20, right: 20 }}
-        />
-        <YAxis
-          stroke="rgba(255,255,255,0.4)"
-          tickFormatter={(value) => formatCurrency(value, currencyCode)}
-          width={110}
-          domain={chartDomain}
-          tickCount={6}
-        />
-        <Tooltip
-          contentStyle={{
-            background: "rgba(18, 22, 30, 0.96)",
-            border: "1px solid rgba(255,255,255,0.08)",
-            borderRadius: 16,
-          }}
-          formatter={(value) => formatCurrency(value as number, currencyCode)}
-          labelFormatter={(_, payload) => {
-            const point = payload?.[0]?.payload as BalanceChartPoint | undefined;
-            if (!point) {
-              return "";
-            }
+    <div ref={chartRef} className="h-full min-h-0 min-w-0">
+      {chartSize.width > 0 && chartSize.height > 0 ? (
+        <LineChart
+          data={data}
+          height={chartSize.height}
+          margin={{ left: 12, right: 12, top: 12, bottom: 8 }}
+          width={chartSize.width}
+        >
+          {showZeroLine ? <ReferenceLine y={0} stroke="rgba(255,255,255,0.2)" strokeDasharray="4 4" /> : null}
+          <XAxis
+            dataKey="date"
+            stroke="rgba(255,255,255,0.28)"
+            height={28}
+            tick={{ fontSize: 10, fill: "rgba(255,255,255,0.58)" }}
+            tickLine={false}
+            tickMargin={6}
+            minTickGap={24}
+            interval="preserveStartEnd"
+            tickFormatter={formatChartDateWithYear}
+            padding={{ left: 20, right: 20 }}
+          />
+          <YAxis
+            stroke="rgba(255,255,255,0.4)"
+            tickFormatter={(value) => formatCurrency(value, currencyCode)}
+            width={110}
+            domain={chartDomain}
+            tickCount={6}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "rgba(18, 22, 30, 0.96)",
+              border: "1px solid rgba(255,255,255,0.08)",
+              borderRadius: 16,
+            }}
+            formatter={(value) => formatCurrency(value as number, currencyCode)}
+            labelFormatter={(_, payload) => {
+              const point = payload?.[0]?.payload as BalanceChartPoint | undefined;
+              if (!point) {
+                return "";
+              }
 
-            return point.description
-              ? `${point.description} / ${formatDateWithYear(point.date)}`
-              : formatDateWithYear(point.date);
-          }}
-        />
-        <Line type="monotone" dataKey="balance" stroke="hsl(var(--primary))" strokeWidth={3} dot={false} />
-      </LineChart>
-    </ResponsiveContainer>
+              return point.description
+                ? `${point.description} / ${formatDateWithYear(point.date)}`
+                : formatDateWithYear(point.date);
+            }}
+          />
+          <Line type="monotone" dataKey="balance" stroke="hsl(var(--primary))" strokeWidth={3} dot={false} />
+        </LineChart>
+      ) : null}
+    </div>
   );
 }

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -252,10 +252,72 @@ describe("MCP server", () => {
         updatedAt: "2026-03-01T00:00:00.000Z",
       }],
     });
+    addRoute("POST", "/api/accounts", {
+      status: 201,
+      body: {
+        id: "account-usd",
+        name: "USD Wallet",
+        balance: 12345,
+        balanceOffset: 100,
+        currencyCode: "USD",
+        exchangeRateToJpy: 150.5,
+        sortOrder: 2,
+      },
+    });
     addRoute("GET", "/api/recurring-items", { body: [] });
+    addRoute("POST", "/api/recurring-items", {
+      status: 201,
+      body: {
+        id: "recurring-1",
+        name: "家賃",
+        type: "expense",
+        amount: 80000,
+        dayOfMonth: 31,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "previous",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        enabled: true,
+        sortOrder: 3,
+      },
+    });
     addRoute("GET", "/api/subscriptions", { body: [] });
     addRoute("GET", "/api/credit-cards", { body: [] });
+    addRoute("POST", "/api/credit-cards", {
+      status: 201,
+      body: {
+        id: "44444444-4444-4444-8444-444444444444",
+        name: "Visa",
+        settlementDay: 27,
+        dateShiftPolicy: "next",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        assumptionAmount: 50000,
+        sortOrder: 4,
+      },
+    });
+    addRoute("GET", "/api/credit-cards/44444444-4444-4444-8444-444444444444/assumption-suggestion?months=12", {
+      body: {
+        creditCardId: "44444444-4444-4444-8444-444444444444",
+        method: "median",
+        months: 12,
+        sampleCount: 3,
+        sourceYearMonths: ["2026-01", "2026-02", "2026-03"],
+        suggestedAmount: 42000,
+      },
+    });
     addRoute("GET", "/api/loans", { body: [] });
+    addRoute("PUT", "/api/loans/55555555-5555-4555-8555-555555555555", {
+      body: {
+        id: "55555555-5555-4555-8555-555555555555",
+        name: "PCローン",
+        totalAmount: 240000,
+        startDate: "2026-04-30",
+        paymentCount: 12,
+        dateShiftPolicy: "previous",
+        paymentMethod: "account_withdrawal",
+        accountId: "11111111-1111-4111-a111-111111111111",
+      },
+    });
     addRoute("GET", "/api/billings?month=2026-03", {
       body: {
         yearMonth: "2026-03",
@@ -309,6 +371,18 @@ describe("MCP server", () => {
         total: 0,
       },
     });
+    addRoute(
+      "GET",
+      "/api/transactions?page=3&limit=10&accountId=11111111-1111-4111-a111-111111111111&startDate=2026-02-01&endDate=2026-02-28",
+      {
+        body: {
+          items: [],
+          page: 3,
+          limit: 10,
+          total: 0,
+        },
+      },
+    );
     addRoute(
       "GET",
       "/api/transactions/balance-history?accountId=11111111-1111-4111-a111-111111111111&startDate=2026-03-01&endDate=2026-03-31&applyOffset=true",
@@ -402,6 +476,7 @@ describe("MCP server", () => {
       "get_balance_history",
       "update_billing",
       "confirm_forecast",
+      "get_credit_card_assumption_suggestion",
     ]));
     expect(resources.resources.map((resource) => resource.uri)).toEqual(expect.arrayContaining([
       "sui://dashboard",
@@ -411,7 +486,7 @@ describe("MCP server", () => {
     ]));
     expect(resourceTemplates.resourceTemplates.map((resource) => resource.uriTemplate)).toEqual(expect.arrayContaining([
       "sui://billings/{yearMonth}",
-      "sui://transactions{?page,startDate,endDate}",
+      "sui://transactions{?page,limit,accountId,startDate,endDate}",
       "sui://balance-history{?accountId,startDate,endDate,applyOffset}",
     ]));
     expect(prompts.prompts.map((prompt) => prompt.name)).toEqual(expect.arrayContaining([
@@ -538,6 +613,131 @@ describe("MCP server", () => {
     });
   });
 
+  it("forwards current API fields from MCP tools", async () => {
+    await client.callTool({
+      name: "create_account",
+      arguments: {
+        name: "USD Wallet",
+        balance: 12345,
+        balanceOffset: 100,
+        currencyCode: "USD",
+        exchangeRateToJpy: 150.5,
+        sortOrder: 2,
+      },
+    });
+    await client.callTool({
+      name: "create_recurring_item",
+      arguments: {
+        name: "家賃",
+        type: "expense",
+        amount: 80000,
+        dayOfMonth: 31,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "previous",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        enabled: true,
+        sortOrder: 3,
+      },
+    });
+    await client.callTool({
+      name: "create_credit_card",
+      arguments: {
+        name: "Visa",
+        settlementDay: 27,
+        dateShiftPolicy: "next",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        assumptionAmount: 50000,
+        sortOrder: 4,
+      },
+    });
+    const suggestion = await client.callTool({
+      name: "get_credit_card_assumption_suggestion",
+      arguments: {
+        id: "44444444-4444-4444-8444-444444444444",
+        months: 12,
+      },
+    });
+    await client.callTool({
+      name: "update_loan",
+      arguments: {
+        id: "55555555-5555-4555-8555-555555555555",
+        name: "PCローン",
+        totalAmount: 240000,
+        paymentCount: 12,
+        startDate: "2026-04-30",
+        dateShiftPolicy: "previous",
+        paymentMethod: "account_withdrawal",
+        accountId: "11111111-1111-4111-a111-111111111111",
+      },
+    });
+
+    expect(getToolText(suggestion)).toContain("¥42,000");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "POST",
+      path: "/api/accounts",
+      body: {
+        name: "USD Wallet",
+        balance: 12345,
+        balanceOffset: 100,
+        currencyCode: "USD",
+        exchangeRateToJpy: 150.5,
+        sortOrder: 2,
+      },
+    });
+    expect(requests).toContainEqual({
+      method: "POST",
+      path: "/api/recurring-items",
+      body: {
+        name: "家賃",
+        type: "expense",
+        amount: 80000,
+        dayOfMonth: 31,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "previous",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        enabled: true,
+        sortOrder: 3,
+      },
+    });
+    expect(requests).toContainEqual({
+      method: "POST",
+      path: "/api/credit-cards",
+      body: {
+        name: "Visa",
+        settlementDay: 27,
+        dateShiftPolicy: "next",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        assumptionAmount: 50000,
+        sortOrder: 4,
+      },
+    });
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/credit-cards/44444444-4444-4444-8444-444444444444/assumption-suggestion?months=12",
+      body: undefined,
+    });
+    expect(requests).toContainEqual({
+      method: "PUT",
+      path: "/api/loans/55555555-5555-4555-8555-555555555555",
+      body: {
+        name: "PCローン",
+        totalAmount: 240000,
+        paymentCount: 12,
+        startDate: "2026-04-30",
+        dateShiftPolicy: "previous",
+        paymentMethod: "account_withdrawal",
+        accountId: "11111111-1111-4111-a111-111111111111",
+      },
+    });
+  });
+
   it("uses the events API when get_dashboard is called with months", async () => {
     const result = await client.callTool({
       name: "get_dashboard",
@@ -580,6 +780,22 @@ describe("MCP server", () => {
     expect(requests).toContainEqual({
       method: "GET",
       path: "/api/transactions?page=2&limit=10&startDate=2026-03-01&endDate=2026-03-31",
+      body: undefined,
+    });
+  });
+
+  it("forwards transaction resource filters to the REST API", async () => {
+    await client.readResource({
+      uri: "sui://transactions?page=3&limit=10&accountId=11111111-1111-4111-a111-111111111111&startDate=2026-02-01&endDate=2026-02-28",
+    });
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/transactions?page=3&limit=10&accountId=11111111-1111-4111-a111-111111111111&startDate=2026-02-01&endDate=2026-02-28",
       body: undefined,
     });
   });

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 export const uuidSchema = z.string().uuid();
 export const yearMonthSchema = z.string().regex(/^\d{4}-\d{2}$/, "YYYY-MM形式で指定してください");
 export const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD形式で指定してください");
+export const supportedCurrencyCodeSchema = z.enum(["JPY", "USD", "EUR"]);
+export const dateShiftPolicySchema = z.enum(["none", "previous", "next"]);
 export const pageSchema = z.number().int().min(1).default(1);
 export const limitSchema = z.number().int().min(1).max(100).default(50);
 export const moneySchema = z.number().int();

--- a/packages/mcp/src/resources/transactions.ts
+++ b/packages/mcp/src/resources/transactions.ts
@@ -1,29 +1,46 @@
 import { ResourceTemplate, type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { BalanceHistoryResponse, TransactionsResponse } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
-import { booleanFlagSchema, dateSchema, jsonResource, pageSchema, uuidSchema } from "../helpers";
+import { booleanFlagSchema, dateSchema, jsonResource, limitSchema, pageSchema, uuidSchema } from "../helpers";
 
 export function registerTransactionResources(server: McpServer, apiClient: SuiApiClient) {
+  const readTransactions = async (uri: URL, variables: Record<string, string | string[]>) => {
+    const page = pageSchema.parse(Number(variables.page ?? uri.searchParams.get("page") ?? "1"));
+    const limit = variables.limit ?? uri.searchParams.get("limit") ?? undefined;
+    const accountId = variables.accountId ?? uri.searchParams.get("accountId") ?? undefined;
+    const startDate = variables.startDate ?? uri.searchParams.get("startDate") ?? undefined;
+    const endDate = variables.endDate ?? uri.searchParams.get("endDate") ?? undefined;
+    const params = new URLSearchParams({ page: String(page) });
+
+    if (limit) {
+      params.set("limit", String(limitSchema.parse(Number(limit))));
+    }
+    if (accountId) {
+      params.set("accountId", uuidSchema.parse(String(accountId)));
+    }
+    if (startDate) {
+      params.set("startDate", dateSchema.parse(startDate));
+    }
+    if (endDate) {
+      params.set("endDate", dateSchema.parse(endDate));
+    }
+
+    const data = await apiClient.get<TransactionsResponse>(`/api/transactions?${params.toString()}`);
+    return jsonResource(uri.href, data);
+  };
+
   server.resource(
     "transactions",
     new ResourceTemplate("sui://transactions{?page,startDate,endDate}", { list: undefined }),
-    { description: "ページ指定で取引履歴を取得する" },
-    async (uri, variables) => {
-      const page = pageSchema.parse(Number(variables.page ?? uri.searchParams.get("page") ?? "1"));
-      const startDate = variables.startDate ?? uri.searchParams.get("startDate") ?? undefined;
-      const endDate = variables.endDate ?? uri.searchParams.get("endDate") ?? undefined;
-      const params = new URLSearchParams({ page: String(page) });
+    { description: "ページ・期間指定で取引履歴を取得する" },
+    readTransactions,
+  );
 
-      if (startDate) {
-        params.set("startDate", dateSchema.parse(startDate));
-      }
-      if (endDate) {
-        params.set("endDate", dateSchema.parse(endDate));
-      }
-
-      const data = await apiClient.get<TransactionsResponse>(`/api/transactions?${params.toString()}`);
-      return jsonResource(uri.href, data);
-    },
+  server.resource(
+    "transactions-filtered",
+    new ResourceTemplate("sui://transactions{?page,limit,accountId,startDate,endDate}", { list: undefined }),
+    { description: "ページ・件数・口座・期間指定で取引履歴を取得する" },
+    readTransactions,
   );
 
   server.resource(

--- a/packages/mcp/src/tools/accounts.ts
+++ b/packages/mcp/src/tools/accounts.ts
@@ -2,13 +2,17 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Account, AccountsResponse, CreateAccountPayload, UpdateAccountPayload } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatAccountsText } from "../format";
-import { moneySchema, textContent, uuidSchema } from "../helpers";
+import { moneySchema, supportedCurrencyCodeSchema, textContent, uuidSchema } from "../helpers";
 import { z } from "zod";
 
 const accountPayload = {
   name: z.string().min(1).max(100).describe("口座名"),
-  balance: moneySchema.describe("残高"),
-  balanceOffset: moneySchema.describe("可処分計算用オフセット"),
+  balance: moneySchema.describe("残高（通貨の最小単位）"),
+  balanceOffset: moneySchema.describe("可処分計算用オフセット（通貨の最小単位）"),
+  currencyCode: z
+    .preprocess((value) => (typeof value === "string" ? value.toUpperCase() : value), supportedCurrencyCodeSchema)
+    .describe("通貨コード"),
+  exchangeRateToJpy: z.number().positive().describe("JPY換算レート。JPY口座では 1"),
   sortOrder: z.number().int().describe("表示順"),
 };
 

--- a/packages/mcp/src/tools/credit-cards.ts
+++ b/packages/mcp/src/tools/credit-cards.ts
@@ -1,18 +1,20 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
   CreateCreditCardPayload,
+  CreditCardAssumptionSuggestionResponse,
   CreditCard,
   CreditCardsResponse,
   UpdateCreditCardPayload,
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
-import { formatCreditCardsText } from "../format";
-import { nonNegativeMoneySchema, textContent, uuidSchema } from "../helpers";
+import { formatCreditCardsText, formatJson } from "../format";
+import { dateShiftPolicySchema, nonNegativeMoneySchema, textContent, uuidSchema } from "../helpers";
 import { z } from "zod";
 
 const creditCardPayload = {
   name: z.string().min(1).max(100).describe("カード名"),
   settlementDay: z.number().int().min(1).max(31).nullable().optional().describe("引き落とし日"),
+  dateShiftPolicy: dateShiftPolicySchema.optional().describe("土日祝の扱い"),
   accountId: uuidSchema.describe("引き落とし口座 ID"),
   assumptionAmount: nonNegativeMoneySchema.describe("仮定請求額"),
   sortOrder: z.number().int().describe("表示順"),
@@ -23,6 +25,29 @@ export function registerCreditCardTools(server: McpServer, apiClient: SuiApiClie
     const data = await apiClient.get<CreditCardsResponse>("/api/credit-cards");
     return textContent(formatCreditCardsText(data));
   });
+
+  server.tool(
+    "get_credit_card_assumption_suggestion",
+    "クレジットカードの過去請求実績から仮定請求額の提案を取得する",
+    {
+      id: uuidSchema.describe("クレジットカード ID"),
+      months: z.number().int().min(1).max(60).optional().describe("集計対象月数"),
+    },
+    async ({ id, months = 6 }) => {
+      const suggestion = await apiClient.get<CreditCardAssumptionSuggestionResponse>(
+        `/api/credit-cards/${id}/assumption-suggestion?months=${months}`,
+      );
+      const amount = suggestion.suggestedAmount === null
+        ? "提案なし"
+        : `¥${suggestion.suggestedAmount.toLocaleString("ja-JP")}`;
+      return textContent([
+        `仮定請求額の提案: ${amount}`,
+        `サンプル数: ${suggestion.sampleCount}件`,
+        "",
+        formatJson(suggestion),
+      ].join("\n"));
+    },
+  );
 
   server.tool("create_credit_card", "クレジットカードを作成する", creditCardPayload, async (args) => {
     const card = await apiClient.post<CreditCard>("/api/credit-cards", args as CreateCreditCardPayload);

--- a/packages/mcp/src/tools/loans.ts
+++ b/packages/mcp/src/tools/loans.ts
@@ -2,16 +2,28 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CreateLoanPayload, Loan, LoansResponse, UpdateLoanPayload } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatLoansText } from "../format";
-import { dateSchema, positiveMoneySchema, textContent, uuidSchema } from "../helpers";
+import { dateSchema, dateShiftPolicySchema, positiveMoneySchema, textContent, uuidSchema } from "../helpers";
 import { z } from "zod";
 
-const loanPayload = {
+const paymentMethodSchema = z.enum(["account_withdrawal", "credit_card"]);
+
+const baseLoanPayload = {
   name: z.string().min(1).max(100).describe("ローン名"),
   totalAmount: positiveMoneySchema.describe("総額"),
   paymentCount: positiveMoneySchema.describe("支払回数"),
   startDate: dateSchema.describe("開始日"),
-  paymentMethod: z.enum(["account_withdrawal", "credit_card"]).optional().describe("支払方法"),
+  dateShiftPolicy: dateShiftPolicySchema.optional().describe("土日祝の扱い"),
   accountId: uuidSchema.nullable().describe("支払口座 ID。クレカ分割の場合は null"),
+};
+
+const createLoanPayload = {
+  ...baseLoanPayload,
+  paymentMethod: paymentMethodSchema.optional().describe("支払方法"),
+};
+
+const updateLoanPayload = {
+  ...baseLoanPayload,
+  paymentMethod: paymentMethodSchema.describe("支払方法"),
 };
 
 export function registerLoanTools(server: McpServer, apiClient: SuiApiClient) {
@@ -20,7 +32,7 @@ export function registerLoanTools(server: McpServer, apiClient: SuiApiClient) {
     return textContent(formatLoansText(data));
   });
 
-  server.tool("create_loan", "ローンを作成する", loanPayload, async (args) => {
+  server.tool("create_loan", "ローンを作成する", createLoanPayload, async (args) => {
     const loan = await apiClient.post<Loan>("/api/loans", args as CreateLoanPayload);
     return textContent(`ローンを作成しました: ${loan.name}`);
   });
@@ -30,7 +42,7 @@ export function registerLoanTools(server: McpServer, apiClient: SuiApiClient) {
     "ローンを更新する",
     {
       id: uuidSchema.describe("ローン ID"),
-      ...loanPayload,
+      ...updateLoanPayload,
     },
     async ({ id, ...payload }) => {
       const loan = await apiClient.put<Loan>(`/api/loans/${id}`, payload as UpdateLoanPayload);

--- a/packages/mcp/src/tools/recurring-items.ts
+++ b/packages/mcp/src/tools/recurring-items.ts
@@ -7,7 +7,7 @@ import type {
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatRecurringItemsText } from "../format";
-import { dateSchema, nonNegativeMoneySchema, textContent, uuidSchema } from "../helpers";
+import { dateSchema, dateShiftPolicySchema, nonNegativeMoneySchema, textContent, uuidSchema } from "../helpers";
 import { z } from "zod";
 
 const recurringPayload = {
@@ -17,6 +17,7 @@ const recurringPayload = {
   dayOfMonth: z.number().int().min(1).max(31).describe("毎月の対象日"),
   startDate: dateSchema.nullable().describe("開始日"),
   endDate: dateSchema.nullable().describe("終了日"),
+  dateShiftPolicy: dateShiftPolicySchema.optional().describe("土日祝の扱い"),
   accountId: uuidSchema.describe("口座 ID"),
   enabled: z.boolean().describe("有効フラグ"),
   sortOrder: z.number().int().describe("表示順"),


### PR DESCRIPTION
## 概要

- MCPの口座・固定収支・クレジットカード・ローンツールを最新API payloadに同期しました
- クレジットカードの仮定請求額提案APIをMCPツールから呼べるようにしました
- 取引リソースで `limit` / `accountId` を扱えるテンプレートを追加し、既存テンプレートも維持しました
- 残高チャートを測定済みサイズで描画するようにして、Rechartsの初期サイズ警告を解消しました

## 背景

最近追加された通貨、土日祝シフト、ローン支払方法、クレカ仮定額提案などのAPI機能に対して、MCP側の入力schemaや公開ツールが一部追従していませんでした。特に口座更新ではMCPから通貨情報を送れないため、APIのデフォルト適用でJPYに戻るリスクがありました。

## 影響

- MCP経由で外貨口座の作成・更新ができます
- MCP経由で固定収支、クレジットカード、ローンの土日祝シフトを指定できます
- MCP経由でクレカ仮定請求額の中央値提案を取得できます
- ローン更新時は `paymentMethod` を必須にし、支払口座更新が黙って無視される状態を避けます
- チャート描画時のコンソール警告が出なくなります

## 検証

- `make typecheck`
- `make test-unit`
- `make lint`
- `make build`
- `make test-integration`（89 passed）
- `make test-e2e`（55 passed、Rechartsのサイズ警告なし）
