### PR TITLE
[codex] automate release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,16 @@ permissions:
   pull-requests: write
 
 jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Check package versions
+        run: make version-check
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,6 +34,19 @@ jobs:
 
       - name: Check out the repo
         uses: actions/checkout@v6.0.3
+
+      - name: Check package versions
+        run: |
+          if [ -n "${RELEASE_TAG}" ]; then
+            make version-check VERSION="${RELEASE_TAG}"
+          elif [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            make version-check VERSION="${GITHUB_REF_NAME}"
+          else
+            make version-check
+          fi
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 

--- a/.github/workflows/mcp-docker.yaml
+++ b/.github/workflows/mcp-docker.yaml
@@ -34,6 +34,18 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6.0.3
 
+      - name: Check package versions
+        run: |
+          if [ -n "${RELEASE_TAG}" ]; then
+            make version-check VERSION="${RELEASE_TAG}"
+          elif [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            make version-check VERSION="${GITHUB_REF_NAME}"
+          else
+            make version-check
+          fi
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -17,6 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
 
+      - name: Check package versions
+        run: |
+          if [ -n "${RELEASE_TAG}" ]; then
+            make version-check VERSION="${RELEASE_TAG}"
+          elif [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            make version-check VERSION="${GITHUB_REF_NAME}"
+          else
+            make version-check
+          fi
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+
       - uses: pnpm/action-setup@v6.0.8
         with:
           run_install: false
@@ -31,7 +43,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run MCP tests
-        run: pnpm --filter @soli0222/sui-mcp test
+        run: make test-unit
 
       - name: Build MCP package
         run: pnpm --filter @soli0222/sui-mcp build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,191 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version, for example 1.8.0 or 1.8.0-rc.1
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ inputs.version }}
+      PORT: "3100"
+      VITE_API_BASE: http://localhost:3100
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v6.0.3
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate release input
+        run: |
+          set -euo pipefail
+
+          if [[ "$VERSION" == v* ]]; then
+            echo "Use ${VERSION#v}; release tags in this repository do not use a v prefix." >&2
+            exit 1
+          fi
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Version must be SemVer like 1.8.0, 1.8.0-rc.1, or 1.8.0-beta.1." >&2
+            exit 1
+          fi
+
+          git fetch --tags --force
+
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "Tag $VERSION already exists." >&2
+            exit 1
+          fi
+
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "GitHub Release $VERSION already exists." >&2
+            exit 1
+          fi
+
+      - uses: pnpm/action-setup@v6.0.8
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24.16.0
+          cache: pnpm
+
+      - name: Set package versions
+        run: make version-set VERSION="$VERSION"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check package versions
+        run: make version-check VERSION="$VERSION"
+
+      - name: Run lint
+        run: make lint
+
+      - name: Run typecheck
+        run: make typecheck
+
+      - name: Run unit tests
+        run: make test-unit
+
+      - name: Run build
+        run: make build
+
+      - name: Run integration tests
+        run: make test-integration
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: make test-e2e
+
+      - name: Commit release version
+        id: commit
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add package.json packages/*/package.json
+
+          if git diff --cached --quiet; then
+            echo "No version changes to commit; tagging current HEAD."
+          else
+            git commit -m "chore(release): $VERSION"
+          fi
+
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Push release commit and tag
+        run: |
+          set -euo pipefail
+
+          git tag "$VERSION"
+          git push origin HEAD:main
+          git push origin "refs/tags/$VERSION"
+
+      - name: Create GitHub Release
+        run: |
+          set -euo pipefail
+
+          args=("$VERSION" --verify-tag --title "$VERSION" --generate-notes)
+          if [[ "$VERSION" == *-* ]]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "${args[@]}"
+
+          {
+            echo "Released $VERSION"
+            echo "Commit: ${{ steps.commit.outputs.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dispatch publish workflows
+        run: |
+          set -euo pipefail
+
+          workflows=(
+            "docker.yaml"
+            "mcp-docker.yaml"
+            "mcp-publish.yml"
+          )
+          release_sha="${{ steps.commit.outputs.sha }}"
+
+          for workflow in "${workflows[@]}"; do
+            echo "Dispatching ${workflow} for ${VERSION}"
+            gh workflow run "$workflow" --ref "$VERSION"
+          done
+
+          for workflow in "${workflows[@]}"; do
+            run_id=""
+
+            for _ in {1..30}; do
+              run_id=$(gh run list \
+                --workflow "$workflow" \
+                --event workflow_dispatch \
+                --json databaseId,headSha \
+                --jq ".[] | select(.headSha == \"${release_sha}\") | .databaseId" | head -n 1)
+
+              if [ -n "$run_id" ]; then
+                break
+              fi
+
+              sleep 2
+            done
+
+            if [ -z "$run_id" ]; then
+              echo "Could not find dispatched run for ${workflow} at ${release_sha}." >&2
+              exit 1
+            fi
+
+            echo "Watching ${workflow} run ${run_id}"
+            gh run watch "$run_id" --exit-status
+          done

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,26 @@
-.PHONY: help test-db-up test-db-down lint typecheck test-unit test-integration test-e2e test-performance build \
+.PHONY: help version-set version-sync version-check test-db-up test-db-down lint typecheck test-unit test-integration test-e2e test-performance build \
 	act-lint act-typecheck act-test-unit act-test-integration act-test-e2e act-test-performance act-build act-all
 
 TEST_DATABASE_URL ?= postgresql://sui_test:sui_test@localhost:5555/sui_test
 PERF_OUTPUT ?= performance-results/head.json
+VERSION ?=
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+# ---------------------------------------------------------------------------
+# Version targets
+# ---------------------------------------------------------------------------
+
+version-set: ## Set root and workspace package versions (VERSION=x.y.z)
+	@test -n "$(VERSION)" || (echo "VERSION is required" >&2; exit 1)
+	./scripts/set-version.sh "$(VERSION)"
+
+version-sync: ## Sync workspace package versions from root package.json
+	./scripts/sync-versions.sh
+
+version-check: ## Check workspace package versions are synchronized
+	./scripts/check-versions.sh $(VERSION)
 
 # ---------------------------------------------------------------------------
 # Local test targets

--- a/README.md
+++ b/README.md
@@ -184,17 +184,31 @@ bash scripts/seed.sh all
 
 ```bash
 # 単体テスト
-pnpm test
+make test-unit
 
-# 型チェック（Prisma クライアントの生成が必要）
-pnpm --filter @sui/db db:generate
-pnpm typecheck
+# 型チェック
+make typecheck
 
-# 結合テスト（テスト DB の起動が必要）
+# 結合テスト
 make test-integration
 
-# E2E テスト（テスト DB の起動が必要）
+# E2E テスト
 make test-e2e
+```
+
+`make test-integration` と `make test-e2e` はテスト用 DB の起動・マイグレーション・停止を自動で行います。
+
+## リリース
+
+GitHub Actions の `Release` workflow を手動実行し、`version` に `1.8.0` や `1.8.0-rc.1` のような SemVer を入力します。タグは既存リリースに合わせて `v` prefix なしで作成されます。
+
+workflow は package version の更新と同期、`make lint` / `make typecheck` / `make test-unit` / `make build` / `make test-integration` / `make test-e2e` の検証、release commit、tag、GitHub Release 作成までを実行します。その後、Docker image と MCP package の publish workflow を同じ tag で実行し、完了まで待ちます。
+
+ローカルで version だけ確認・同期したい場合は以下を使います。
+
+```bash
+make version-set VERSION=1.8.0
+make version-check
 ```
 
 ## MCP サーバー

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test": "pnpm -r test",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "version:check": "./scripts/check-versions.sh",
+    "version:sync": "./scripts/sync-versions.sh",
     "upgrade:latest": "pnpm -r upgrade --latest && pnpm upgrade --latest"
   },
   "devDependencies": {

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+EXPECTED_VERSION="${1:-}"
+ROOT_VERSION=$(jq -r '.version' "$ROOT_DIR/package.json")
+
+if [ -z "$ROOT_VERSION" ] || [ "$ROOT_VERSION" = "null" ]; then
+  echo "Error: version not found in root package.json" >&2
+  exit 1
+fi
+
+if [ -n "$EXPECTED_VERSION" ] && [ "$EXPECTED_VERSION" != "$ROOT_VERSION" ]; then
+  echo "Error: root package.json version ${ROOT_VERSION} does not match expected ${EXPECTED_VERSION}" >&2
+  exit 1
+fi
+
+failed=0
+for pkg in "$ROOT_DIR"/packages/*/package.json; do
+  name=$(jq -r '.name' "$pkg")
+  version=$(jq -r '.version' "$pkg")
+
+  if [ "$version" != "$ROOT_VERSION" ]; then
+    echo "Error: ${name} has version ${version}, expected ${ROOT_VERSION}" >&2
+    failed=1
+  fi
+done
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "All package versions are synced at ${ROOT_VERSION}"

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="${1:-}"
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+if [[ "$VERSION" == v* ]]; then
+  echo "Error: version must not start with v; use ${VERSION#v}" >&2
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+  echo "Error: version must be a SemVer release like 1.2.3, 1.2.3-rc.1, or 1.2.3-beta.1" >&2
+  exit 1
+fi
+
+tmp=$(mktemp)
+jq --arg v "$VERSION" '.version = $v' "$ROOT_DIR/package.json" > "$tmp"
+mv "$tmp" "$ROOT_DIR/package.json"
+
+"$ROOT_DIR/scripts/sync-versions.sh"
+"$ROOT_DIR/scripts/check-versions.sh" "$VERSION"


### PR DESCRIPTION
## 概要

- 手動実行の `Release` workflow を追加し、SemVer の `version` 入力から package version 更新、同期、リリース前検証、release commit、tag、GitHub Release 作成までを自動化しました。
- workspace package の version を設定・同期・検証する helper script と、Makefile / package.json の実行口を追加しました。
- CI と publish workflows に version guard を追加し、package version や tag version が不一致の場合は publish 前に失敗するようにしました。
- Release workflow から既存の Docker / MCP publish workflows を同じ tag で明示実行し、完了まで待つようにしました。
- README に新しいリリース手順を追記し、テストコマンドも Makefile 経由に揃えました。

## 検証

- `make version-check`
- `make version-set VERSION=1.7.1`
- `make lint`
- `make typecheck`
- `make test-unit`
- `make build`
- `make test-integration`
- `make test-e2e`
- `actionlint .github/workflows/ci.yml .github/workflows/docker.yaml .github/workflows/mcp-docker.yaml .github/workflows/mcp-publish.yml .github/workflows/release.yml`
- 変更した workflow の YAML parse check

補足: repository 全体に対する `actionlint` は、既存の `renovate.yaml` の app-token input 問題で失敗します。今回変更した workflow は個別に `actionlint` を通しています。