### PR TITLE
feat: 残高チャートを時間スケール軸のステップチャートに再設計

### DIFF
--- a/packages/frontend/src/components/balance-chart.tsx
+++ b/packages/frontend/src/components/balance-chart.tsx
@@ -1,19 +1,37 @@
 import {
   Line,
   LineChart,
+  ReferenceArea,
+  ReferenceDot,
   ReferenceLine,
   Tooltip,
+  type TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
 import { useEffect, useRef, useState } from "react";
 import type { SupportedCurrencyCode } from "@sui/shared";
 import { formatChartDateWithYear, formatCurrency, formatDateWithYear } from "../lib/format";
+import {
+  buildBalanceChartSegments,
+  buildBalanceChartYDomain,
+  buildTimeScaleTicks,
+  dateOnlyToTimestamp,
+  timestampToDateOnly,
+  type BalanceChartInputPoint,
+  type DailyBalanceChartPoint,
+} from "../lib/balance-chart";
 
-type BalanceChartPoint = {
+type BalanceChartPoint = BalanceChartInputPoint;
+
+type BalanceChartDatum = {
   date: string;
-  balance: number;
-  description?: string;
+  timestamp: number;
+  order: number;
+  actualBalance?: number;
+  forecastBalance?: number;
+  actualDescription?: string;
+  forecastDescription?: string;
 };
 
 function useElementSize() {
@@ -53,20 +71,106 @@ function useElementSize() {
   return [ref, size] as const;
 }
 
+function formatTimestampTick(value: number) {
+  return formatChartDateWithYear(timestampToDateOnly(value));
+}
+
+function getTooltipEntry(
+  payload: TooltipContentProps["payload"],
+  dataKey: "actualBalance" | "forecastBalance",
+) {
+  return payload.find((entry) => entry.dataKey === dataKey && entry.value !== null && entry.value !== undefined);
+}
+
+function BalanceTooltip({
+  active,
+  payload,
+  currencyCode,
+  showSeriesLabel,
+}: TooltipContentProps & {
+  currencyCode: SupportedCurrencyCode;
+  showSeriesLabel: boolean;
+}) {
+  if (!active || payload.length === 0) {
+    return null;
+  }
+
+  const actualEntry = getTooltipEntry(payload, "actualBalance");
+  const forecastEntry = getTooltipEntry(payload, "forecastBalance");
+  const selectedEntry = forecastEntry ?? actualEntry;
+  if (!selectedEntry || typeof selectedEntry.value !== "number") {
+    return null;
+  }
+
+  const point = selectedEntry.payload as Partial<BalanceChartDatum> | undefined;
+  if (!point?.date) {
+    return null;
+  }
+
+  const seriesLabel = actualEntry && forecastEntry ? "実績 / 予測" : forecastEntry ? "予測" : "実績";
+  const description =
+    selectedEntry.dataKey === "forecastBalance" ? point.forecastDescription : point.actualDescription;
+
+  return (
+    <div className="max-w-64 rounded-2xl border border-white/10 bg-[rgba(18,22,30,0.96)] px-3 py-2 text-sm shadow-xl">
+      {showSeriesLabel ? <div className="mb-1 text-xs font-medium text-white/55">{seriesLabel}</div> : null}
+      <div className="text-white/75">{formatDateWithYear(point.date)}</div>
+      <div className="mt-1 font-semibold text-white">{formatCurrency(selectedEntry.value, currencyCode)}</div>
+      {description ? <div className="mt-1 break-words text-xs text-white/60">{description}</div> : null}
+    </div>
+  );
+}
+
+function isInDomain(point: DailyBalanceChartPoint, domain: [number, number]) {
+  return point.timestamp >= domain[0] && point.timestamp <= domain[1];
+}
+
+function getMinimumForecastPoint(points: DailyBalanceChartPoint[], domain: [number, number]) {
+  return points
+    .filter((point) => isInDomain(point, domain))
+    .reduce<DailyBalanceChartPoint | null>(
+      (minimum, point) => (!minimum || point.balance < minimum.balance ? point : minimum),
+      null,
+    );
+}
+
 export function BalanceChart({
   data,
+  forecastData,
+  todayPoint,
+  todayDate,
+  displayStartDate,
+  displayEndDate,
   currentBalance,
   label,
   currencyCode = "JPY",
 }: {
   data: BalanceChartPoint[];
+  forecastData?: BalanceChartPoint[];
+  todayPoint?: BalanceChartPoint;
+  todayDate?: string;
+  displayStartDate?: string;
+  displayEndDate?: string;
   currentBalance: number;
   label: string;
   currencyCode?: SupportedCurrencyCode;
 }) {
   const [chartRef, chartSize] = useElementSize();
+  const {
+    actualLineSeries,
+    forecastEventSeries,
+    forecastLineSeries,
+    xDomain,
+  } = buildBalanceChartSegments({
+    actualPoints: data,
+    forecastPoints: forecastData,
+    todayPoint,
+    displayStartDate,
+    displayEndDate,
+    currentBalance,
+  });
 
-  if (data.length === 0) {
+  if (actualLineSeries.length === 0 && forecastLineSeries.length === 0) {
     return (
       <div ref={chartRef} className="flex h-full min-h-0 min-w-0 items-center justify-center text-white/60">
         表示できる {label} の推移がありません。
@@ -74,33 +178,93 @@ export function BalanceChart({
     );
   }
 
-  const balances = data.map((point) => point.balance);
-  const minBalance = Math.min(...balances);
-  const maxBalance = Math.max(...balances);
-  const chartDomain: [number, number] =
-    minBalance === maxBalance
-      ? [
-          minBalance - Math.max(Math.abs(currentBalance) * 0.08, 10_000),
-          maxBalance + Math.max(Math.abs(currentBalance) * 0.08, 10_000),
-        ]
-      : [
-          minBalance - Math.max((maxBalance - minBalance) * 0.12, 10_000),
-          maxBalance + Math.max((maxBalance - minBalance) * 0.12, 10_000),
-        ];
+  const visibleBalances = [...actualLineSeries, ...forecastLineSeries]
+    .filter((point) => isInDomain(point, xDomain))
+    .map((point) => point.balance);
+  const chartDomain = buildBalanceChartYDomain(visibleBalances, currentBalance);
+  const visibleMinBalance = Math.min(...(visibleBalances.length > 0 ? visibleBalances : [currentBalance]));
   const showZeroLine = chartDomain[0] <= 0 && chartDomain[1] >= 0;
+  const showNegativeArea = visibleMinBalance < 0 && showZeroLine;
+  const todayTimestamp = todayDate
+    ? dateOnlyToTimestamp(todayDate)
+    : todayPoint
+      ? dateOnlyToTimestamp(todayPoint.date)
+      : undefined;
+  const showTodayLine =
+    todayTimestamp !== undefined && todayTimestamp >= xDomain[0] && todayTimestamp <= xDomain[1];
+  const minimumForecastPoint = getMinimumForecastPoint(forecastEventSeries, xDomain);
+  const minimumForecastLabelPosition =
+    minimumForecastPoint && minimumForecastPoint.timestamp > xDomain[0] + (xDomain[1] - xDomain[0]) * 0.85
+      ? "left"
+      : "right";
+  const chartData: BalanceChartDatum[] = [
+    ...actualLineSeries.map((point) => ({
+      date: point.date,
+      timestamp: point.timestamp,
+      order: 0,
+      actualBalance: point.balance,
+      actualDescription: point.description,
+    })),
+    ...forecastLineSeries.map((point, index) => ({
+      date: point.date,
+      timestamp: point.timestamp,
+      order: index === 0 && todayPoint ? 1 : 2,
+      forecastBalance: point.balance,
+      forecastDescription: point.description,
+    })),
+  ].sort((left, right) => left.timestamp - right.timestamp || left.order - right.order);
+  const xTicks = buildTimeScaleTicks(timestampToDateOnly(xDomain[0]), timestampToDateOnly(xDomain[1]));
+  const primaryColor = "hsl(var(--primary))";
 
   return (
     <div ref={chartRef} className="h-full min-h-0 min-w-0">
       {chartSize.width > 0 && chartSize.height > 0 ? (
         <LineChart
-          data={data}
+          data={chartData}
           height={chartSize.height}
           margin={{ left: 12, right: 12, top: 12, bottom: 8 }}
           width={chartSize.width}
         >
+          {showNegativeArea ? (
+            <ReferenceArea
+              x1={xDomain[0]}
+              x2={xDomain[1]}
+              y1={chartDomain[0]}
+              y2={0}
+              fill="rgba(244, 63, 94, 0.08)"
+              strokeOpacity={0}
+            />
+          ) : null}
           {showZeroLine ? <ReferenceLine y={0} stroke="rgba(255,255,255,0.2)" strokeDasharray="4 4" /> : null}
+          {showTodayLine ? (
+            <ReferenceLine
+              x={todayTimestamp}
+              stroke="rgba(255,255,255,0.32)"
+              strokeDasharray="3 5"
+              label={{ value: "今日", position: "insideTop", fill: "rgba(255,255,255,0.68)", fontSize: 12 }}
+            />
+          ) : null}
+          {minimumForecastPoint ? (
+            <ReferenceDot
+              x={minimumForecastPoint.timestamp}
+              y={minimumForecastPoint.balance}
+              r={4}
+              fill={primaryColor}
+              stroke="rgba(255,255,255,0.75)"
+              strokeWidth={1.5}
+              label={{
+                value: `表示期間の最小 ${formatCurrency(minimumForecastPoint.balance, currencyCode)} / ${formatDateWithYear(minimumForecastPoint.date)}`,
+                position: minimumForecastLabelPosition,
+                fill: "rgba(255,255,255,0.72)",
+                fontSize: 12,
+              }}
+            />
+          ) : null}
           <XAxis
-            dataKey="date"
+            dataKey="timestamp"
+            type="number"
+            domain={xDomain}
+            ticks={xTicks}
             stroke="rgba(255,255,255,0.28)"
             height={28}
             tick={{ fontSize: 10, fill: "rgba(255,255,255,0.58)" }}
@@ -108,8 +272,8 @@ export function BalanceChart({
             tickMargin={6}
             minTickGap={24}
             interval="preserveStartEnd"
-            tickFormatter={formatChartDateWithYear}
-            padding={{ left: 20, right: 20 }}
+            tickFormatter={formatTimestampTick}
+            allowDataOverflow
           />
           <YAxis
             stroke="rgba(255,255,255,0.4)"
@@ -117,26 +281,41 @@ export function BalanceChart({
             width={110}
             domain={chartDomain}
             tickCount={6}
+            tick={{ fontSize: 11, fill: "rgba(255,255,255,0.58)" }}
+            tickLine={false}
+            allowDataOverflow
           />
           <Tooltip
-            contentStyle={{
-              background: "rgba(18, 22, 30, 0.96)",
-              border: "1px solid rgba(255,255,255,0.08)",
-              borderRadius: 16,
-            }}
-            formatter={(value) => formatCurrency(value as number, currencyCode)}
-            labelFormatter={(_, payload) => {
-              const point = payload?.[0]?.payload as BalanceChartPoint | undefined;
-              if (!point) {
-                return "";
-              }
-
-              return point.description
-                ? `${point.description} / ${formatDateWithYear(point.date)}`
-                : formatDateWithYear(point.date);
-            }}
+            content={(props) => (
+              <BalanceTooltip {...props} currencyCode={currencyCode} showSeriesLabel={forecastData !== undefined} />
+            )}
+            cursor={{ stroke: "rgba(255,255,255,0.18)", strokeDasharray: "4 4" }}
           />
-          <Line type="monotone" dataKey="balance" stroke="hsl(var(--primary))" strokeWidth={3} dot={false} />
+          {actualLineSeries.length > 0 ? (
+            <Line
+              type="stepAfter"
+              dataKey="actualBalance"
+              stroke={primaryColor}
+              strokeWidth={3}
+              dot={false}
+              activeDot={{ r: 4 }}
+              isAnimationActive={false}
+              connectNulls
+            />
+          ) : null}
+          {forecastLineSeries.length > 0 ? (
+            <Line
+              type="stepAfter"
+              dataKey="forecastBalance"
+              stroke={primaryColor}
+              strokeDasharray="7 6"
+              strokeWidth={3}
+              dot={false}
+              activeDot={{ r: 4 }}
+              isAnimationActive={false}
+              connectNulls
+            />
+          ) : null}
         </LineChart>
       ) : null}
     </div>

--- a/packages/frontend/src/lib/balance-chart.ts
+++ b/packages/frontend/src/lib/balance-chart.ts
@@ -1,0 +1,306 @@
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type BalanceChartInputPoint = {
+  date: string;
+  balance: number;
+  description?: string;
+};
+
+export type DailyBalanceChartPoint = BalanceChartInputPoint & {
+  timestamp: number;
+  eventCount: number;
+};
+
+export type BalanceChartSegments = {
+  actualLineSeries: DailyBalanceChartPoint[];
+  forecastEventSeries: DailyBalanceChartPoint[];
+  forecastLineSeries: DailyBalanceChartPoint[];
+  xDomain: [number, number];
+};
+
+function parseDateParts(value: string) {
+  const [year = "0", month = "1", day = "1"] = value.split("-");
+
+  return {
+    year: Number(year),
+    month: Number(month),
+    day: Number(day),
+  };
+}
+
+function formatDateParts(date: Date) {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+function toUtcDate(value: string) {
+  const { year, month, day } = parseDateParts(value);
+
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+export function dateOnlyToTimestamp(value: string) {
+  const { year, month, day } = parseDateParts(value);
+
+  return Date.UTC(year, month - 1, day) - JST_OFFSET_MS;
+}
+
+export function timestampToDateOnly(value: number) {
+  return formatDateParts(new Date(value + JST_OFFSET_MS));
+}
+
+export function addDaysToDateOnly(value: string, days: number) {
+  const date = toUtcDate(value);
+  date.setUTCDate(date.getUTCDate() + days);
+
+  return formatDateParts(date);
+}
+
+export function addMonthsToDateOnly(value: string, months: number) {
+  const date = toUtcDate(value);
+  date.setUTCMonth(date.getUTCMonth() + months);
+
+  return formatDateParts(date);
+}
+
+export function aggregateBalancePointsByDate(points: BalanceChartInputPoint[]): DailyBalanceChartPoint[] {
+  const byDate = new Map<
+    string,
+    {
+      date: string;
+      balance: number;
+      descriptions: string[];
+      eventCount: number;
+    }
+  >();
+
+  for (const point of points) {
+    const existing = byDate.get(point.date);
+    const descriptions = existing?.descriptions ?? [];
+    if (point.description) {
+      descriptions.push(point.description);
+    }
+
+    byDate.set(point.date, {
+      date: point.date,
+      balance: point.balance,
+      descriptions,
+      eventCount: (existing?.eventCount ?? 0) + 1,
+    });
+  }
+
+  return Array.from(byDate.values())
+    .sort((left, right) => left.date.localeCompare(right.date))
+    .map((point) => {
+      const firstDescription = point.descriptions[0];
+
+      return {
+        date: point.date,
+        timestamp: dateOnlyToTimestamp(point.date),
+        balance: point.balance,
+        description:
+          firstDescription && point.eventCount > 1
+            ? `${firstDescription} 他${point.eventCount - 1}件`
+            : firstDescription,
+        eventCount: point.eventCount,
+      };
+    });
+}
+
+function toDailyPoint(point: BalanceChartInputPoint): DailyBalanceChartPoint {
+  return {
+    ...point,
+    timestamp: dateOnlyToTimestamp(point.date),
+    eventCount: point.description ? 1 : 0,
+  };
+}
+
+function sortDailyPoints(points: DailyBalanceChartPoint[]) {
+  return [...points].sort((left, right) => left.timestamp - right.timestamp);
+}
+
+function createSyntheticPoint(date: string, balance: number): DailyBalanceChartPoint {
+  return {
+    date,
+    timestamp: dateOnlyToTimestamp(date),
+    balance,
+    eventCount: 0,
+  };
+}
+
+function upsertDailyPoint(points: DailyBalanceChartPoint[], point: DailyBalanceChartPoint) {
+  return sortDailyPoints([...points.filter((item) => item.date !== point.date), point]);
+}
+
+function findLastPointBeforeOrAt(points: DailyBalanceChartPoint[], timestamp: number) {
+  for (let index = points.length - 1; index >= 0; index -= 1) {
+    if (points[index].timestamp <= timestamp) {
+      return points[index];
+    }
+  }
+
+  return undefined;
+}
+
+function ensureRangeEndpoints(
+  points: DailyBalanceChartPoint[],
+  startTimestamp: number,
+  endTimestamp: number,
+  fallbackBalance: number,
+) {
+  if (endTimestamp < startTimestamp) {
+    return [];
+  }
+
+  const startDate = timestampToDateOnly(startTimestamp);
+  const endDate = timestampToDateOnly(endTimestamp);
+  const sorted = sortDailyPoints(points);
+
+  if (sorted.length === 0) {
+    const startPoint = createSyntheticPoint(startDate, fallbackBalance);
+    return startDate === endDate ? [startPoint] : [startPoint, createSyntheticPoint(endDate, fallbackBalance)];
+  }
+
+  const inRange = sorted.filter((point) => point.timestamp >= startTimestamp && point.timestamp <= endTimestamp);
+  const lastBeforeOrAtStart = findLastPointBeforeOrAt(sorted, startTimestamp);
+  const firstAfterStart = sorted.find((point) => point.timestamp > startTimestamp);
+  const startBalance = lastBeforeOrAtStart?.balance ?? firstAfterStart?.balance ?? fallbackBalance;
+  const lastBeforeOrAtEnd = findLastPointBeforeOrAt(sorted, endTimestamp);
+  const endBalance = lastBeforeOrAtEnd?.balance ?? startBalance;
+  const ranged = [...inRange];
+
+  if (!ranged.some((point) => point.timestamp === startTimestamp)) {
+    ranged.unshift(createSyntheticPoint(startDate, startBalance));
+  }
+
+  if (!ranged.some((point) => point.timestamp === endTimestamp)) {
+    ranged.push(createSyntheticPoint(endDate, endBalance));
+  }
+
+  if (ranged.length === 1 && startTimestamp < endTimestamp) {
+    const onlyPoint = ranged[0];
+    if (onlyPoint.timestamp === startTimestamp) {
+      ranged.push(createSyntheticPoint(endDate, onlyPoint.balance));
+    } else {
+      ranged.unshift(createSyntheticPoint(startDate, onlyPoint.balance));
+    }
+  }
+
+  return ranged;
+}
+
+export function buildBalanceChartYDomain(values: number[], currentBalance: number): [number, number] {
+  const targetValues = values.length > 0 ? values : [currentBalance];
+  const minBalance = Math.min(...targetValues);
+  const maxBalance = Math.max(...targetValues);
+
+  if (minBalance === maxBalance) {
+    const padding = Math.max(Math.abs(currentBalance) * 0.08, 10_000);
+    return [minBalance - padding, maxBalance + padding];
+  }
+
+  const padding = Math.max((maxBalance - minBalance) * 0.12, 10_000);
+  return [minBalance - padding, maxBalance + padding];
+}
+
+export function buildBalanceChartSegments({
+  actualPoints,
+  forecastPoints = [],
+  todayPoint,
+  displayStartDate,
+  displayEndDate,
+  currentBalance,
+}: {
+  actualPoints: BalanceChartInputPoint[];
+  forecastPoints?: BalanceChartInputPoint[];
+  todayPoint?: BalanceChartInputPoint;
+  displayStartDate?: string;
+  displayEndDate?: string;
+  currentBalance: number;
+}): BalanceChartSegments {
+  const actualSeries = aggregateBalancePointsByDate(actualPoints);
+  const forecastEventSeries = aggregateBalancePointsByDate(forecastPoints);
+  const boundaryPoint = todayPoint ? toDailyPoint(todayPoint) : null;
+  const actualBaseSeries = boundaryPoint ? upsertDailyPoint(actualSeries, boundaryPoint) : actualSeries;
+  const forecastBaseSeries = boundaryPoint
+    ? sortDailyPoints([boundaryPoint, ...forecastEventSeries])
+    : forecastEventSeries;
+  const allTimestamps = [...actualBaseSeries, ...forecastBaseSeries].map((point) => point.timestamp);
+  const fallbackStart = allTimestamps.length > 0 ? Math.min(...allTimestamps) : dateOnlyToTimestamp(displayStartDate ?? "1970-01-01");
+  const fallbackEnd = allTimestamps.length > 0 ? Math.max(...allTimestamps) : fallbackStart;
+  const xDomain: [number, number] = [
+    displayStartDate
+      ? dateOnlyToTimestamp(displayStartDate)
+      : fallbackStart === fallbackEnd
+        ? fallbackStart - DAY_MS * 7
+        : fallbackStart,
+    displayEndDate
+      ? dateOnlyToTimestamp(displayEndDate)
+      : fallbackStart === fallbackEnd
+        ? fallbackEnd + DAY_MS * 7
+        : fallbackEnd,
+  ];
+  const actualEndTimestamp = boundaryPoint
+    ? Math.min(Math.max(boundaryPoint.timestamp, xDomain[0]), xDomain[1])
+    : xDomain[1];
+  const forecastStartTimestamp = boundaryPoint
+    ? Math.min(Math.max(boundaryPoint.timestamp, xDomain[0]), xDomain[1])
+    : xDomain[0];
+
+  return {
+    actualLineSeries: ensureRangeEndpoints(actualBaseSeries, xDomain[0], actualEndTimestamp, currentBalance),
+    forecastEventSeries,
+    forecastLineSeries: ensureRangeEndpoints(
+      forecastBaseSeries,
+      forecastStartTimestamp,
+      xDomain[1],
+      boundaryPoint?.balance ?? currentBalance,
+    ),
+    xDomain,
+  };
+}
+
+function isMoreThanThreeMonths(startDate: string, endDate: string) {
+  return endDate > addMonthsToDateOnly(startDate, 3);
+}
+
+function getStartOfNextMonth(value: string) {
+  const { year, month } = parseDateParts(value);
+
+  return formatDateParts(new Date(Date.UTC(year, month, 1)));
+}
+
+export function buildTimeScaleTicks(startDate: string, endDate: string) {
+  if (endDate < startDate) {
+    return [];
+  }
+
+  const ticks: number[] = [];
+  const useMonthTicks = isMoreThanThreeMonths(startDate, endDate);
+  let cursor = useMonthTicks ? getStartOfNextMonth(startDate) : startDate;
+
+  while (cursor <= endDate) {
+    ticks.push(dateOnlyToTimestamp(cursor));
+    cursor = useMonthTicks ? addMonthsToDateOnly(cursor, 1) : addDaysToDateOnly(cursor, 7);
+  }
+
+  if (ticks.length === 0) {
+    ticks.push(dateOnlyToTimestamp(startDate));
+  }
+
+  return ticks;
+}
+
+export function getDashboardChartStartDate(today: string) {
+  return addMonthsToDateOnly(today, -1);
+}
+
+export function getDashboardChartEndDate(today: string, months: number) {
+  return addMonthsToDateOnly(today, months);
+}
+
+export { DAY_MS };

--- a/packages/frontend/src/lib/format.test.ts
+++ b/packages/frontend/src/lib/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  aggregateBalancePointsByDate,
+  buildBalanceChartSegments,
+  buildBalanceChartYDomain,
+  buildTimeScaleTicks,
+  timestampToDateOnly,
+} from "./balance-chart";
+import {
   formatChartDateWithYear,
   formatCurrency,
   formatCurrencyInputValue,
@@ -47,5 +54,114 @@ describe("formatDateWithYear", () => {
 describe("formatChartDateWithYear", () => {
   it("formats YYYY-MM-DD into YY/M/D", () => {
     expect(formatChartDateWithYear("2026-03-14")).toBe("26/3/14");
+  });
+});
+
+describe("buildTimeScaleTicks", () => {
+  it("generates weekly ticks for ranges up to three months", () => {
+    expect(buildTimeScaleTicks("2026-03-01", "2026-03-22").map(timestampToDateOnly)).toEqual([
+      "2026-03-01",
+      "2026-03-08",
+      "2026-03-15",
+      "2026-03-22",
+    ]);
+  });
+
+  it("generates month-start ticks for ranges over three months", () => {
+    expect(buildTimeScaleTicks("2026-03-14", "2026-07-20").map(timestampToDateOnly)).toEqual([
+      "2026-04-01",
+      "2026-05-01",
+      "2026-06-01",
+      "2026-07-01",
+    ]);
+  });
+});
+
+describe("aggregateBalancePointsByDate", () => {
+  it("keeps the last balance for each day and summarizes same-day descriptions", () => {
+    expect(
+      aggregateBalancePointsByDate([
+        { date: "2026-03-02", balance: 1_000, description: "Coffee" },
+        { date: "2026-03-01", balance: 2_000, description: "Salary" },
+        { date: "2026-03-02", balance: 700, description: "Lunch" },
+      ]),
+    ).toEqual([
+      {
+        date: "2026-03-01",
+        timestamp: expect.any(Number),
+        balance: 2_000,
+        description: "Salary",
+        eventCount: 1,
+      },
+      {
+        date: "2026-03-02",
+        timestamp: expect.any(Number),
+        balance: 700,
+        description: "Coffee 他1件",
+        eventCount: 2,
+      },
+    ]);
+  });
+});
+
+describe("buildBalanceChartSegments", () => {
+  it("keeps flat actual and forecast lines visible when there are no events", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [],
+      forecastPoints: [],
+      todayPoint: {
+        date: "2026-07-04",
+        balance: 100_000,
+        description: "現在残高",
+      },
+      displayStartDate: "2026-06-04",
+      displayEndDate: "2026-10-04",
+      currentBalance: 100_000,
+    });
+
+    expect(segments.actualLineSeries.map((point) => point.date)).toEqual(["2026-06-04", "2026-07-04"]);
+    expect(segments.actualLineSeries.map((point) => point.balance)).toEqual([100_000, 100_000]);
+    expect(segments.forecastLineSeries.map((point) => point.date)).toEqual(["2026-07-04", "2026-10-04"]);
+    expect(segments.forecastLineSeries.map((point) => point.balance)).toEqual([100_000, 100_000]);
+  });
+
+  it("extends a single actual point to the visible range endpoints", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [{ date: "2026-03-14", balance: 50_000, description: "Salary" }],
+      displayStartDate: "2026-03-01",
+      displayEndDate: "2026-03-31",
+      currentBalance: 50_000,
+    });
+
+    expect(segments.actualLineSeries.map((point) => point.date)).toEqual([
+      "2026-03-01",
+      "2026-03-14",
+      "2026-03-31",
+    ]);
+    expect(segments.actualLineSeries.map((point) => point.balance)).toEqual([50_000, 50_000, 50_000]);
+  });
+
+  it("excludes out-of-window extremes from rendered segments and y-domain", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [{ date: "2026-01-08", balance: 100_000, description: "Past event" }],
+      forecastPoints: [
+        { date: "2026-01-20", balance: 150_000, description: "Visible event" },
+        { date: "2026-10-01", balance: -1_000_000, description: "Outside event" },
+      ],
+      todayPoint: {
+        date: "2026-01-15",
+        balance: 100_000,
+        description: "現在残高",
+      },
+      displayStartDate: "2026-01-01",
+      displayEndDate: "2026-02-15",
+      currentBalance: 100_000,
+    });
+    const displayedBalances = [...segments.actualLineSeries, ...segments.forecastLineSeries].map(
+      (point) => point.balance,
+    );
+
+    expect(displayedBalances).not.toContain(-1_000_000);
+    expect(buildBalanceChartYDomain(displayedBalances, 100_000)).toEqual([90_000, 160_000]);
   });
 });

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -1,5 +1,6 @@
 import type {
   Account,
+  BalanceHistoryResponse,
   DashboardEventsResponse,
   DashboardResponse,
   ForecastEvent,
@@ -32,6 +33,7 @@ import {
   formatDateWithYear,
   parseCurrencyInputValue,
 } from "../lib/format";
+import { getDashboardChartEndDate, getDashboardChartStartDate } from "../lib/balance-chart";
 import { getTodayDate } from "../lib/utils";
 
 type DashboardPeriodPreset = "next1Month" | "next3Months" | "next6Months" | "next1Year" | "all";
@@ -60,6 +62,25 @@ function buildDashboardPath(applyOffset: boolean) {
 
 function buildDashboardEventsPath(months: number, applyOffset: boolean) {
   return `/api/dashboard/events?months=${months}&applyOffset=${String(applyOffset)}`;
+}
+
+function buildDashboardBalanceHistoryPath(params: {
+  selectedAccountId: string | "total";
+  startDate: string;
+  endDate: string;
+  applyOffset: boolean;
+}) {
+  const searchParams = new URLSearchParams({
+    startDate: params.startDate,
+    endDate: params.endDate,
+    applyOffset: String(params.applyOffset),
+  });
+
+  if (params.selectedAccountId !== "total") {
+    searchParams.set("accountId", params.selectedAccountId);
+  }
+
+  return `/api/transactions/balance-history?${searchParams.toString()}`;
 }
 
 function formatSummaryEvent(event: DashboardResponse["nextIncome"] | DashboardResponse["nextExpense"]) {
@@ -154,6 +175,9 @@ export function DashboardPage() {
     accountId: string;
   } | null>(null);
   const months = presetToMonths[periodPreset];
+  const today = getTodayDate();
+  const chartDisplayStartDate = getDashboardChartStartDate(today);
+  const chartDisplayEndDate = getDashboardChartEndDate(today, months);
 
   const {
     data: dashboardData,
@@ -175,8 +199,23 @@ export function DashboardPage() {
     () => apiFetch<DashboardEventsResponse>(buildDashboardEventsPath(months, applyOffset)),
     [reloadKey, months, applyOffset],
   );
+  const {
+    data: balanceHistoryData,
+    loading: balanceHistoryLoading,
+    error: balanceHistoryError,
+  } = useResource(
+    () =>
+      apiFetch<BalanceHistoryResponse>(
+        buildDashboardBalanceHistoryPath({
+          selectedAccountId,
+          startDate: chartDisplayStartDate,
+          endDate: today,
+          applyOffset,
+        }),
+      ),
+    [reloadKey, selectedAccountId, chartDisplayStartDate, today, applyOffset],
+  );
 
-  const today = getTodayDate();
   const accounts = dashboardData?.accounts ?? [];
   const accountForecasts = dashboardData?.dashboard.accountForecasts ?? [];
   const selectedAccountForecast =
@@ -187,7 +226,10 @@ export function DashboardPage() {
     selectedAccountId === "total"
       ? null
       : eventsData?.accountForecasts.find((forecast) => forecast.accountId === selectedAccountId) ?? null;
-  const chartForecast = selectedAccountForecast?.events ?? dashboardData?.dashboard.forecast ?? [];
+  const chartForecast =
+    selectedAccountId === "total"
+      ? eventsData?.forecast ?? dashboardData?.dashboard.forecast ?? []
+      : selectedAccountEvents?.events ?? selectedAccountForecast?.events ?? [];
   const tableForecast = selectedAccountEvents?.events ?? eventsData?.forecast ?? [];
   const overdueForecast = dashboardData?.dashboard.overdueForecast ?? [];
   const visibleOverdueForecast = overdueForecast.filter((event) => !hiddenOverdueIds.includes(event.id));
@@ -197,18 +239,21 @@ export function DashboardPage() {
   const currentBalance =
     selectedAccountForecast?.currentBalance ?? dashboardData?.dashboard.totalBalance ?? 0;
   const displayCurrencyCode: SupportedCurrencyCode = selectedAccountForecast?.currencyCode ?? "JPY";
-  const chartData = [
-    {
-      date: today,
-      description: selectedAccountForecast ? `${selectedAccountForecast.accountName} 現在残高` : "総所持金",
-      balance: currentBalance,
-    },
-    ...chartForecast.map((point) => ({
-      date: point.date,
-      description: point.description,
-      balance: point.balance,
-    })),
-  ];
+  const todayChartPoint = {
+    date: today,
+    description: selectedAccountForecast ? `${selectedAccountForecast.accountName} 現在残高` : "総所持金",
+    balance: currentBalance,
+  };
+  const chartData = (balanceHistoryData?.points ?? []).map((point) => ({
+    date: point.date,
+    description: point.description,
+    balance: point.balance,
+  }));
+  const chartForecastData = chartForecast.map((point) => ({
+    date: point.date,
+    description: point.description,
+    balance: point.balance,
+  }));
   const yellowForecasts = accountForecasts
     .filter((forecast) => forecast.warningLevel === "yellow")
     .map((forecast) => ({
@@ -443,14 +488,19 @@ export function DashboardPage() {
             </Button>
           )}
         </div>
-        {dashboardLoading ? (
+        {dashboardLoading || balanceHistoryLoading || eventsLoading ? (
           <StateMessage message="読み込み中..." />
-        ) : dashboardError ? (
-          <StateMessage message={dashboardError} tone="danger" />
+        ) : dashboardError || balanceHistoryError || eventsError ? (
+          <StateMessage message={dashboardError ?? balanceHistoryError ?? eventsError ?? "読み込みに失敗しました。"} tone="danger" />
         ) : (
           <div className="min-h-0 min-w-0 flex-1">
             <BalanceChart
               data={chartData}
+              forecastData={chartForecastData}
+              todayPoint={todayChartPoint}
+              todayDate={today}
+              displayStartDate={chartDisplayStartDate}
+              displayEndDate={chartDisplayEndDate}
               currentBalance={currentBalance}
               label={selectedAccountForecast?.accountName ?? "総所持金"}
               currencyCode={displayCurrencyCode}


### PR DESCRIPTION
## 背景

プロダクトレビュー（20260702-review.md）指摘 C-3。従来はカテゴリ軸（イベント1件=1目盛り）でイベント密度により時間が歪み、「いつ危ないか」を読むチャートとして機能不全だった。過去実績との接続・今日の位置・最小残高の注釈もなかった。

## 変更内容

- **時間スケール X 軸**（エポック + 月初/週単位 ticks、期間セレクタに追従）
- **stepAfter**: 残高は離散イベントで変わる「水準」なので階段表示。チャート点は日単位に集約（同日複数イベントは「最初のイベント名 他N件」）
- **過去 → 今日 → 未来の接続**: 過去1ヶ月の実績（`/api/transactions/balance-history`、実線）→「今日」縦線 → 予測（同色破線）。実績/予測の区別は破線 + 今日線 + ツールチップの「実績/予測」表記で伝え、色のみに依存しない
- **表示期間の最小残高注釈**（1点のみの選択的直接ラベル。右端15%では左側配置で見切れ防止。全期間の「最小残高」バッジと区別する文言）
- **Y 軸ドメインは表示ウィンドウ内の点のみから計算**（ウィンドウ外の極端値混入の回帰テスト付き）
- 負領域の警告色 ReferenceArea、ゼロライン維持、単一系列のため凡例なし
- tick 生成・日単位集約・ドメイン計算を `lib/balance-chart.ts` の純関数に切り出しユニットテスト

## レビュー過程（スクリーンショット目視で2回差し戻し）

1. 初回: 残高ラインが不可視（単一点セグメント + dot=false）→ セグメント2点保証で修正
2. 2回目: Y軸ドメインが全24ヶ月の予測から計算され表示の下半分が空白 → ウィンドウ内計算に修正 + 注釈見切れ/文言修正

最終スクリーンショット（合計/口座別）で、ステップ形状・実線/破線接続・注釈・ドメインすべて確認済み。

## 検証

- `make lint` / `make typecheck` / `make test-unit` / `make test-e2e`（57件）通過
- 変更は frontend のみ

Implemented-by: Codex (gpt-5.5) / Reviewed-by: Claude (Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)