### PR TITLE
feat: 定期振替を追加し口座別の残高予測に反映

### DIFF
--- a/e2e/helpers/db-runner.ts
+++ b/e2e/helpers/db-runner.ts
@@ -30,12 +30,13 @@ type DbCommand =
     action: "seedRecurringItem";
     payload: {
       name?: string;
-      type?: "income" | "expense";
+      type?: "income" | "expense" | "transfer";
       amount?: number;
       dayOfMonth?: number;
       startDate?: string | null;
       endDate?: string | null;
       accountId: string;
+      transferToAccountId?: string | null;
       enabled?: boolean;
       sortOrder?: number;
     };
@@ -135,6 +136,7 @@ async function run(command: DbCommand) {
         startDate: command.payload.startDate ? new Date(command.payload.startDate) : null,
         endDate: command.payload.endDate ? new Date(command.payload.endDate) : null,
         accountId: command.payload.accountId,
+        transferToAccountId: command.payload.transferToAccountId ?? null,
         enabled: command.payload.enabled ?? true,
         sortOrder: command.payload.sortOrder ?? 0,
       });

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -32,12 +32,13 @@ type DbCommand =
     action: "seedRecurringItem";
     payload: {
       name?: string;
-      type?: "income" | "expense";
+      type?: "income" | "expense" | "transfer";
       amount?: number;
       dayOfMonth?: number;
       startDate?: string | null;
       endDate?: string | null;
       accountId: string;
+      transferToAccountId?: string | null;
       enabled?: boolean;
       sortOrder?: number;
     };
@@ -263,12 +264,13 @@ export async function seedAccount(overrides: {
 
 export async function seedRecurringItem(overrides: {
   name?: string;
-  type?: "income" | "expense";
+  type?: "income" | "expense" | "transfer";
   amount?: number;
   dayOfMonth?: number;
   startDate?: Date | null;
   endDate?: Date | null;
   accountId: string;
+  transferToAccountId?: string | null;
   enabled?: boolean;
   sortOrder?: number;
 }): Promise<RecurringItem> {
@@ -282,6 +284,7 @@ export async function seedRecurringItem(overrides: {
       startDate: serializeNullableDate(overrides.startDate),
       endDate: serializeNullableDate(overrides.endDate),
       accountId: overrides.accountId,
+      transferToAccountId: overrides.transferToAccountId,
       enabled: overrides.enabled,
       sortOrder: overrides.sortOrder,
     },

--- a/e2e/scenarios/forecast-flow.spec.ts
+++ b/e2e/scenarios/forecast-flow.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { fillAndSubmitAccountForm, navigateTo, waitForReload } from "../helpers/actions";
 import { resetDatabase } from "../helpers/db";
-import { formatCurrency, getForecastDayOfMonth } from "../helpers/scenario";
+import { formatCurrency, getForecastDayOfMonth, getFutureDate } from "../helpers/scenario";
 
 test.beforeEach(async () => {
   await resetDatabase();
@@ -54,4 +54,69 @@ test("reflects newly created accounts and recurring items on the dashboard forec
   await expect(forecastTable.getByRole("cell", { name: "給料" }).first()).toBeVisible();
   await expect(forecastTable.getByRole("cell", { name: "家賃" }).first()).toBeVisible();
   await expect(page.locator("svg.recharts-surface")).toBeVisible();
+});
+
+test("reflects recurring transfers in account forecasts and confirms them as transfer transactions", async ({ page }) => {
+  const eventDate = getFutureDate(7);
+  const dayOfMonth = Number(eventDate.slice(8, 10));
+
+  await navigateTo(page, "/accounts");
+  await fillAndSubmitAccountForm(page, {
+    name: "給与口座",
+    balance: 300000,
+    sortOrder: 1,
+  });
+  await waitForReload(page);
+  await fillAndSubmitAccountForm(page, {
+    name: "引落口座",
+    balance: 10000,
+    sortOrder: 2,
+  });
+  await waitForReload(page);
+
+  await navigateTo(page, "/recurring");
+  await page.getByRole("button", { name: "固定収支を追加" }).click();
+  await page.getByLabel("カテゴリ名 *").first().fill("資金移動");
+  await page.getByLabel("種別").first().selectOption("transfer");
+  await page.getByLabel("金額 (円)").first().fill("100000");
+  await page.getByLabel("毎月の発生日").first().fill(String(dayOfMonth));
+  await page.getByLabel("開始日").first().fill(eventDate);
+  await page.getByLabel("終了日").first().fill(eventDate);
+  await page.getByLabel("振替元口座 *").selectOption({ label: "給与口座" });
+  await page.getByLabel("振替先口座 *").selectOption({ label: "引落口座" });
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  const recurringRow = page.getByRole("row", { name: /資金移動/ });
+  await expect(recurringRow).toContainText("振替");
+  await expect(recurringRow).toContainText("給与口座 → 引落口座");
+
+  await navigateTo(page, "/");
+  await expect(page.getByText("総所持金").locator("..")).toContainText(formatCurrency(310000));
+
+  await page.getByRole("button", { name: "引落口座" }).click();
+  const transferRow = page.locator("table").last().getByRole("row", { name: /資金移動/ });
+  await expect(transferRow).toContainText("振替");
+  await expect(transferRow).toContainText("給与口座 → 引落口座");
+  await expect(transferRow).toContainText(formatCurrency(110000));
+
+  await transferRow.getByRole("button", { name: "確定" }).click();
+  await expect(page.getByRole("heading", { name: "予測イベントを確定" })).toBeVisible();
+  await expect(page.getByLabel("対象口座")).toBeDisabled();
+  await page.getByRole("button", { name: "確定する" }).click();
+  await waitForReload(page);
+
+  await expect(page.locator("table").last().getByRole("cell", { name: "資金移動" })).toHaveCount(0);
+
+  await navigateTo(page, "/accounts");
+  await expect(page.getByRole("row", { name: /給与口座/ }).first()).toContainText(formatCurrency(200000));
+  await expect(page.getByRole("row", { name: /引落口座/ }).first()).toContainText(formatCurrency(110000));
+
+  await navigateTo(page, "/transactions");
+  await page.getByLabel("期間プリセット").selectOption("all");
+  await waitForReload(page);
+  const transactionRow = page.getByRole("row", { name: /資金移動/ }).first();
+  await expect(transactionRow).toContainText("振替");
+  await expect(transactionRow).toContainText("給与口座 -> 引落口座");
+  await expect(transactionRow).toContainText(formatCurrency(100000));
 });

--- a/packages/backend/src/routes/dashboard.integration.test.ts
+++ b/packages/backend/src/routes/dashboard.integration.test.ts
@@ -172,6 +172,105 @@ describe("dashboard routes", () => {
     );
   });
 
+  it("builds and confirms recurring transfer forecast events", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const source = await createAccount(testPrisma, {
+      name: "Source",
+      balance: 100000,
+      sortOrder: 1,
+    });
+    const destination = await createAccount(testPrisma, {
+      name: "Destination",
+      balance: 10000,
+      sortOrder: 2,
+    });
+    const transfer = await createRecurringItem(testPrisma, {
+      name: "Monthly Move",
+      type: "transfer",
+      amount: 30000,
+      dayOfMonth: 20,
+      accountId: source.id,
+      transferToAccountId: destination.id,
+      sortOrder: 1,
+    });
+    const forecastEventId = `recurring:${transfer.id}:2026-03`;
+
+    const dashboard = await client.get("/api/dashboard");
+    const body = await parseJson<{
+      totalBalance: number;
+      minBalance: number;
+      forecast: Array<{
+        id: string;
+        type: string;
+        balance: number;
+        accountId: string | null;
+        transferToAccountId: string | null;
+      }>;
+      accountForecasts: Array<{
+        accountId: string;
+        events: Array<{ id: string; type: string; balance: number; transferToAccountId: string | null }>;
+      }>;
+    }>(dashboard);
+
+    expect(dashboard.status).toBe(200);
+    expect(body.totalBalance).toBe(110000);
+    expect(body.minBalance).toBe(110000);
+    expect(body.forecast).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: forecastEventId,
+        type: "transfer",
+        balance: 110000,
+        accountId: source.id,
+        transferToAccountId: destination.id,
+      }),
+    ]));
+    expect(body.accountForecasts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: source.id,
+          events: expect.arrayContaining([
+            expect.objectContaining({ id: forecastEventId, type: "transfer", balance: 70000 }),
+          ]),
+        }),
+        expect.objectContaining({
+          accountId: destination.id,
+          events: expect.arrayContaining([
+            expect.objectContaining({ id: forecastEventId, type: "transfer", balance: 40000 }),
+          ]),
+        }),
+      ]),
+    );
+
+    const confirm = await client.post("/api/dashboard/confirm", {
+      forecastEventId,
+      amount: 30000,
+      accountId: destination.id,
+    });
+
+    expect(confirm.status).toBe(201);
+    const savedTransaction = await testPrisma.transaction.findFirstOrThrow({
+      where: { forecastEventId },
+    });
+    expect(savedTransaction).toMatchObject({
+      accountId: source.id,
+      transferToAccountId: destination.id,
+      type: "transfer",
+      amount: 30000,
+    });
+
+    const [savedSource, savedDestination] = await Promise.all([
+      testPrisma.account.findUniqueOrThrow({ where: { id: source.id } }),
+      testPrisma.account.findUniqueOrThrow({ where: { id: destination.id } }),
+    ]);
+    expect(savedSource.balance).toBe(70000);
+    expect(savedDestination.balance).toBe(40000);
+
+    const afterConfirm = await parseJson<{ forecast: Array<{ id: string }> }>(await client.get("/api/dashboard"));
+    expect(afterConfirm.forecast.map((event) => event.id)).not.toContain(forecastEventId);
+  });
+
   it("applies dateShiftPolicy to recurring items and credit cards without shifting manual card settlement dates", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-01T00:00:00.000Z"));

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -62,6 +62,61 @@ export const dashboardRoutes = new Hono()
         }
         return notFound(c, "Forecast event not found");
       }
+
+      if (event.type === "transfer") {
+        if (!event.accountId || !event.transferToAccountId) {
+          return c.json({ error: "Transfer forecast event requires source and destination accounts" }, 400);
+        }
+        if (event.accountId === event.transferToAccountId) {
+          return c.json({ error: "transfer accounts must be different" }, 400);
+        }
+        const sourceAccountId = event.accountId;
+        const destinationAccountId = event.transferToAccountId;
+
+        const transaction = await prisma.$transaction(async (tx) => {
+          const [sourceAccount, destinationAccount] = await Promise.all([
+            tx.account.findFirst({ where: { id: sourceAccountId, deletedAt: null } }),
+            tx.account.findFirst({ where: { id: destinationAccountId, deletedAt: null } }),
+          ]);
+
+          if (!sourceAccount) {
+            throw new BadRequestError("Source account not found");
+          }
+          if (!destinationAccount) {
+            throw new BadRequestError("Destination account not found");
+          }
+          if (
+            normalizeCurrencyCode(sourceAccount.currencyCode) !==
+            normalizeCurrencyCode(destinationAccount.currencyCode)
+          ) {
+            throw new BadRequestError("Cross-currency transfers are not supported");
+          }
+
+          await tx.account.update({
+            where: { id: sourceAccount.id },
+            data: { balance: { decrement: body.amount } },
+          });
+          await tx.account.update({
+            where: { id: destinationAccount.id },
+            data: { balance: { increment: body.amount } },
+          });
+
+          return tx.transaction.create({
+            data: {
+              accountId: sourceAccount.id,
+              transferToAccountId: destinationAccount.id,
+              forecastEventId: event.id,
+              date: new Date(`${event.date}T00:00:00.000Z`),
+              type: "transfer",
+              description: event.description,
+              amount: body.amount,
+            },
+          });
+        });
+
+        return c.json(transaction, 201);
+      }
+
       const resolvedAccountId = body.accountId ?? event.accountId ?? undefined;
       if (!resolvedAccountId) {
         return c.json({ error: "Account is required for this forecast event" }, 400);

--- a/packages/backend/src/routes/recurring-items.integration.test.ts
+++ b/packages/backend/src/routes/recurring-items.integration.test.ts
@@ -71,6 +71,100 @@ describe("recurring items routes", () => {
     expect(saved.type).toBe("income");
   });
 
+  it("creates transfer items and stores the destination account relation", async () => {
+    const source = await createAccount(testPrisma, { name: "Source" });
+    const destination = await createAccount(testPrisma, { name: "Destination" });
+
+    const response = await client.post("/api/recurring-items", {
+      name: "Monthly Move",
+      type: "transfer",
+      amount: 50000,
+      dayOfMonth: 20,
+      startDate: null,
+      endDate: null,
+      accountId: source.id,
+      transferToAccountId: destination.id,
+      enabled: true,
+      sortOrder: 3,
+    });
+
+    expect(response.status).toBe(201);
+    const created = await parseJson<{
+      id: string;
+      type: string;
+      accountId: string;
+      transferToAccountId: string;
+      transferToAccount: { name: string };
+    }>(response);
+    expect(created).toMatchObject({
+      type: "transfer",
+      accountId: source.id,
+      transferToAccountId: destination.id,
+      transferToAccount: { name: "Destination" },
+    });
+
+    const saved = await testPrisma.recurringItem.findUniqueOrThrow({
+      where: { id: created.id },
+    });
+    expect(saved.transferToAccountId).toBe(destination.id);
+  });
+
+  it("validates transfer account rules", async () => {
+    const source = await createAccount(testPrisma, { name: "Source" });
+    const destination = await createAccount(testPrisma, { name: "Destination" });
+    const usdDestination = await createAccount(testPrisma, {
+      name: "USD Destination",
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+    });
+
+    const sameAccount = await client.post("/api/recurring-items", {
+      name: "Same Account",
+      type: "transfer",
+      amount: 1000,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      accountId: source.id,
+      transferToAccountId: source.id,
+      enabled: true,
+      sortOrder: 1,
+    });
+    const crossCurrency = await client.post("/api/recurring-items", {
+      name: "Cross Currency",
+      type: "transfer",
+      amount: 1000,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      accountId: source.id,
+      transferToAccountId: usdDestination.id,
+      enabled: true,
+      sortOrder: 1,
+    });
+    const incomeWithTransferTo = await client.post("/api/recurring-items", {
+      name: "Invalid Income",
+      type: "income",
+      amount: 1000,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      accountId: source.id,
+      transferToAccountId: destination.id,
+      enabled: true,
+      sortOrder: 1,
+    });
+
+    expect(sameAccount.status).toBe(400);
+    expect(await parseJson(sameAccount)).toEqual({ error: "transfer accounts must be different" });
+    expect(crossCurrency.status).toBe(400);
+    expect(await parseJson(crossCurrency)).toEqual({ error: "Cross-currency transfers are not supported" });
+    expect(incomeWithTransferTo.status).toBe(400);
+    expect(await parseJson(incomeWithTransferTo)).toEqual({
+      error: "transferToAccountId is only allowed for transfer",
+    });
+  });
+
   it("round-trips dateShiftPolicy and preserves it when omitted on update", async () => {
     const account = await createAccount(testPrisma, { name: "Main" });
 

--- a/packages/backend/src/routes/recurring-items.ts
+++ b/packages/backend/src/routes/recurring-items.ts
@@ -1,20 +1,22 @@
 import { Hono } from "hono";
 import { z } from "zod";
+import { normalizeCurrencyCode } from "../lib/currency";
 import { fromDateOnlyString, isDateString, toDateOnlyString } from "../lib/dates";
 import { prisma } from "../lib/db";
-import { badRequest, handleRouteError, notFound } from "../lib/http";
+import { BadRequestError, badRequest, handleRouteError, notFound } from "../lib/http";
 import { int32Schema, nonNegativeInt32Schema } from "../lib/validation";
 
 const dateShiftPolicySchema = z.enum(["none", "previous", "next"]);
 
 const basePayloadSchema = z.object({
   name: z.string().min(1).max(100),
-  type: z.enum(["income", "expense"]),
+  type: z.enum(["income", "expense", "transfer"]),
   amount: nonNegativeInt32Schema(),
   dayOfMonth: z.number().int().min(1).max(31),
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
   accountId: z.string().uuid(),
+  transferToAccountId: z.string().uuid().nullish(),
   enabled: z.boolean(),
   sortOrder: int32Schema(),
 });
@@ -26,6 +28,8 @@ const createPayloadSchema = basePayloadSchema.extend({
 const updatePayloadSchema = basePayloadSchema.extend({
   dateShiftPolicy: dateShiftPolicySchema.optional(),
 });
+
+type RecurringPayload = z.infer<typeof createPayloadSchema> | z.infer<typeof updatePayloadSchema>;
 
 function isOptionalDateString(value: string | null) {
   return value === null || isDateString(value);
@@ -56,7 +60,7 @@ function serializeRecurringItem<T extends { startDate: Date | null; endDate: Dat
 }
 
 function buildRecurringItemData(
-  body: z.infer<typeof createPayloadSchema> | z.infer<typeof updatePayloadSchema>,
+  body: RecurringPayload,
 ) {
   return {
     name: body.name,
@@ -66,17 +70,54 @@ function buildRecurringItemData(
     startDate: body.startDate ? fromDateOnlyString(body.startDate) : null,
     endDate: body.endDate ? fromDateOnlyString(body.endDate) : null,
     accountId: body.accountId,
+    transferToAccountId: body.type === "transfer" ? body.transferToAccountId : null,
     enabled: body.enabled,
     sortOrder: body.sortOrder,
     ...(body.dateShiftPolicy !== undefined ? { dateShiftPolicy: body.dateShiftPolicy } : {}),
   };
 }
 
+async function validateRecurringPayload(body: RecurringPayload) {
+  if (body.type !== "transfer") {
+    if (body.transferToAccountId) {
+      return "transferToAccountId is only allowed for transfer";
+    }
+    return null;
+  }
+
+  if (!body.transferToAccountId) {
+    return "transferToAccountId is required for transfer";
+  }
+
+  if (body.accountId === body.transferToAccountId) {
+    return "transfer accounts must be different";
+  }
+
+  const [sourceAccount, destinationAccount] = await Promise.all([
+    prisma.account.findFirst({ where: { id: body.accountId, deletedAt: null } }),
+    prisma.account.findFirst({ where: { id: body.transferToAccountId, deletedAt: null } }),
+  ]);
+  if (!sourceAccount) {
+    return "Source account not found";
+  }
+  if (!destinationAccount) {
+    return "Destination account not found";
+  }
+  if (
+    normalizeCurrencyCode(sourceAccount.currencyCode) !==
+    normalizeCurrencyCode(destinationAccount.currencyCode)
+  ) {
+    throw new BadRequestError("Cross-currency transfers are not supported");
+  }
+
+  return null;
+}
+
 export const recurringItemsRoutes = new Hono()
   .get("/", async (c) => {
     const items = await prisma.recurringItem.findMany({
       where: { deletedAt: null },
-      include: { account: true },
+      include: { account: true, transferToAccount: true },
       orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
     });
     return c.json(items.map(serializeRecurringItem));
@@ -88,8 +129,15 @@ export const recurringItemsRoutes = new Hono()
       if (periodError) {
         return badRequest(c, periodError);
       }
+      const validationError = await validateRecurringPayload(body);
+      if (validationError) {
+        return badRequest(c, validationError);
+      }
 
-      const item = await prisma.recurringItem.create({ data: buildRecurringItemData(body) });
+      const item = await prisma.recurringItem.create({
+        data: buildRecurringItemData(body),
+        include: { account: true, transferToAccount: true },
+      });
       return c.json(serializeRecurringItem(item), 201);
     } catch (error) {
       return handleRouteError(c, error);
@@ -102,6 +150,10 @@ export const recurringItemsRoutes = new Hono()
       if (periodError) {
         return badRequest(c, periodError);
       }
+      const validationError = await validateRecurringPayload(body);
+      if (validationError) {
+        return badRequest(c, validationError);
+      }
 
       const existing = await prisma.recurringItem.findFirst({
         where: { id: c.req.param("id"), deletedAt: null },
@@ -113,6 +165,7 @@ export const recurringItemsRoutes = new Hono()
       const item = await prisma.recurringItem.update({
         where: { id: existing.id },
         data: buildRecurringItemData(body),
+        include: { account: true, transferToAccount: true },
       });
       return c.json(serializeRecurringItem(item));
     } catch (error) {

--- a/packages/backend/src/services/forecast-core.test.ts
+++ b/packages/backend/src/services/forecast-core.test.ts
@@ -41,6 +41,7 @@ function account(overrides: Partial<Account> = {}): Account {
 
 function recurringItem(overrides: Partial<ForecastRecurringItem> = {}): ForecastRecurringItem {
   const linkedAccount = overrides.account ?? null;
+  const linkedTransferToAccount = overrides.transferToAccount ?? null;
   return {
     id: "recurring-1",
     name: "Recurring",
@@ -48,6 +49,7 @@ function recurringItem(overrides: Partial<ForecastRecurringItem> = {}): Forecast
     amount: 100,
     dayOfMonth: 1,
     accountId: linkedAccount?.id ?? null,
+    transferToAccountId: linkedTransferToAccount?.id ?? null,
     enabled: true,
     startDate: null,
     endDate: null,
@@ -57,6 +59,7 @@ function recurringItem(overrides: Partial<ForecastRecurringItem> = {}): Forecast
     createdAt: timestamp,
     updatedAt: timestamp,
     account: linkedAccount,
+    transferToAccount: linkedTransferToAccount,
     ...overrides,
   };
 }
@@ -320,6 +323,101 @@ describe("buildDashboardCore", () => {
 
     expect(result.forecast.map((event) => event.id)).not.toContain("recurring:confirmed:2026-03");
     expect(result.overdueForecast.map((event) => event.id)).not.toContain("recurring:confirmed:2026-03");
+  });
+
+  it("keeps recurring transfers neutral in total forecast and applies them to account forecasts", () => {
+    const source = account({ id: "source", name: "Source", balance: 500, sortOrder: 1 });
+    const destination = account({ id: "destination", name: "Destination", balance: 100, sortOrder: 2 });
+    const transfer = recurringItem({
+      id: "monthly-transfer",
+      name: "Monthly Transfer",
+      type: "transfer" as RecurringItemType,
+      amount: 200,
+      dayOfMonth: 10,
+      account: source,
+      accountId: source.id,
+      transferToAccount: destination,
+      transferToAccountId: destination.id,
+    });
+
+    const result = buildDashboard({
+      accounts: [source, destination],
+      recurringItems: [transfer],
+      today: "2026-03-01",
+      forecastMonths: 1,
+    });
+
+    expect(result.totalBalance).toBe(600);
+    expect(result.minBalance).toBe(600);
+    expect(result.nextIncome).toBeNull();
+    expect(result.nextExpense).toBeNull();
+    expect(result.forecast).toEqual([
+      expect.objectContaining({
+        id: "recurring:monthly-transfer:2026-03",
+        type: "transfer",
+        balance: 600,
+        accountId: source.id,
+        transferToAccountId: destination.id,
+      }),
+    ]);
+    expect(result.accountForecasts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: source.id,
+          minBalance: 300,
+          events: [
+            expect.objectContaining({
+              id: "recurring:monthly-transfer:2026-03",
+              type: "transfer",
+              balance: 300,
+              accountId: source.id,
+              transferToAccountId: destination.id,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          accountId: destination.id,
+          minBalance: 100,
+          events: [
+            expect.objectContaining({
+              id: "recurring:monthly-transfer:2026-03",
+              type: "transfer",
+              balance: 300,
+              accountId: source.id,
+              transferToAccountId: destination.id,
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("excludes recurring transfer forecast events that already have confirmed transactions", () => {
+    const source = account({ id: "source", name: "Source", balance: 500, sortOrder: 1 });
+    const destination = account({ id: "destination", name: "Destination", balance: 100, sortOrder: 2 });
+    const transfer = recurringItem({
+      id: "confirmed-transfer",
+      type: "transfer" as RecurringItemType,
+      amount: 200,
+      dayOfMonth: 10,
+      account: source,
+      accountId: source.id,
+      transferToAccount: destination,
+      transferToAccountId: destination.id,
+    });
+
+    const result = buildDashboard({
+      accounts: [source, destination],
+      recurringItems: [transfer],
+      confirmedTransactions: [{ forecastEventId: "recurring:confirmed-transfer:2026-03", amount: 200 }],
+      today: "2026-03-01",
+      forecastMonths: 1,
+    });
+
+    expect(result.forecast.map((event) => event.id)).not.toContain("recurring:confirmed-transfer:2026-03");
+    expect(result.accountForecasts.flatMap((forecast) => forecast.events.map((event) => event.id))).not.toContain(
+      "recurring:confirmed-transfer:2026-03",
+    );
   });
 
   it("splits events before today into overdueForecast and keeps today or later in forecast", () => {

--- a/packages/backend/src/services/forecast-core.ts
+++ b/packages/backend/src/services/forecast-core.ts
@@ -29,12 +29,13 @@ import { buildLoanForecastEvents } from "./loans";
 export interface RawForecastEvent {
   id: string;
   date: string;
-  type: "income" | "expense";
+  type: "income" | "expense" | "transfer";
   description: string;
   amount: number;
   currencyCode?: SupportedCurrencyCode;
   exchangeRateToJpy?: number;
   accountId: string | null;
+  transferToAccountId?: string | null;
   sourcePriority: number;
   sortOrder: number;
 }
@@ -46,6 +47,7 @@ type CurrencyAccount = {
 
 export type ForecastRecurringItem = RecurringItem & {
   account: Account | null;
+  transferToAccount: Account | null;
 };
 
 export type ForecastCreditCard = CreditCard & {
@@ -80,6 +82,12 @@ function createCreditCardCardId(cardId: string, yearMonth: string) {
   return `credit-card:${cardId}:${yearMonth}`;
 }
 
+const eventTypeOrder: Record<RawForecastEvent["type"], number> = {
+  income: 0,
+  transfer: 1,
+  expense: 2,
+};
+
 export function sortEvents(events: RawForecastEvent[]) {
   return events.sort((left, right) => {
     if (left.date !== right.date) {
@@ -87,7 +95,7 @@ export function sortEvents(events: RawForecastEvent[]) {
     }
 
     if (left.type !== right.type) {
-      return left.type === "income" ? -1 : 1;
+      return eventTypeOrder[left.type] - eventTypeOrder[right.type];
     }
 
     if (left.sourcePriority !== right.sourcePriority) {
@@ -103,7 +111,15 @@ export function sortEvents(events: RawForecastEvent[]) {
 }
 
 export function applyEvent(balance: number, event: Pick<RawForecastEvent, "type" | "amount">) {
-  return balance + (event.type === "income" ? event.amount : -event.amount);
+  if (event.type === "income") {
+    return balance + event.amount;
+  }
+
+  if (event.type === "expense") {
+    return balance - event.amount;
+  }
+
+  return balance;
 }
 
 function getEventAmountJpy(event: Pick<RawForecastEvent, "amount" | "currencyCode" | "exchangeRateToJpy">) {
@@ -196,6 +212,7 @@ export function buildDashboardCore({
         amount: item.amount,
         ...getAccountCurrency(item.account),
         accountId: item.accountId,
+        transferToAccountId: item.transferToAccountId,
         sourcePriority: 10,
         sortOrder: item.sortOrder,
       });
@@ -278,6 +295,7 @@ export function buildDashboardCore({
       balanceJpy: runningOverdueBalance,
       currencyCode,
       accountId: event.accountId,
+      transferToAccountId: event.transferToAccountId,
     });
   }
 
@@ -308,36 +326,24 @@ export function buildDashboardCore({
     ]),
   );
 
-  for (const event of futureEvents) {
-    const amountJpy = getEventAmountJpy(event);
-    const currencyCode = event.currencyCode ?? DEFAULT_CURRENCY_CODE;
-    runningTotalBalance = applyEvent(runningTotalBalance, { type: event.type, amount: amountJpy });
-    minBalance = Math.min(minBalance, runningTotalBalance);
-
-    forecast.push({
-      id: event.id,
-      date: event.date,
-      type: event.type,
-      description: event.description,
-      amount: event.amount,
-      amountJpy,
-      balance: runningTotalBalance,
-      balanceJpy: runningTotalBalance,
-      currencyCode,
-      accountId: event.accountId,
-    });
-
-    if (!event.accountId) {
-      continue;
+  const appendAccountEvent = (
+    accountId: string | null | undefined,
+    event: RawForecastEvent,
+    balanceDelta: number,
+    amountJpy: number,
+    currencyCode: SupportedCurrencyCode,
+  ) => {
+    if (!accountId) {
+      return;
     }
 
-    const accountState = accountStates.get(event.accountId);
+    const accountState = accountStates.get(accountId);
     if (!accountState) {
-      continue;
+      return;
     }
 
-    accountState.runningBalance = applyEvent(accountState.runningBalance, event);
-    accountState.runningRealBalance = applyEvent(accountState.runningRealBalance, event);
+    accountState.runningBalance += balanceDelta;
+    accountState.runningRealBalance += balanceDelta;
     if (accountState.runningRealBalance < 0) {
       accountState.willBeRealNegative = true;
     }
@@ -358,7 +364,43 @@ export function buildDashboardCore({
       balanceJpy: toJpy(accountState.runningBalance, accountState),
       currencyCode,
       accountId: event.accountId,
+      transferToAccountId: event.transferToAccountId,
     });
+  };
+
+  for (const event of futureEvents) {
+    const amountJpy = getEventAmountJpy(event);
+    const currencyCode = event.currencyCode ?? DEFAULT_CURRENCY_CODE;
+    runningTotalBalance = applyEvent(runningTotalBalance, { type: event.type, amount: amountJpy });
+    minBalance = Math.min(minBalance, runningTotalBalance);
+
+    forecast.push({
+      id: event.id,
+      date: event.date,
+      type: event.type,
+      description: event.description,
+      amount: event.amount,
+      amountJpy,
+      balance: runningTotalBalance,
+      balanceJpy: runningTotalBalance,
+      currencyCode,
+      accountId: event.accountId,
+      transferToAccountId: event.transferToAccountId,
+    });
+
+    if (event.type === "transfer") {
+      appendAccountEvent(event.accountId, event, -event.amount, amountJpy, currencyCode);
+      appendAccountEvent(event.transferToAccountId, event, event.amount, amountJpy, currencyCode);
+      continue;
+    }
+
+    appendAccountEvent(
+      event.accountId,
+      event,
+      event.type === "income" ? event.amount : -event.amount,
+      amountJpy,
+      currencyCode,
+    );
   }
 
   const accountForecasts: AccountForecast[] = Array.from(accountStates.values()).map((state) => ({

--- a/packages/backend/src/services/forecast.test.ts
+++ b/packages/backend/src/services/forecast.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { applyEvent, sortEvents } from "./forecast";
 
 describe("sortEvents", () => {
-  it("sorts by date, income first, source priority, sort order, and description", () => {
+  it("sorts by date, income, transfer, expense, source priority, sort order, and description", () => {
     const sorted = sortEvents([
       {
         id: "late-date",
@@ -45,6 +45,17 @@ describe("sortEvents", () => {
         sortOrder: 9,
       },
       {
+        id: "transfer-before-expense",
+        date: "2026-03-14",
+        type: "transfer",
+        description: "Move",
+        amount: 10,
+        accountId: "account-1",
+        transferToAccountId: "account-2",
+        sourcePriority: 99,
+        sortOrder: 99,
+      },
+      {
         id: "income-first",
         date: "2026-03-14",
         type: "income",
@@ -58,6 +69,7 @@ describe("sortEvents", () => {
 
     expect(sorted.map((event) => event.id)).toEqual([
       "income-first",
+      "transfer-before-expense",
       "source-priority",
       "sort-order",
       "description-a",
@@ -67,8 +79,9 @@ describe("sortEvents", () => {
 });
 
 describe("applyEvent", () => {
-  it("adds income and subtracts expense", () => {
+  it("adds income, subtracts expense, and keeps transfer neutral", () => {
     expect(applyEvent(1000, { type: "income", amount: 300 })).toBe(1300);
     expect(applyEvent(1000, { type: "expense", amount: 300 })).toBe(700);
+    expect(applyEvent(1000, { type: "transfer", amount: 300 })).toBe(1000);
   });
 });

--- a/packages/backend/src/services/forecast.ts
+++ b/packages/backend/src/services/forecast.ts
@@ -21,7 +21,7 @@ export async function buildDashboard(
       }),
       prisma.recurringItem.findMany({
         where: { deletedAt: null, enabled: true },
-        include: { account: true },
+        include: { account: true, transferToAccount: true },
         orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
       }),
       prisma.creditCard.findMany({

--- a/packages/db/prisma/migrations/20260704010000_add_recurring_transfers/migration.sql
+++ b/packages/db/prisma/migrations/20260704010000_add_recurring_transfers/migration.sql
@@ -1,0 +1,8 @@
+ALTER TYPE "RecurringItemType" ADD VALUE 'transfer';
+
+ALTER TABLE "recurring_items"
+  ADD COLUMN "transfer_to_account_id" UUID;
+
+ALTER TABLE "recurring_items"
+  ADD CONSTRAINT "recurring_items_transfer_to_account_id_fkey"
+  FOREIGN KEY ("transfer_to_account_id") REFERENCES "accounts"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -13,6 +13,7 @@ datasource db {
 enum RecurringItemType {
   income
   expense
+  transfer
 }
 
 enum TransactionType {
@@ -34,43 +35,46 @@ enum LoanPaymentMethod {
 }
 
 model Account {
-  id                String        @id @default(uuid()) @db.Uuid
-  name              String        @db.VarChar(100)
-  balance           Int
-  balanceOffset     Int           @default(0) @map("balance_offset")
-  lastReconciledAt  DateTime?      @map("last_reconciled_at")
-  currencyCode      String        @default("JPY") @map("currency_code") @db.VarChar(3)
-  exchangeRateToJpy Float         @default(1) @map("exchange_rate_to_jpy")
-  exchangeRateUpdatedAt DateTime  @default(now()) @map("exchange_rate_updated_at")
-  sortOrder         Int           @map("sort_order")
-  deletedAt         DateTime?     @map("deleted_at")
-  createdAt         DateTime      @default(now()) @map("created_at")
-  updatedAt         DateTime      @updatedAt @map("updated_at")
-  transactions      Transaction[] @relation("account_transactions")
-  incomingTransfers Transaction[] @relation("transfer_account_transactions")
-  recurringItems    RecurringItem[]
-  creditCards       CreditCard[]
-  loans             Loan[]
+  id                         String          @id @default(uuid()) @db.Uuid
+  name                       String          @db.VarChar(100)
+  balance                    Int
+  balanceOffset              Int             @default(0) @map("balance_offset")
+  lastReconciledAt           DateTime?       @map("last_reconciled_at")
+  currencyCode               String          @default("JPY") @map("currency_code") @db.VarChar(3)
+  exchangeRateToJpy          Float           @default(1) @map("exchange_rate_to_jpy")
+  exchangeRateUpdatedAt      DateTime        @default(now()) @map("exchange_rate_updated_at")
+  sortOrder                  Int             @map("sort_order")
+  deletedAt                  DateTime?       @map("deleted_at")
+  createdAt                  DateTime        @default(now()) @map("created_at")
+  updatedAt                  DateTime        @updatedAt @map("updated_at")
+  transactions               Transaction[]   @relation("account_transactions")
+  incomingTransfers          Transaction[]   @relation("transfer_account_transactions")
+  recurringItems             RecurringItem[] @relation("recurring_item_account")
+  incomingRecurringTransfers RecurringItem[] @relation("recurring_item_transfer_to_account")
+  creditCards                CreditCard[]
+  loans                      Loan[]
 
   @@map("accounts")
 }
 
 model RecurringItem {
-  id              String          @id @default(uuid()) @db.Uuid
-  name            String          @db.VarChar(100)
-  type            RecurringItemType
-  amount          Int
-  dayOfMonth      Int             @map("day_of_month")
-  accountId       String?         @map("account_id") @db.Uuid
-  enabled         Boolean         @default(true)
-  startDate       DateTime?       @map("start_date") @db.Date
-  endDate         DateTime?       @map("end_date") @db.Date
-  dateShiftPolicy DateShiftPolicy @default(none) @map("date_shift_policy")
-  sortOrder       Int             @map("sort_order")
-  deletedAt       DateTime?       @map("deleted_at")
-  createdAt       DateTime        @default(now()) @map("created_at")
-  updatedAt       DateTime        @updatedAt @map("updated_at")
-  account         Account?        @relation(fields: [accountId], references: [id])
+  id                  String            @id @default(uuid()) @db.Uuid
+  name                String            @db.VarChar(100)
+  type                RecurringItemType
+  amount              Int
+  dayOfMonth          Int               @map("day_of_month")
+  accountId           String?           @map("account_id") @db.Uuid
+  transferToAccountId String?           @map("transfer_to_account_id") @db.Uuid
+  enabled             Boolean           @default(true)
+  startDate           DateTime?         @map("start_date") @db.Date
+  endDate             DateTime?         @map("end_date") @db.Date
+  dateShiftPolicy     DateShiftPolicy   @default(none) @map("date_shift_policy")
+  sortOrder           Int               @map("sort_order")
+  deletedAt           DateTime?         @map("deleted_at")
+  createdAt           DateTime          @default(now()) @map("created_at")
+  updatedAt           DateTime          @updatedAt @map("updated_at")
+  account             Account?          @relation("recurring_item_account", fields: [accountId], references: [id])
+  transferToAccount   Account?          @relation("recurring_item_transfer_to_account", fields: [transferToAccountId], references: [id])
 
   @@map("recurring_items")
 }

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -24,13 +24,14 @@ export async function createRecurringItem(
   prisma: TestPrisma,
   data: {
     name: string;
-    type?: "income" | "expense";
+    type?: "income" | "expense" | "transfer";
     amount?: number;
     dayOfMonth?: number;
     startDate?: Date | null;
     endDate?: Date | null;
     dateShiftPolicy?: "none" | "previous" | "next";
     accountId: string;
+    transferToAccountId?: string | null;
     enabled?: boolean;
     sortOrder?: number;
     deletedAt?: Date | null;
@@ -46,6 +47,7 @@ export async function createRecurringItem(
       endDate: data.endDate ?? null,
       dateShiftPolicy: data.dateShiftPolicy ?? "none",
       accountId: data.accountId,
+      transferToAccountId: data.transferToAccountId ?? null,
       enabled: data.enabled ?? true,
       sortOrder: data.sortOrder ?? 0,
       deletedAt: data.deletedAt ?? null,

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -86,6 +86,46 @@ function getDefaultConfirmAccountId(event: ForecastEvent, accounts: Account[]) {
   return event.accountId ?? fallbackAccount?.id ?? "";
 }
 
+function isTransferEvent(event: ForecastEvent | null | undefined) {
+  return event?.type === "transfer";
+}
+
+function getForecastTypeLabel(type: ForecastEvent["type"]) {
+  if (type === "income") {
+    return "収入";
+  }
+
+  if (type === "expense") {
+    return "支出";
+  }
+
+  return "振替";
+}
+
+function getForecastTypeClassName(type: ForecastEvent["type"]) {
+  if (type === "income") {
+    return "text-sky-300";
+  }
+
+  if (type === "expense") {
+    return "text-pink-300";
+  }
+
+  return "text-amber-300";
+}
+
+function getAccountName(accounts: Account[], accountId: string | null | undefined) {
+  return accountId ? accounts.find((account) => account.id === accountId)?.name ?? "未設定" : "-";
+}
+
+function formatForecastAccounts(event: ForecastEvent, accounts: Account[]) {
+  if (event.type === "transfer") {
+    return `${getAccountName(accounts, event.accountId)} → ${getAccountName(accounts, event.transferToAccountId)}`;
+  }
+
+  return getAccountName(accounts, event.accountId);
+}
+
 function createOverdueConfirmDraft(event: ForecastEvent, accounts: Account[]): OverdueConfirmDraft {
   return {
     selected: true,
@@ -245,7 +285,7 @@ export function DashboardPage() {
       body: JSON.stringify({
         forecastEventId: selectedEvent.id,
         amount: confirmAmount,
-        accountId: accountId || undefined,
+        accountId: selectedEvent.type === "transfer" ? undefined : accountId || undefined,
       }),
     });
 
@@ -271,7 +311,7 @@ export function DashboardPage() {
           body: JSON.stringify({
             forecastEventId: event.id,
             amount: draft.amount,
-            accountId: draft.accountId || undefined,
+            accountId: event.type === "transfer" ? undefined : draft.accountId || undefined,
           }),
         });
         confirmedIds.push(event.id);
@@ -461,8 +501,8 @@ export function DashboardPage() {
                   <tr key={event.id} className="border-b border-white/5">
                     <td className="px-3 py-3 text-white/70">{formatDateWithYear(event.date)}</td>
                     <td className="px-3 py-3">
-                      <span className={event.type === "income" ? "text-sky-300" : "text-pink-300"}>
-                        {event.type === "income" ? "収入" : "支出"}
+                      <span className={getForecastTypeClassName(event.type)}>
+                        {getForecastTypeLabel(event.type)}
                       </span>
                     </td>
                     <td className="px-3 py-3">{event.description}</td>
@@ -475,7 +515,7 @@ export function DashboardPage() {
                         : formatCurrency(event.balanceJpy)}
                     </td>
                     <td className="px-3 py-3">
-                      {accounts.find((account) => account.id === event.accountId)?.name ?? "-"}
+                      {formatForecastAccounts(event, accounts)}
                     </td>
                     <td className="px-3 py-3 text-right">
                       <Button variant="ghost" onClick={() => openConfirm(event)}>
@@ -545,8 +585,8 @@ export function DashboardPage() {
                           ) : null}
                         </td>
                         <td className="whitespace-nowrap px-3 py-3">
-                          <span className={event.type === "income" ? "text-sky-300" : "text-pink-300"}>
-                            {event.type === "income" ? "収入" : "支出"}
+                          <span className={getForecastTypeClassName(event.type)}>
+                            {getForecastTypeLabel(event.type)}
                           </span>
                         </td>
                         <td className="px-3 py-3">
@@ -565,25 +605,36 @@ export function DashboardPage() {
                           />
                         </td>
                         <td className="px-3 py-3">
-                          <Select
-                            aria-label={`${event.description} の対象口座`}
-                            value={draft.accountId}
-                            onChange={(changeEvent) =>
-                              updateOverdueDraft(event, {
-                                accountId: changeEvent.target.value,
-                              })}
-                            className="w-48"
-                            disabled={isBatchConfirming}
-                          >
-                            <option value="">イベント設定口座を使用</option>
-                            {accounts
-                              .filter((account) => account.currencyCode === event.currencyCode)
-                              .map((account) => (
-                                <option key={account.id} value={account.id}>
-                                  {account.name}
-                                </option>
-                              ))}
-                          </Select>
+                          {event.type === "transfer" ? (
+                            <Select
+                              aria-label={`${event.description} の対象口座`}
+                              value="fixed"
+                              className="w-56"
+                              disabled
+                            >
+                              <option value="fixed">{formatForecastAccounts(event, accounts)}</option>
+                            </Select>
+                          ) : (
+                            <Select
+                              aria-label={`${event.description} の対象口座`}
+                              value={draft.accountId}
+                              onChange={(changeEvent) =>
+                                updateOverdueDraft(event, {
+                                  accountId: changeEvent.target.value,
+                                })}
+                              className="w-48"
+                              disabled={isBatchConfirming}
+                            >
+                              <option value="">イベント設定口座を使用</option>
+                              {accounts
+                                .filter((account) => account.currencyCode === event.currencyCode)
+                                .map((account) => (
+                                  <option key={account.id} value={account.id}>
+                                    {account.name}
+                                  </option>
+                                ))}
+                            </Select>
+                          )}
                         </td>
                       </tr>
                     );
@@ -623,7 +674,8 @@ export function DashboardPage() {
         <DialogContent>
           <DialogTitle className="text-lg font-semibold">予測イベントを確定</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-white/60">
-            予定額と実績額が一致するとは限らないため、自動確定せず手動で確認します。必要なら金額と口座を変更できます。
+            予定額と実績額が一致するとは限らないため、自動確定せず手動で確認します。必要なら金額を変更できます。
+            収入・支出イベントでは口座も変更できます。
           </DialogDescription>
           <div className="mt-6 grid gap-4">
             <div className="rounded-2xl bg-black/20 p-4 text-sm">
@@ -658,16 +710,22 @@ export function DashboardPage() {
             </label>
             <label className="grid gap-2 text-sm">
               <span>対象口座</span>
-              <Select value={accountId} onChange={(event) => updateConfirmDraft({ accountId: event.target.value })}>
-                <option value="">イベント設定口座を使用</option>
-                {accounts
-                  .filter((account) => !selectedEvent || account.currencyCode === selectedEvent.currencyCode)
-                  .map((account) => (
-                    <option key={account.id} value={account.id}>
-                      {account.name}
-                    </option>
-                  ))}
-              </Select>
+              {isTransferEvent(selectedEvent) && selectedEvent ? (
+                <Select value="fixed" disabled>
+                  <option value="fixed">{formatForecastAccounts(selectedEvent, accounts)}</option>
+                </Select>
+              ) : (
+                <Select value={accountId} onChange={(event) => updateConfirmDraft({ accountId: event.target.value })}>
+                  <option value="">イベント設定口座を使用</option>
+                  {accounts
+                    .filter((account) => !selectedEvent || account.currencyCode === selectedEvent.currencyCode)
+                    .map((account) => (
+                      <option key={account.id} value={account.id}>
+                        {account.name}
+                      </option>
+                    ))}
+                </Select>
+              )}
             </label>
             <div className="flex justify-end gap-3">
               <DialogClose asChild>

--- a/packages/frontend/src/routes/recurring.tsx
+++ b/packages/frontend/src/routes/recurring.tsx
@@ -1,4 +1,4 @@
-import type { Account, DateShiftPolicy, RecurringItem } from "@sui/shared";
+import type { Account, DateShiftPolicy, RecurringItem, RecurringItemType } from "@sui/shared";
 import { useState, startTransition } from "react";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
@@ -12,13 +12,14 @@ import { formatCurrency, formatDateWithYear } from "../lib/format";
 
 type RecurringForm = {
   name: string;
-  type: "income" | "expense";
+  type: RecurringItemType;
   amount: number;
   dayOfMonth: number;
   startDate: string | null;
   endDate: string | null;
   dateShiftPolicy: DateShiftPolicy;
   accountId: string;
+  transferToAccountId: string;
   enabled: boolean;
   sortOrder: number;
 };
@@ -32,6 +33,7 @@ const emptyForm: RecurringForm = {
   endDate: null,
   dateShiftPolicy: "none",
   accountId: "",
+  transferToAccountId: "",
   enabled: true,
   sortOrder: 0,
 };
@@ -60,6 +62,86 @@ function parseOptionalDate(value: string) {
   return value === "" ? null : value;
 }
 
+function getRecurringTypeLabel(type: RecurringItemType) {
+  if (type === "income") {
+    return "収入";
+  }
+
+  if (type === "expense") {
+    return "支出";
+  }
+
+  return "振替";
+}
+
+function getAccountLabel(type: RecurringItemType) {
+  if (type === "income") {
+    return "振り込み先口座 *";
+  }
+
+  if (type === "transfer") {
+    return "振替元口座 *";
+  }
+
+  return "引き落とし口座 *";
+}
+
+function getTransferDestinationAccounts(accounts: Account[], sourceAccountId: string) {
+  const sourceAccount = accounts.find((account) => account.id === sourceAccountId);
+  if (!sourceAccount) {
+    return [];
+  }
+
+  return accounts.filter(
+    (account) => account.id !== sourceAccount.id && account.currencyCode === sourceAccount.currencyCode,
+  );
+}
+
+function isTransferDestinationValid(form: RecurringForm, accounts: Account[]) {
+  if (form.type !== "transfer") {
+    return true;
+  }
+
+  return getTransferDestinationAccounts(accounts, form.accountId).some(
+    (account) => account.id === form.transferToAccountId,
+  );
+}
+
+function normalizeTransferToAccountId(form: RecurringForm, accounts: Account[]) {
+  if (form.type !== "transfer") {
+    return "";
+  }
+
+  return isTransferDestinationValid(form, accounts) ? form.transferToAccountId : "";
+}
+
+function canSaveRecurringForm(form: RecurringForm, accounts: Account[]) {
+  return (
+    form.name.trim().length > 0 &&
+    form.dayOfMonth >= 1 &&
+    form.dayOfMonth <= 31 &&
+    form.accountId !== "" &&
+    isPeriodValid(form.startDate, form.endDate) &&
+    isTransferDestinationValid(form, accounts)
+  );
+}
+
+function toRecurringPayload(form: RecurringForm) {
+  return {
+    ...form,
+    transferToAccountId: form.type === "transfer" ? form.transferToAccountId : null,
+  };
+}
+
+function formatRecurringAccounts(item: RecurringItem) {
+  const sourceName = item.account?.name ?? "未設定";
+  if (item.type !== "transfer") {
+    return sourceName;
+  }
+
+  return `${sourceName} → ${item.transferToAccount?.name ?? "未設定"}`;
+}
+
 export function RecurringPage() {
   const [reloadKey, setReloadKey] = useState(0);
   const [form, setForm] = useState(emptyForm);
@@ -77,44 +159,23 @@ export function RecurringPage() {
 
   const reload = () => startTransition(() => setReloadKey((value) => value + 1));
   const accounts = data?.accounts ?? [];
-  const canCreate =
-    form.name.trim().length > 0 &&
-    form.dayOfMonth >= 1 &&
-    form.dayOfMonth <= 31 &&
-    form.accountId !== "" &&
-    isPeriodValid(form.startDate, form.endDate);
-  const canSaveEdit =
-    editForm.name.trim().length > 0 &&
-    editForm.dayOfMonth >= 1 &&
-    editForm.dayOfMonth <= 31 &&
-    editForm.accountId !== "" &&
-    isPeriodValid(editForm.startDate, editForm.endDate);
+  const canCreate = canSaveRecurringForm(form, accounts);
+  const canSaveEdit = canSaveRecurringForm(editForm, accounts);
 
   const createItem = async () => {
     await apiFetch("/api/recurring-items", {
       method: "POST",
-      body: JSON.stringify(form),
+      body: JSON.stringify(toRecurringPayload(form)),
     });
     setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
     setCreateOpen(false);
     reload();
   };
 
-  const updateItem = async (item: RecurringItem) => {
+  const updateItem = async (item: RecurringItem, nextForm: RecurringForm) => {
     await apiFetch(`/api/recurring-items/${item.id}`, {
       method: "PUT",
-      body: JSON.stringify({
-        name: item.name,
-        type: item.type,
-        amount: item.amount,
-        dayOfMonth: item.dayOfMonth,
-        startDate: item.startDate,
-        endDate: item.endDate,
-        dateShiftPolicy: item.dateShiftPolicy,
-        accountId: item.accountId ?? "",
-        enabled: item.enabled,
-        sortOrder: item.sortOrder,
-      }),
+      body: JSON.stringify(toRecurringPayload(nextForm)),
     });
     reload();
   };
@@ -138,6 +199,7 @@ export function RecurringPage() {
       endDate: item.endDate,
       dateShiftPolicy: item.dateShiftPolicy,
       accountId: item.accountId ?? "",
+      transferToAccountId: item.transferToAccountId ?? "",
       enabled: item.enabled,
       sortOrder: item.sortOrder,
     });
@@ -153,12 +215,7 @@ export function RecurringPage() {
       return;
     }
 
-    await updateItem({
-      ...editingItem,
-      ...editForm,
-      accountId: editForm.accountId,
-      account: accounts.find((account) => account.id === editForm.accountId) ?? null,
-    });
+    await updateItem(editingItem, editForm);
     closeEdit();
   };
 
@@ -269,6 +326,8 @@ function RecurringEditModal({
   onSave: () => void;
   actionLabel?: string;
 }) {
+  const transferDestinationAccounts = getTransferDestinationAccounts(accounts, form.accountId);
+
   return (
     <div className="mt-6 grid gap-5">
       <section className="grid gap-4">
@@ -280,9 +339,22 @@ function RecurringEditModal({
         <div className="grid gap-4 md:grid-cols-3">
           <label className="grid gap-2 text-sm">
             <span>種別</span>
-            <Select value={form.type} onChange={(event) => onChange({ ...form, type: event.target.value as "income" | "expense" })}>
+            <Select
+              value={form.type}
+              onChange={(event) => {
+                const nextForm = {
+                  ...form,
+                  type: event.target.value as RecurringItemType,
+                };
+                onChange({
+                  ...nextForm,
+                  transferToAccountId: normalizeTransferToAccountId(nextForm, accounts),
+                });
+              }}
+            >
               <option value="income">収入</option>
               <option value="expense">支出</option>
+              <option value="transfer">振替</option>
             </Select>
           </label>
           <label className="grid gap-2 text-sm">
@@ -317,8 +389,17 @@ function RecurringEditModal({
       <section className="grid gap-4 border-t border-white/10 pt-4">
         <div className="text-xs uppercase tracking-[0.18em] text-white/45">口座・その他</div>
         <label className="grid gap-2 text-sm">
-          <span>{form.type === "income" ? "振り込み先口座 *" : "引き落とし口座 *"}</span>
-          <Select value={form.accountId} onChange={(event) => onChange({ ...form, accountId: event.target.value })}>
+          <span>{getAccountLabel(form.type)}</span>
+          <Select
+            value={form.accountId}
+            onChange={(event) => {
+              const nextForm = { ...form, accountId: event.target.value };
+              onChange({
+                ...nextForm,
+                transferToAccountId: normalizeTransferToAccountId(nextForm, accounts),
+              });
+            }}
+          >
             <option value="">口座を選択</option>
             {accounts.map((account) => (
               <option key={account.id} value={account.id}>
@@ -327,6 +408,23 @@ function RecurringEditModal({
             ))}
           </Select>
         </label>
+        {form.type === "transfer" ? (
+          <label className="grid gap-2 text-sm">
+            <span>振替先口座 *</span>
+            <Select
+              value={form.transferToAccountId}
+              onChange={(event) => onChange({ ...form, transferToAccountId: event.target.value })}
+              disabled={form.accountId === ""}
+            >
+              <option value="">口座を選択</option>
+              {transferDestinationAccounts.map((account) => (
+                <option key={account.id} value={account.id}>
+                  {account.name}
+                </option>
+              ))}
+            </Select>
+          </label>
+        ) : null}
         <label className="grid gap-2 text-sm">
           <span>土日祝の扱い</span>
           <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
@@ -383,11 +481,11 @@ function RecurringRow({
   return (
     <tr className="border-b border-white/5">
       <td className="px-3 py-3">{item.name}</td>
-      <td className="px-3 py-3">{item.type === "income" ? "収入" : "支出"}</td>
+      <td className="px-3 py-3">{getRecurringTypeLabel(item.type)}</td>
       <td className="px-3 py-3">{formatCurrency(item.amount)}</td>
       <td className="px-3 py-3">{item.dayOfMonth}</td>
       <td className="px-3 py-3">{formatPeriod(item.startDate, item.endDate)}</td>
-      <td className="px-3 py-3">{item.account?.name ?? "未設定"}</td>
+      <td className="px-3 py-3">{formatRecurringAccounts(item)}</td>
       <td className="px-3 py-3">{item.sortOrder}</td>
       <td className="px-3 py-3 text-center">{item.enabled ? "有効" : "無効"}</td>
       <td className="px-3 py-3">

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -836,6 +836,118 @@ describe("MCP server", () => {
     });
   });
 
+  it("forwards recurring transfer payloads to the REST API", async () => {
+    addRoute("POST", "/api/recurring-items", {
+      status: 201,
+      body: {
+        id: "recurring-transfer",
+        name: "資金移動",
+        type: "transfer",
+        amount: 50000,
+        dayOfMonth: 20,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "none",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        transferToAccountId: "22222222-2222-4222-a222-222222222222",
+        enabled: true,
+        sortOrder: 5,
+      },
+    });
+
+    const result = await client.callTool({
+      name: "create_recurring_item",
+      arguments: {
+        name: "資金移動",
+        type: "transfer",
+        amount: 50000,
+        dayOfMonth: 20,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "none",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        transferToAccountId: "22222222-2222-4222-a222-222222222222",
+        enabled: true,
+        sortOrder: 5,
+      },
+    });
+
+    expect(getToolText(result)).toContain("資金移動");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "POST",
+      path: "/api/recurring-items",
+      body: {
+        name: "資金移動",
+        type: "transfer",
+        amount: 50000,
+        dayOfMonth: 20,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "none",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        transferToAccountId: "22222222-2222-4222-a222-222222222222",
+        enabled: true,
+        sortOrder: 5,
+      },
+    });
+  });
+
+  it("formats transfer forecast labels in dashboard tools", async () => {
+    const transferEvent = {
+      id: "transfer-event",
+      date: "2026-03-10",
+      type: "transfer",
+      description: "資金移動",
+      amount: 50000,
+      amountJpy: 50000,
+      balance: 123456,
+      balanceJpy: 123456,
+      currencyCode: "JPY",
+      accountId: "11111111-1111-4111-a111-111111111111",
+      transferToAccountId: "22222222-2222-4222-a222-222222222222",
+    };
+    addRoute("GET", "/api/dashboard?applyOffset=true", {
+      body: {
+        totalBalance: 123456,
+        minBalance: 123456,
+        nextIncome: null,
+        nextExpense: null,
+        overdueForecast: [transferEvent],
+        forecast: [transferEvent],
+        accountForecasts: [],
+      },
+    });
+    addRoute("GET", "/api/dashboard", {
+      body: {
+        overdueForecast: [transferEvent],
+      },
+    });
+    addRoute("GET", "/api/accounts", {
+      body: [
+        { id: "11111111-1111-4111-a111-111111111111", name: "Source" },
+        { id: "22222222-2222-4222-a222-222222222222", name: "Destination" },
+      ],
+    });
+
+    const dashboard = await client.callTool({
+      name: "get_dashboard",
+      arguments: {},
+    });
+    const review = await client.callTool({
+      name: "review_overdue_events",
+      arguments: {},
+    });
+
+    expect(getToolText(dashboard)).toContain("振替");
+    expect(getToolText(review)).toContain("振替");
+    expect(getToolText(review)).toContain("Source → Destination");
+  });
+
   it("uses the events API when get_dashboard is called with months", async () => {
     const result = await client.callTool({
       name: "get_dashboard",
@@ -884,6 +996,8 @@ describe("MCP server", () => {
           currencyCode: "JPY",
           accountId: "11111111-1111-4111-a111-111111111111",
           accountName: "Main",
+          transferToAccountId: null,
+          transferToAccountName: null,
         },
         {
           id: "overdue-2",
@@ -895,6 +1009,8 @@ describe("MCP server", () => {
           currencyCode: "JPY",
           accountId: "22222222-2222-4222-a222-222222222222",
           accountName: null,
+          transferToAccountId: null,
+          transferToAccountName: null,
         },
       ],
     });

--- a/packages/mcp/src/format.ts
+++ b/packages/mcp/src/format.ts
@@ -28,6 +28,18 @@ function formatCurrency(amount: number) {
   return currencyFormatter.format(amount);
 }
 
+function formatForecastEventType(type: "income" | "expense" | "transfer") {
+  if (type === "income") {
+    return "収入";
+  }
+
+  if (type === "expense") {
+    return "支出";
+  }
+
+  return "振替";
+}
+
 function formatAccountForecast(item: AccountForecast) {
   const warning = item.warningLevel === "red"
     ? " 🔴 実残高不足"
@@ -70,7 +82,7 @@ export function formatDashboardText(data: DashboardResponse, today: string) {
   if (overdueForecast.length > 0) {
     lines.push("", "【予定日超過の未確定イベント】");
     for (const event of overdueForecast) {
-      const typeLabel = event.type === "income" ? "収入" : "支出";
+      const typeLabel = formatForecastEventType(event.type);
       lines.push(
         `  [${event.id}] ${event.date} ${typeLabel}: ${event.description} ${formatCurrency(event.amount)}`,
       );
@@ -83,7 +95,7 @@ export function formatDashboardText(data: DashboardResponse, today: string) {
   if (todayEvents.length > 0) {
     lines.push("", "【本日の未確定イベント】");
     for (const event of todayEvents) {
-      const typeLabel = event.type === "income" ? "収入" : "支出";
+      const typeLabel = formatForecastEventType(event.type);
       lines.push(
         `  [${event.id}] ${typeLabel}: ${event.description} ${formatCurrency(event.amount)}`,
       );
@@ -134,7 +146,11 @@ export function formatForecastSummary(data: DashboardResponse, forecastMonths?: 
   if (data.nextExpense) {
     lines.push(`  支出: ${data.nextExpense.description} ${formatCurrency(data.nextExpense.amount)}（${data.nextExpense.date}）`);
   }
-  if (!data.nextIncome && !data.nextExpense) {
+  const nextTransfer = data.forecast.find((event) => event.type === "transfer");
+  if (nextTransfer) {
+    lines.push(`  振替: ${nextTransfer.description} ${formatCurrency(nextTransfer.amount)}（${nextTransfer.date}）`);
+  }
+  if (!data.nextIncome && !data.nextExpense && !nextTransfer) {
     lines.push("  直近のイベントはありません");
   }
 

--- a/packages/mcp/src/tools/dashboard.ts
+++ b/packages/mcp/src/tools/dashboard.ts
@@ -14,13 +14,15 @@ import { z } from "zod";
 const reviewOverdueEventSchema = z.object({
   id: z.string(),
   date: z.string(),
-  type: z.enum(["income", "expense"]),
+  type: z.enum(["income", "expense", "transfer"]),
   description: z.string(),
   amount: z.number(),
   amountJpy: z.number(),
   currencyCode: supportedCurrencyCodeSchema,
   accountId: z.string().nullable(),
   accountName: z.string().nullable(),
+  transferToAccountId: z.string().nullable(),
+  transferToAccountName: z.string().nullable(),
 });
 
 const reviewOverdueGuidance =
@@ -37,6 +39,26 @@ function formatReviewAmount(event: z.infer<typeof reviewOverdueEventSchema>) {
   return `${event.currencyCode} ${amount}（¥${amountJpy}）`;
 }
 
+function formatReviewEventType(type: z.infer<typeof reviewOverdueEventSchema>["type"]) {
+  if (type === "income") {
+    return "収入";
+  }
+
+  if (type === "expense") {
+    return "支出";
+  }
+
+  return "振替";
+}
+
+function formatReviewAccount(event: z.infer<typeof reviewOverdueEventSchema>) {
+  if (event.type === "transfer") {
+    return `${event.accountName ?? "口座未解決"} → ${event.transferToAccountName ?? "口座未解決"}`;
+  }
+
+  return event.accountName ?? "口座未解決";
+}
+
 function formatReviewOverdueText(events: Array<z.infer<typeof reviewOverdueEventSchema>>) {
   if (events.length === 0) {
     return "予定日超過の未確定イベントはありません。";
@@ -44,9 +66,9 @@ function formatReviewOverdueText(events: Array<z.infer<typeof reviewOverdueEvent
 
   const lines = [`予定日超過の未確定イベント: ${events.length}件`, ""];
   for (const event of events) {
-    const typeLabel = event.type === "income" ? "収入" : "支出";
+    const typeLabel = formatReviewEventType(event.type);
     lines.push(
-      `[${event.id}] ${event.date} ${typeLabel} ${event.description} ${formatReviewAmount(event)} ${event.accountName ?? "口座未解決"}`,
+      `[${event.id}] ${event.date} ${typeLabel} ${event.description} ${formatReviewAmount(event)} ${formatReviewAccount(event)}`,
     );
   }
   lines.push("", reviewOverdueGuidance);
@@ -123,6 +145,10 @@ export function registerDashboardTools(server: McpServer, apiClient: SuiApiClien
         currencyCode: event.currencyCode,
         accountId: event.accountId,
         accountName: event.accountId ? accountNames.get(event.accountId) ?? null : null,
+        transferToAccountId: event.transferToAccountId ?? null,
+        transferToAccountName: event.transferToAccountId
+          ? accountNames.get(event.transferToAccountId) ?? null
+          : null,
       }));
       const structuredContent = {
         overdueCount: events.length,

--- a/packages/mcp/src/tools/recurring-items.ts
+++ b/packages/mcp/src/tools/recurring-items.ts
@@ -12,13 +12,14 @@ import { z } from "zod";
 
 const recurringPayload = {
   name: z.string().min(1).max(100).describe("固定収支名"),
-  type: z.enum(["income", "expense"]).describe("種別"),
+  type: z.enum(["income", "expense", "transfer"]).describe("種別。transfer は定期振替"),
   amount: nonNegativeMoneySchema.describe("金額"),
   dayOfMonth: z.number().int().min(1).max(31).describe("毎月の対象日"),
   startDate: dateSchema.nullable().describe("開始日"),
   endDate: dateSchema.nullable().describe("終了日"),
   dateShiftPolicy: dateShiftPolicySchema.optional().describe("土日祝の扱い"),
-  accountId: uuidSchema.describe("口座 ID"),
+  accountId: uuidSchema.describe("口座 ID。振替では振替元口座"),
+  transferToAccountId: uuidSchema.optional().describe("振替先口座 ID。type が transfer の場合に指定。振替は口座別予測に反映され、合計残高には中立"),
   enabled: z.boolean().describe("有効フラグ"),
   sortOrder: z.number().int().describe("表示順"),
 };
@@ -29,14 +30,14 @@ export function registerRecurringItemTools(server: McpServer, apiClient: SuiApiC
     return textContent(formatRecurringItemsText(data));
   });
 
-  server.tool("create_recurring_item", "固定収支を作成する", recurringPayload, async (args) => {
+  server.tool("create_recurring_item", "固定収支を作成する。type=transfer の定期振替は口座別予測に反映され、合計残高には中立", recurringPayload, async (args) => {
     const item = await apiClient.post<RecurringItem>("/api/recurring-items", args as CreateRecurringItemPayload);
     return textContent(`固定収支を作成しました: ${item.name} ¥${item.amount.toLocaleString("ja-JP")}`);
   });
 
   server.tool(
     "update_recurring_item",
-    "固定収支を更新する",
+    "固定収支を更新する。type=transfer の定期振替は口座別予測に反映され、合計残高には中立",
     {
       id: uuidSchema.describe("固定収支 ID"),
       ...recurringPayload,

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -7,6 +7,7 @@ import type {
   Loan,
   LoanPaymentMethod,
   RecurringItem,
+  RecurringItemType,
   Subscription,
   Transaction,
   TransactionType,
@@ -70,13 +71,14 @@ export interface ReconcileAccountResponse {
 
 export interface CreateRecurringItemPayload {
   name: string;
-  type: "income" | "expense";
+  type: RecurringItemType;
   amount: number;
   dayOfMonth: number;
   startDate: string | null;
   endDate: string | null;
   dateShiftPolicy?: DateShiftPolicy;
   accountId: string;
+  transferToAccountId?: string | null;
   enabled: boolean;
   sortOrder: number;
 }

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -1,7 +1,7 @@
 import type { SupportedCurrencyCode } from "../constants/currency";
 
 export type TransactionType = "income" | "expense" | "transfer" | "adjustment";
-export type RecurringItemType = "income" | "expense";
+export type RecurringItemType = "income" | "expense" | "transfer";
 export type DateShiftPolicy = "none" | "previous" | "next";
 export type LoanPaymentMethod = "account_withdrawal" | "credit_card";
 
@@ -31,6 +31,8 @@ export interface RecurringItem {
   dateShiftPolicy: DateShiftPolicy;
   accountId: string | null;
   account: Account | null;
+  transferToAccountId: string | null;
+  transferToAccount: Account | null;
   enabled: boolean;
   sortOrder: number;
   deletedAt: string | null;
@@ -121,7 +123,7 @@ export interface Transaction {
 export interface ForecastEvent {
   id: string;
   date: string;
-  type: "income" | "expense";
+  type: "income" | "expense" | "transfer";
   description: string;
   amount: number;
   amountJpy: number;
@@ -129,4 +131,5 @@ export interface ForecastEvent {
   balanceJpy: number;
   currencyCode: SupportedCurrencyCode;
   accountId: string | null;
+  transferToAccountId?: string | null;
 }


### PR DESCRIPTION
## 背景

プロダクトレビュー（20260702-review.md）指摘 A-6。口座別予測と警告は「引き落とし口座の残高不足」の検知が目的だが、ユーザーが毎月必ず行う口座間の資金移動（給与口座→引き落とし口座）を予測に入れる手段がなく、警告が誤検知（狼少年化）していた。

## 設計判断

- 予測イベントに **transfer 型を一級で追加**。half-event（収支2件）への分解は、確定時に「振替1件」でなく「収支2件」の取引が生まれてドメインが壊れるため不採用
- **合計残高チェーンには中立**（イベントは表示されるが残高を変えない）、口座別チェーンで振替元−/振替先+
- 同日内の適用順は **収入 → 振替 → 支出**（着金→資金移動→引き落としの自然な順序）
- 確定時は transfer 取引を生成。from/to はイベント定義で固定（確定時の口座変更は不可）

## 変更内容

- schema: `RecurringItemType.transfer` + `RecurringItem.transferToAccountId`（マイグレーション同梱）
- backend: recurring-items の振替検証（両口座必須・同一口座不可・同一通貨必須・income/expense への transferToAccountId 禁止）、forecast-core の transfer 反映、confirm の transfer 分岐（通貨検証・両残高更新・冪等性維持）
- frontend: 固定収支フォームの振替対応（同一通貨口座のみのセレクト）、ダッシュボードの振替表示（元→先表記）、確定ダイアログの口座セレクト無効化
- MCP: recurring ツール payload + 各 format の振替対応

## 検証

- `make lint` / `make typecheck` / `make test-unit` / `make test-integration` / `make test-e2e` / `make build` すべて通過
- forecast-core ユニット: 合計中立性・口座別±・同日順序
- 統合: 振替 CRUD 検証、dashboard 反映、confirm での transfer 取引生成と両口座残高更新
- e2e: 振替登録→口座別予測反映→確定→両口座残高変化のシナリオ

Implemented-by: Codex (gpt-5.5) / Reviewed-by: Claude (Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)