### PR TITLE
feat: MCP に review_overdue_events ツールを追加

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -104,9 +104,10 @@ SUI_API_URL=https://sui.example.com docker compose -f compose.mcp.yaml up -d --b
 | ツール | 説明 |
 |--------|------|
 | `get_dashboard` | 残高予測・直近イベント・口座別予測を取得（`months`, `applyOffset` 指定可）。予測は固定収支・クレジットカード請求・ローン返済から生成し、サブスク台帳は二重計上防止のため含めない |
+| `review_overdue_events` | 予定日を過ぎた未確定の予測イベントを確認用に一覧する（読み取り専用）。確定には人間の確認を経て `confirm_forecast` を使う |
 | `confirm_forecast` | 実際の金額と口座を人間が確認した予測イベントを、手動で実取引として確定。自動確定目的では使わない |
 
-予定額と実績額は一致しないことがあるため、予定日超過イベントも自動確定しません。MCP クライアントは `get_dashboard` で対象イベントを確認し、ユーザー確認後に `confirm_forecast` を呼び出してください。
+予定額と実績額は一致しないことがあるため、予定日超過イベントも自動確定しません。MCP クライアントは `review_overdue_events` で対象イベントを確認し、ユーザー確認後に `confirm_forecast` を呼び出してください。
 
 ### 口座
 

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -37,6 +37,14 @@ function getToolText(result: unknown) {
   return result.content[0].text;
 }
 
+function getStructuredContent(result: unknown) {
+  if (typeof result !== "object" || result === null || !("structuredContent" in result)) {
+    return undefined;
+  }
+
+  return result.structuredContent;
+}
+
 function createFetchStub() {
   const requests: Array<{ method: string; path: string; body?: unknown }> = [];
   const routes = new Map<string, RouteResponse>();
@@ -76,9 +84,12 @@ function createFetchStub() {
 describe("MCP server", () => {
   let client: Client;
   let server: ReturnType<typeof buildServer>;
+  let addRoute: (method: string, path: string, response: RouteResponse) => void;
 
   beforeEach(async () => {
-    const { addRoute, fetchImpl, requests } = createFetchStub();
+    const fetchStub = createFetchStub();
+    addRoute = fetchStub.addRoute;
+    const { fetchImpl, requests } = fetchStub;
     addRoute("GET", "/api/dashboard", {
       body: {
         totalBalance: 123456,
@@ -95,6 +106,32 @@ describe("MCP server", () => {
           description: "家賃",
           amount: 80000,
         },
+        overdueForecast: [
+          {
+            id: "overdue-1",
+            date: "2026-03-01",
+            type: "expense",
+            description: "水道代",
+            amount: 8000,
+            amountJpy: 8000,
+            balance: 115456,
+            balanceJpy: 115456,
+            currencyCode: "JPY",
+            accountId: "11111111-1111-4111-a111-111111111111",
+          },
+          {
+            id: "overdue-2",
+            date: "2026-03-05",
+            type: "income",
+            description: "立替精算",
+            amount: 12000,
+            amountJpy: 12000,
+            balance: 127456,
+            balanceJpy: 127456,
+            currencyCode: "JPY",
+            accountId: "22222222-2222-4222-a222-222222222222",
+          },
+        ],
         forecast: [
           {
             id: "event-1",
@@ -468,6 +505,7 @@ describe("MCP server", () => {
 
     expect(tools.tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
       "get_dashboard",
+      "review_overdue_events",
       "list_accounts",
       "list_subscriptions",
       "create_transaction",
@@ -495,6 +533,9 @@ describe("MCP server", () => {
       "forecast-analysis",
       "expense-breakdown",
     ]));
+    expect(tools.tools.find((tool) => tool.name === "review_overdue_events")).toMatchObject({
+      annotations: { readOnlyHint: true },
+    });
 
     const summary = await client.readResource({ uri: "sui://forecast/summary" });
     expect(getResourceText(summary.contents[0])).toContain("=== sui 資産予測サマリー ===");
@@ -759,6 +800,78 @@ describe("MCP server", () => {
       method: "GET",
       path: "/api/dashboard/events?months=3&applyOffset=true",
       body: undefined,
+    });
+  });
+
+  it("reviews overdue events with account names and structured content", async () => {
+    const result = await client.callTool({
+      name: "review_overdue_events",
+      arguments: {},
+    });
+
+    const text = getToolText(result);
+    expect(text).toContain("予定日超過の未確定イベント: 2件");
+    expect(text).toContain("[overdue-1]");
+    expect(text).toContain("Main");
+    expect(text).toContain("各イベントについてユーザーに実際の金額と口座を確認し");
+    expect(getStructuredContent(result)).toEqual({
+      overdueCount: 2,
+      events: [
+        {
+          id: "overdue-1",
+          date: "2026-03-01",
+          type: "expense",
+          description: "水道代",
+          amount: 8000,
+          amountJpy: 8000,
+          currencyCode: "JPY",
+          accountId: "11111111-1111-4111-a111-111111111111",
+          accountName: "Main",
+        },
+        {
+          id: "overdue-2",
+          date: "2026-03-05",
+          type: "income",
+          description: "立替精算",
+          amount: 12000,
+          amountJpy: 12000,
+          currencyCode: "JPY",
+          accountId: "22222222-2222-4222-a222-222222222222",
+          accountName: null,
+        },
+      ],
+    });
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/dashboard",
+      body: undefined,
+    });
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/accounts",
+      body: undefined,
+    });
+  });
+
+  it("reports when there are no overdue events to review", async () => {
+    addRoute("GET", "/api/dashboard", {
+      body: { overdueForecast: [] },
+    });
+
+    const result = await client.callTool({
+      name: "review_overdue_events",
+      arguments: {},
+    });
+
+    expect(getToolText(result)).toBe("予定日超過の未確定イベントはありません。");
+    expect(getStructuredContent(result)).toEqual({
+      overdueCount: 0,
+      events: [],
     });
   });
 

--- a/packages/mcp/src/tools/dashboard.ts
+++ b/packages/mcp/src/tools/dashboard.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
+  AccountsResponse,
   ConfirmForecastPayload,
   DashboardEventsResponse,
   DashboardResponse,
@@ -7,8 +8,51 @@ import type {
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatDashboardText } from "../format";
-import { booleanFlagSchema, positiveMoneySchema, textContent, uuidSchema } from "../helpers";
+import { booleanFlagSchema, positiveMoneySchema, supportedCurrencyCodeSchema, textContent, uuidSchema } from "../helpers";
 import { z } from "zod";
+
+const reviewOverdueEventSchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  type: z.enum(["income", "expense"]),
+  description: z.string(),
+  amount: z.number(),
+  amountJpy: z.number(),
+  currencyCode: supportedCurrencyCodeSchema,
+  accountId: z.string().nullable(),
+  accountName: z.string().nullable(),
+});
+
+const reviewOverdueGuidance =
+  "各イベントについてユーザーに実際の金額と口座を確認し、確認が取れたものだけ confirm_forecast で確定してください。自動で確定してはいけません。";
+
+function formatReviewAmount(event: z.infer<typeof reviewOverdueEventSchema>) {
+  const amount = event.amount.toLocaleString("ja-JP");
+  const amountJpy = event.amountJpy.toLocaleString("ja-JP");
+
+  if (event.currencyCode === "JPY") {
+    return `¥${amount}`;
+  }
+
+  return `${event.currencyCode} ${amount}（¥${amountJpy}）`;
+}
+
+function formatReviewOverdueText(events: Array<z.infer<typeof reviewOverdueEventSchema>>) {
+  if (events.length === 0) {
+    return "予定日超過の未確定イベントはありません。";
+  }
+
+  const lines = [`予定日超過の未確定イベント: ${events.length}件`, ""];
+  for (const event of events) {
+    const typeLabel = event.type === "income" ? "収入" : "支出";
+    lines.push(
+      `[${event.id}] ${event.date} ${typeLabel} ${event.description} ${formatReviewAmount(event)} ${event.accountName ?? "口座未解決"}`,
+    );
+  }
+  lines.push("", reviewOverdueGuidance);
+
+  return lines.join("\n");
+}
 
 function replaceDashboardEvents(
   dashboard: DashboardResponse,
@@ -49,6 +93,46 @@ export function registerDashboardTools(server: McpServer, apiClient: SuiApiClien
       const now = new Date();
       const today = new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
       return textContent(formatDashboardText(data, today));
+    },
+  );
+
+  server.registerTool(
+    "review_overdue_events",
+    {
+      description: "予定日を過ぎた未確定の予測イベントを確認用に一覧する（読み取り専用）。確定には人間の確認を経て confirm_forecast を使う",
+      inputSchema: {},
+      outputSchema: {
+        overdueCount: z.number().int().nonnegative(),
+        events: z.array(reviewOverdueEventSchema),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async () => {
+      const [dashboard, accounts] = await Promise.all([
+        apiClient.get<DashboardResponse>("/api/dashboard"),
+        apiClient.get<AccountsResponse>("/api/accounts"),
+      ]);
+      const accountNames = new Map(accounts.map((account) => [account.id, account.name]));
+      const events = (dashboard.overdueForecast ?? []).map((event) => ({
+        id: event.id,
+        date: event.date,
+        type: event.type,
+        description: event.description,
+        amount: event.amount,
+        amountJpy: event.amountJpy,
+        currencyCode: event.currencyCode,
+        accountId: event.accountId,
+        accountName: event.accountId ? accountNames.get(event.accountId) ?? null : null,
+      }));
+      const structuredContent = {
+        overdueCount: events.length,
+        events,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatReviewOverdueText(events) }],
+        structuredContent,
+      };
     },
   );
 


### PR DESCRIPTION
## 背景

プロダクトレビュー（20260702-review.md）指摘 B-1/B-4。sui は「予測イベントは人間の確認後に手動確定」が設計哲学だが、MCP には `confirm_forecast` ツールがあるのに確定対象の ID を得る正規の手段がなく、エージェント経由で確認ワークフローを回せなかった。#275 で `get_dashboard` のテキストに overdue 一覧を足したのに続き、本 PR でワークフローを一級のツールとして表現する。

## 変更内容

- **`review_overdue_events` ツール新設**（入力パラメータなし・読み取り専用）
  - `/api/dashboard` + `/api/accounts` から予定日超過イベントを ID・日付・種別・金額（JPY換算含む）・口座名付きで一覧
  - text と structuredContent（`registerTool` + `outputSchema`、SDK ^1.29）の2形式で返却
  - `annotations.readOnlyHint: true`
  - text 末尾にエージェント向けガイダンス:「確認が取れたものだけ confirm_forecast で確定。自動で確定してはいけない」
  - 口座が解決できない場合は `accountName: null` / テキストでは「口座未解決」
- MCP README のツール表と確認フロー説明を更新

## 検証

- `make lint` / `make typecheck` / `make test-unit` 通過（mcp 33 tests、新規 2 ケース: 滞留あり時の text/structuredContent/API呼び出し検証、滞留 0 件時のメッセージ）
- backend / frontend / shared への変更なし

Implemented-by: Codex (gpt-5.5) / Reviewed-by: Claude (Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)