### PR TITLE
feat: 予定日超過イベントの一括確認ダイアログに刷新

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -184,32 +184,58 @@ test("confirms a forecast event from the dialog", async ({ page }) => {
 
 test("forces overdue forecast confirmation from the dashboard", async ({ page }) => {
   const account = await seedAccount({ name: "Main Account", balance: 100000, sortOrder: 1 });
-  const card = await seedCreditCard({
+  const firstCard = await seedCreditCard({
     name: "Past Card",
     accountId: account.id,
     settlementDay: getFutureDayOfMonth(),
     assumptionAmount: 0,
     sortOrder: 1,
   });
+  const secondCard = await seedCreditCard({
+    name: "Backup Card",
+    accountId: account.id,
+    settlementDay: getFutureDayOfMonth(),
+    assumptionAmount: 0,
+    sortOrder: 2,
+  });
   await seedBilling(
     getYearMonth(0),
-    [{ creditCardId: card.id, amount: 12000 }],
+    [
+      { creditCardId: firstCard.id, amount: 12000 },
+      { creditCardId: secondCard.id, amount: 5000 },
+    ],
     new Date(`${getDateString(-1)}T00:00:00.000Z`),
   );
 
   await navigateTo(page, "/");
 
-  await expect(page.getByRole("heading", { name: "予測イベントを確定" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "予定日超過イベントを確認" })).toBeVisible();
   await expect(page.getByText("予定日を過ぎた未確定イベントです")).toBeVisible();
-  await expect(page.getByRole("button", { name: "閉じる" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "選択した 2 件を確定" })).toBeVisible();
   await expect(page.getByText("Past Card 引き落とし").first()).toBeVisible();
+  await expect(page.getByText("Backup Card 引き落とし").first()).toBeVisible();
 
-  await page.getByLabel("実際の金額").fill("9000");
-  await page.getByRole("button", { name: "確定する" }).click();
+  await page.getByRole("button", { name: "あとで" }).click();
+  await expect(page.getByRole("heading", { name: "予定日超過イベントを確認" })).toHaveCount(0);
+  await expect(page.getByText("⏳ 予定日超過の未確定イベントが 2 件あります")).toBeVisible();
+
+  await page.getByRole("button", { name: "確認する" }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "予定日超過イベントを確認" })).toBeVisible();
+
+  await dialog.getByRole("row", { name: /Past Card 引き落とし/ }).getByRole("spinbutton").fill("9000");
+  await dialog.getByRole("button", { name: "選択した 2 件を確定" }).click();
   await waitForReload(page);
 
-  await expect(page.getByRole("heading", { name: "予測イベントを確定" })).toHaveCount(0);
-  await expect(page.getByText("総所持金").locator("..").first()).toContainText(formatCurrency(91000));
+  await expect(page.getByRole("heading", { name: "予定日超過イベントを確認" })).toHaveCount(0);
+  await expect(page.getByText("⏳ 予定日超過の未確定イベントが")).toHaveCount(0);
+  await expect(page.getByText("総所持金").locator("..").first()).toContainText(formatCurrency(86000));
+
+  await navigateTo(page, "/transactions");
+  await page.getByLabel("期間プリセット").selectOption("all");
+  await waitForReload(page);
+  await expect(page.getByRole("row", { name: /Past Card 引き落とし/ }).first()).toContainText(formatCurrency(9000));
+  await expect(page.getByRole("row", { name: /Backup Card 引き落とし/ }).first()).toContainText(formatCurrency(5000));
 });
 
 test("shows a red balance warning card", async ({ page }) => {

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -74,13 +74,40 @@ function formatSummaryEvent(event: DashboardResponse["nextIncome"] | DashboardRe
   )}`;
 }
 
+type OverdueConfirmDraft = {
+  selected: boolean;
+  amount: number;
+  accountId: string;
+  error?: string;
+};
+
+function getDefaultConfirmAccountId(event: ForecastEvent, accounts: Account[]) {
+  const fallbackAccount = accounts.find((account) => account.currencyCode === event.currencyCode);
+  return event.accountId ?? fallbackAccount?.id ?? "";
+}
+
+function createOverdueConfirmDraft(event: ForecastEvent, accounts: Account[]): OverdueConfirmDraft {
+  return {
+    selected: true,
+    amount: event.amount,
+    accountId: getDefaultConfirmAccountId(event, accounts),
+  };
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "確定に失敗しました。";
+}
+
 export function DashboardPage() {
   const [reloadKey, setReloadKey] = useState(0);
   const [selectedAccountId, setSelectedAccountId] = useState<string | "total">("total");
   const [periodPreset, setPeriodPreset] = useState<DashboardPeriodPreset>(DEFAULT_DASHBOARD_PERIOD);
   const [applyOffset, setApplyOffset] = useState(true);
   const [manualSelectedEvent, setManualSelectedEvent] = useState<ForecastEvent | null>(null);
-  const [confirmedOverdueIds, setConfirmedOverdueIds] = useState<string[]>([]);
+  const [dismissedOverdueSignature, setDismissedOverdueSignature] = useState<string | null>(null);
+  const [overdueDrafts, setOverdueDrafts] = useState<Record<string, OverdueConfirmDraft>>({});
+  const [hiddenOverdueIds, setHiddenOverdueIds] = useState<string[]>([]);
+  const [isBatchConfirming, setIsBatchConfirming] = useState(false);
   const [confirmDraft, setConfirmDraft] = useState<{
     eventId: string;
     amount: number;
@@ -122,6 +149,11 @@ export function DashboardPage() {
       : eventsData?.accountForecasts.find((forecast) => forecast.accountId === selectedAccountId) ?? null;
   const chartForecast = selectedAccountForecast?.events ?? dashboardData?.dashboard.forecast ?? [];
   const tableForecast = selectedAccountEvents?.events ?? eventsData?.forecast ?? [];
+  const overdueForecast = dashboardData?.dashboard.overdueForecast ?? [];
+  const visibleOverdueForecast = overdueForecast.filter((event) => !hiddenOverdueIds.includes(event.id));
+  const visibleOverdueSignature = visibleOverdueForecast.map((event) => event.id).join("|");
+  const isOverdueDialogOpen =
+    visibleOverdueForecast.length > 0 && dismissedOverdueSignature !== visibleOverdueSignature;
   const currentBalance =
     selectedAccountForecast?.currentBalance ?? dashboardData?.dashboard.totalBalance ?? 0;
   const displayCurrencyCode: SupportedCurrencyCode = selectedAccountForecast?.currencyCode ?? "JPY";
@@ -149,18 +181,15 @@ export function DashboardPage() {
       accountName: forecast.accountName,
       firstNegativeDate: forecast.events.find((event) => event.balance < 0)?.date ?? forecast.minBalanceDate,
     }));
-  const pendingOverdueEvent = dashboardData?.dashboard.overdueForecast.find(
-    (event) => !confirmedOverdueIds.includes(event.id),
-  ) ?? null;
-  const selectedEvent = pendingOverdueEvent ?? manualSelectedEvent;
-  const isOverdueConfirm = Boolean(pendingOverdueEvent);
-  const defaultAccount = selectedEvent
-    ? accounts.find((account) => account.currencyCode === selectedEvent.currencyCode)
-    : accounts[0];
-  const defaultAccountId = selectedEvent?.accountId ?? defaultAccount?.id ?? "";
+  const selectedEvent = manualSelectedEvent;
+  const defaultAccountId = selectedEvent ? getDefaultConfirmAccountId(selectedEvent, accounts) : "";
   const activeDraft = confirmDraft?.eventId === selectedEvent?.id ? confirmDraft : null;
   const confirmAmount = activeDraft?.amount ?? selectedEvent?.amount ?? 0;
   const accountId = activeDraft?.accountId ?? defaultAccountId;
+  const selectedOverdueEvents = visibleOverdueForecast.filter(
+    (event) => overdueDrafts[event.id]?.selected ?? true,
+  );
+  const selectedOverdueCount = selectedOverdueEvents.length;
 
   const updateConfirmDraft = (draft: { amount?: number; accountId?: string }) => {
     if (!selectedEvent) {
@@ -174,13 +203,30 @@ export function DashboardPage() {
     });
   };
 
+  const updateOverdueDraft = (
+    event: ForecastEvent,
+    draft: Partial<Omit<OverdueConfirmDraft, "error">>,
+  ) => {
+    setOverdueDrafts((current) => {
+      const existing = current[event.id] ?? createOverdueConfirmDraft(event, accounts);
+
+      return {
+        ...current,
+        [event.id]: {
+          ...existing,
+          ...draft,
+          error: undefined,
+        },
+      };
+    });
+  };
+
   const openConfirm = (event: ForecastEvent) => {
-    const fallbackAccount = accounts.find((account) => account.currencyCode === event.currencyCode);
     setManualSelectedEvent(event);
     setConfirmDraft({
       eventId: event.id,
       amount: event.amount,
-      accountId: event.accountId ?? fallbackAccount?.id ?? "",
+      accountId: getDefaultConfirmAccountId(event, accounts),
     });
   };
 
@@ -203,12 +249,61 @@ export function DashboardPage() {
       }),
     });
 
-    if (isOverdueConfirm) {
-      setConfirmedOverdueIds((ids) => (
-        ids.includes(selectedEvent.id) ? ids : [...ids, selectedEvent.id]
-      ));
-    }
     closeConfirm();
+    startTransition(() => setReloadKey((value) => value + 1));
+  };
+
+  const handleBatchConfirm = async () => {
+    if (selectedOverdueEvents.length === 0 || isBatchConfirming) {
+      return;
+    }
+
+    setIsBatchConfirming(true);
+    const confirmedIds: string[] = [];
+    const failedById = new Map<string, string>();
+
+    for (const event of selectedOverdueEvents) {
+      const draft = overdueDrafts[event.id] ?? createOverdueConfirmDraft(event, accounts);
+
+      try {
+        await apiFetch("/api/dashboard/confirm", {
+          method: "POST",
+          body: JSON.stringify({
+            forecastEventId: event.id,
+            amount: draft.amount,
+            accountId: draft.accountId || undefined,
+          }),
+        });
+        confirmedIds.push(event.id);
+      } catch (error) {
+        failedById.set(event.id, getErrorMessage(error));
+      }
+    }
+
+    setOverdueDrafts((current) => {
+      const next = { ...current };
+
+      for (const eventId of confirmedIds) {
+        delete next[eventId];
+      }
+
+      for (const [eventId, error] of failedById) {
+        const event = overdueForecast.find((item) => item.id === eventId);
+        const existing = current[eventId] ?? (event ? createOverdueConfirmDraft(event, accounts) : null);
+        if (existing) {
+          next[eventId] = {
+            ...existing,
+            selected: true,
+            error,
+          };
+        }
+      }
+
+      return next;
+    });
+    setHiddenOverdueIds((ids) => Array.from(new Set([...ids, ...confirmedIds])));
+    setDismissedOverdueSignature(failedById.size > 0 ? null : visibleOverdueSignature);
+    setIsBatchConfirming(false);
     startTransition(() => setReloadKey((value) => value + 1));
   };
 
@@ -231,6 +326,18 @@ export function DashboardPage() {
             {yellowForecasts
               .map((forecast) => `${forecast.accountName}（${formatDateWithYear(forecast.firstNegativeDate)}）`)
               .join("、")}
+          </div>
+        </Card>
+      ) : null}
+      {visibleOverdueForecast.length > 0 && !isOverdueDialogOpen ? (
+        <Card className="border-yellow-400/30 bg-yellow-900/70">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="break-words text-sm font-medium text-yellow-100">
+              ⏳ 予定日超過の未確定イベントが {visibleOverdueForecast.length} 件あります
+            </div>
+            <Button variant="ghost" onClick={() => setDismissedOverdueSignature(null)}>
+              確認する
+            </Button>
           </div>
         </Card>
       ) : null}
@@ -384,20 +491,139 @@ export function DashboardPage() {
       </Card>
 
       <Dialog
+        open={isOverdueDialogOpen}
+        onOpenChange={(open) => {
+          setDismissedOverdueSignature(open ? null : visibleOverdueSignature);
+        }}
+      >
+        <DialogContent className="w-[min(96vw,72rem)]">
+          <DialogTitle className="text-lg font-semibold">予定日超過イベントを確認</DialogTitle>
+          <DialogDescription className="mt-2 text-sm text-white/60">
+            予定日を過ぎた未確定イベントです。予定額と実績額が一致するとは限らないため、実際の金額と対象口座を確認して確定してください。
+          </DialogDescription>
+          <div className="mt-6">
+            <TableWrapper className="max-h-[55dvh] overflow-y-auto rounded-xl border border-white/10">
+              <Table className="min-w-[58rem]">
+                <thead>
+                  <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] text-white/45">
+                    <th className="px-3 py-3">選択</th>
+                    <th className="px-3 py-3">日付</th>
+                    <th className="px-3 py-3">説明</th>
+                    <th className="px-3 py-3">種別</th>
+                    <th className="px-3 py-3">金額</th>
+                    <th className="px-3 py-3">対象口座</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleOverdueForecast.map((event) => {
+                    const draft = overdueDrafts[event.id] ?? createOverdueConfirmDraft(event, accounts);
+
+                    return (
+                      <tr key={event.id} className="border-b border-white/5 align-top">
+                        <td className="px-3 py-3">
+                          <input
+                            type="checkbox"
+                            aria-label={`${event.description} を確定対象にする`}
+                            checked={draft.selected}
+                            onChange={(changeEvent) =>
+                              updateOverdueDraft(event, {
+                                selected: changeEvent.target.checked,
+                              })}
+                            className="h-4 w-4 rounded border-white/20 bg-black/20"
+                            disabled={isBatchConfirming}
+                          />
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-3 text-white/70">
+                          {formatDateWithYear(event.date)}
+                        </td>
+                        <td className="min-w-48 px-3 py-3">
+                          <div className="break-words">{event.description}</div>
+                          {draft.error ? (
+                            <div role="alert" className="mt-2 break-words text-xs text-pink-300">
+                              {draft.error}
+                            </div>
+                          ) : null}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-3">
+                          <span className={event.type === "income" ? "text-sky-300" : "text-pink-300"}>
+                            {event.type === "income" ? "収入" : "支出"}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3">
+                          <Input
+                            type="number"
+                            inputMode="decimal"
+                            step={event.currencyCode === "JPY" ? 1 : 0.01}
+                            aria-label={`${event.description} の実際の金額`}
+                            value={formatCurrencyInputValue(draft.amount, event.currencyCode)}
+                            onChange={(changeEvent) =>
+                              updateOverdueDraft(event, {
+                                amount: parseCurrencyInputValue(changeEvent.target.value, event.currencyCode),
+                              })}
+                            className="w-36"
+                            disabled={isBatchConfirming}
+                          />
+                        </td>
+                        <td className="px-3 py-3">
+                          <Select
+                            aria-label={`${event.description} の対象口座`}
+                            value={draft.accountId}
+                            onChange={(changeEvent) =>
+                              updateOverdueDraft(event, {
+                                accountId: changeEvent.target.value,
+                              })}
+                            className="w-48"
+                            disabled={isBatchConfirming}
+                          >
+                            <option value="">イベント設定口座を使用</option>
+                            {accounts
+                              .filter((account) => account.currencyCode === event.currencyCode)
+                              .map((account) => (
+                                <option key={account.id} value={account.id}>
+                                  {account.name}
+                                </option>
+                              ))}
+                          </Select>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </Table>
+            </TableWrapper>
+            <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+              <div className="text-sm text-white/60">
+                選択中 {selectedOverdueCount} / {visibleOverdueForecast.length} 件
+              </div>
+              <div className="flex flex-wrap justify-end gap-3">
+                <Button
+                  variant="ghost"
+                  onClick={() => setDismissedOverdueSignature(visibleOverdueSignature)}
+                  disabled={isBatchConfirming}
+                >
+                  あとで
+                </Button>
+                <Button onClick={handleBatchConfirm} disabled={isBatchConfirming || selectedOverdueCount === 0}>
+                  選択した {selectedOverdueCount} 件を確定
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
         open={Boolean(selectedEvent)}
         onOpenChange={(open) => {
-          if (open || isOverdueConfirm) {
-            return;
+          if (!open) {
+            closeConfirm();
           }
-          closeConfirm();
         }}
       >
         <DialogContent>
           <DialogTitle className="text-lg font-semibold">予測イベントを確定</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
-            {isOverdueConfirm
-              ? "予定日を過ぎた未確定イベントです。予定額と実績額が一致するとは限らないため、実際の金額と対象口座を確認して確定してください。"
-              : "予定額と実績額が一致するとは限らないため、自動確定せず手動で確認します。必要なら金額と口座を変更できます。"}
+            予定額と実績額が一致するとは限らないため、自動確定せず手動で確認します。必要なら金額と口座を変更できます。
           </DialogDescription>
           <div className="mt-6 grid gap-4">
             <div className="rounded-2xl bg-black/20 p-4 text-sm">
@@ -444,11 +670,9 @@ export function DashboardPage() {
               </Select>
             </label>
             <div className="flex justify-end gap-3">
-              {isOverdueConfirm ? null : (
-                <DialogClose asChild>
-                  <Button variant="ghost">閉じる</Button>
-                </DialogClose>
-              )}
+              <DialogClose asChild>
+                <Button variant="ghost">閉じる</Button>
+              </DialogClose>
               <Button onClick={handleConfirm}>確定する</Button>
             </div>
           </div>


### PR DESCRIPTION
## 背景

プロダクトレビュー（20260702-review.md）指摘 A-2(2)/C-2（owner 合意: 「同じ日付で複数件あったときダイアログがその分出てくるのは煩わしいので、1ダイアログにまとめられるようにするのは良い」）。従来は overdue イベントごとに閉じられないモーダルが出て、1件確定するたびにダッシュボード全体を再取得していた。手動確定という設計哲学は維持する。

## 変更内容

- **一括確認ダイアログ**: ダッシュボード表示時に overdue があれば自動で開く。全イベントを行リスト表示し、行ごとにチェックボックス（デフォルト全選択）・金額（通貨対応のインライン編集）・対象口座（通貨一致口座のみ）を編集可能。「選択した N 件を確定」で逐次 POST、**再読込は全件処理後に1回だけ**
- **失敗行の扱い**: 確定に失敗した行はエラーメッセージ付きで残し、他の行は継続。失敗が残る場合ダイアログは開いたまま
- **「あとで」**: ダイアログを閉じられるようにし、滞留が残る間は「⏳ 予定日超過の未確定イベントが N 件あります」バナー + 「確認する」ボタンを表示（リロードしても滞留はサーバー由来なので消えない）
- 将来イベント用の単一確定ダイアログ（テーブルの確定ボタン）は従来どおり。overdue の強制モーダル経路は削除

## 検証

- `make lint` / `make typecheck` / `make test-unit` / `make test-e2e`（56件）通過
- e2e/dashboard.spec.ts の overdue テストを新 UX に書き換え（自動オープン → あとで → バナー表示 → 再オープン → 一括確定 → 残高・取引反映）
- confirm-flow シナリオは将来イベント経路のみで overdue 非依存を確認済み
- 変更は frontend と e2e のみ（backend / MCP 変更なし）

Implemented-by: Codex (gpt-5.5) / Reviewed-by: Claude (Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)