### PR TITLE
feat: MCP prompts を要約ベースに刷新し monthly-report のデータ欠落を修正

### DIFF
--- a/packages/mcp/src/__tests__/format.test.ts
+++ b/packages/mcp/src/__tests__/format.test.ts
@@ -1,0 +1,250 @@
+import type {
+  AccountsResponse,
+  BillingResponse,
+  CreditCardsResponse,
+  DashboardResponse,
+  LoansResponse,
+  RecurringItemsResponse,
+  SubscriptionsResponse,
+  TransactionsResponse,
+} from "@sui/shared";
+import {
+  formatAccountsText,
+  formatBillingText,
+  formatCreditCardsText,
+  formatForecastAnalysisText,
+  formatLoansText,
+  formatRecurringItemsText,
+  formatSubscriptionsText,
+  formatTransactionsText,
+} from "../format";
+import { describe, expect, it } from "vitest";
+
+const rawJsonKeyPattern = /"[^"\n]+":/;
+
+describe("formatters", () => {
+  it("formats transactions as compact one-line entries with omitted counts", () => {
+    const transactions: TransactionsResponse = {
+      items: [
+        {
+          id: "tx-1",
+          accountId: "account-1",
+          transferToAccountId: null,
+          forecastEventId: null,
+          date: "2026-03-01",
+          type: "expense",
+          description: "スーパー",
+          amount: 5200,
+          amountJpy: 5200,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          currencyCode: "JPY",
+          accountName: "Main",
+        },
+        {
+          id: "tx-2",
+          accountId: "account-1",
+          transferToAccountId: "account-2",
+          forecastEventId: null,
+          date: "2026-03-02",
+          type: "transfer",
+          description: "貯蓄移動",
+          amount: 30000,
+          amountJpy: 30000,
+          createdAt: "2026-03-02T00:00:00.000Z",
+          currencyCode: "JPY",
+          accountName: "Main",
+          transferToAccountName: "Savings",
+          transferToAccountCurrencyCode: "JPY",
+        },
+      ],
+      page: 1,
+      limit: 100,
+      total: 4,
+    };
+
+    const text = formatTransactionsText(transactions);
+
+    expect(text).toContain("取引履歴: 全4件中 2件を表示");
+    expect(text).toContain("2026-03-01 支出 スーパー ￥5,200 / 口座 Main");
+    expect(text).toContain("2026-03-02 振替 貯蓄移動 ￥30,000 / 口座 Main -> Savings");
+    expect(text).toContain("他 2 件省略");
+    expect(text).not.toMatch(rawJsonKeyPattern);
+  });
+
+  it("formats forecast analysis from aggregate events without account-event duplicates", () => {
+    const dashboard: DashboardResponse = {
+      totalBalance: 123456,
+      minBalance: 34567,
+      nextIncome: {
+        id: "income-1",
+        date: "2026-03-25",
+        description: "給与",
+        amount: 250000,
+        amountJpy: 250000,
+        currencyCode: "JPY",
+      },
+      nextExpense: null,
+      overdueForecast: [],
+      forecast: [
+        {
+          id: "event-1",
+          date: "2026-03-25",
+          type: "income",
+          description: "給与",
+          amount: 250000,
+          amountJpy: 250000,
+          balance: 373456,
+          balanceJpy: 373456,
+          currencyCode: "JPY",
+          accountId: "account-1",
+        },
+      ],
+      accountForecasts: [
+        {
+          accountId: "account-1",
+          accountName: "三菱UFJ銀行",
+          currentBalance: 123456,
+          currentBalanceJpy: 123456,
+          currencyCode: "JPY",
+          exchangeRateToJpy: 1,
+          events: [
+            {
+              id: "account-event-1",
+              date: "2026-03-27",
+              type: "expense",
+              description: "口座別だけの重複イベント",
+              amount: 130000,
+              amountJpy: 130000,
+              balance: -1000,
+              balanceJpy: -1000,
+              currencyCode: "JPY",
+              accountId: "account-1",
+            },
+          ],
+          minBalance: 34567,
+          minBalanceJpy: 34567,
+          minBalanceDate: "2026-03-25",
+          warningLevel: "red",
+        },
+      ],
+    };
+
+    const text = formatForecastAnalysisText(dashboard, 6);
+
+    expect(text).toContain("2026-03-25 収入 給与 ￥250,000 残高 ￥373,456");
+    expect(text).toContain("三菱UFJ銀行: 現在 ￥123,456 / 最小");
+    expect(text).toContain("2026-03-27");
+    expect(text).not.toContain("口座別だけの重複イベント");
+    expect(text).not.toMatch(rawJsonKeyPattern);
+  });
+
+  it("formats list-style API responses without raw JSON", () => {
+    const account = {
+      id: "account-1",
+      name: "Main",
+      balance: 123456,
+      balanceOffset: 1000,
+      lastReconciledAt: null,
+      currencyCode: "JPY",
+      exchangeRateToJpy: 1,
+      exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+      sortOrder: 1,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    } as const;
+    const sections = [
+      formatAccountsText([account] as AccountsResponse),
+      formatRecurringItemsText([
+        {
+          id: "recurring-1",
+          name: "家賃",
+          type: "expense",
+          amount: 80000,
+          dayOfMonth: 27,
+          startDate: null,
+          endDate: null,
+          dateShiftPolicy: "previous",
+          accountId: "account-1",
+          account,
+          transferToAccountId: null,
+          transferToAccount: null,
+          enabled: true,
+          sortOrder: 1,
+          deletedAt: null,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ] as RecurringItemsResponse),
+      formatCreditCardsText([
+        {
+          id: "card-1",
+          name: "Visa",
+          settlementDay: 27,
+          accountId: "account-1",
+          account,
+          assumptionAmount: 50000,
+          dateShiftPolicy: "next",
+          sortOrder: 1,
+          deletedAt: null,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ] as CreditCardsResponse),
+      formatSubscriptionsText([
+        {
+          id: "subscription-1",
+          name: "Music",
+          amount: 980,
+          intervalMonths: 1,
+          startDate: "2026-01-01",
+          dayOfMonth: 10,
+          endDate: null,
+          paymentSource: "Visa",
+          deletedAt: null,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ] as SubscriptionsResponse),
+      formatLoansText([
+        {
+          id: "loan-1",
+          name: "PCローン",
+          totalAmount: 240000,
+          startDate: "2026-04-30",
+          paymentCount: 12,
+          dateShiftPolicy: "previous",
+          paymentMethod: "account_withdrawal",
+          accountId: "account-1",
+          account,
+          remainingBalance: 180000,
+          remainingPayments: 9,
+          nextPaymentAmount: 20000,
+          deletedAt: null,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ] as LoansResponse),
+      formatBillingText({
+        yearMonth: "2026-03",
+        settlementDate: "2026-03-27",
+        resolvedSettlementDate: "2026-03-27",
+        items: [{ creditCardId: "card-1", amount: 50000 }],
+        total: 50000,
+        appliedTotal: 50000,
+        safetyValveActive: false,
+        sourceType: "actual",
+        monthOffset: 0,
+      } as BillingResponse),
+    ];
+
+    const text = sections.join("\n\n");
+
+    expect(text).toContain("家賃: 支出 ￥80,000");
+    expect(text).toContain("Visa: 引落日 27");
+    expect(text).toContain("Music: ￥980");
+    expect(text).toContain("PCローン: 総額 ￥240,000");
+    expect(text).toContain("カード card-1: ￥50,000");
+    expect(text).not.toMatch(rawJsonKeyPattern);
+  });
+});

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -37,6 +37,35 @@ function getToolText(result: unknown) {
   return result.content[0].text;
 }
 
+function getPromptText(result: unknown) {
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    !("messages" in result) ||
+    !Array.isArray(result.messages) ||
+    result.messages.length === 0
+  ) {
+    return "";
+  }
+
+  const message = result.messages[0];
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    !("content" in message) ||
+    typeof message.content !== "object" ||
+    message.content === null ||
+    !("type" in message.content) ||
+    message.content.type !== "text" ||
+    !("text" in message.content) ||
+    typeof message.content.text !== "string"
+  ) {
+    return "";
+  }
+
+  return message.content.text;
+}
+
 function getStructuredContent(result: unknown) {
   if (typeof result !== "object" || result === null || !("structuredContent" in result)) {
     return undefined;
@@ -44,6 +73,8 @@ function getStructuredContent(result: unknown) {
 
   return result.structuredContent;
 }
+
+const rawJsonKeyPattern = /"[^"\n]+":/;
 
 function createFetchStub() {
   const requests: Array<{ method: string; path: string; body?: unknown }> = [];
@@ -1131,18 +1162,289 @@ describe("MCP server", () => {
     });
   });
 
+  it("builds monthly-report with month-scoped transaction details", async () => {
+    const items = Array.from({ length: 100 }, (_, index) => ({
+      id: `monthly-tx-${index + 1}`,
+      accountId: "11111111-1111-4111-a111-111111111111",
+      transferToAccountId: null,
+      forecastEventId: null,
+      date: index === 0 ? "2026-03-25" : "2026-03-20",
+      type: index === 0 ? "income" : "expense",
+      description: index === 0 ? "給与" : `支出${index}`,
+      amount: index === 0 ? 250000 : 1000 + index,
+      amountJpy: index === 0 ? 250000 : 1000 + index,
+      createdAt: "2026-03-20T00:00:00.000Z",
+      currencyCode: "JPY",
+      accountName: "Main",
+    }));
+    addRoute("GET", "/api/transactions?page=1&limit=100&startDate=2026-03-01&endDate=2026-03-31", {
+      body: {
+        items,
+        page: 1,
+        limit: 100,
+        total: 101,
+      },
+    });
+
+    const prompt = await client.getPrompt({
+      name: "monthly-report",
+      arguments: { month: "2026-03" },
+    });
+
+    const promptText = getPromptText(prompt);
+    expect(promptText).toContain("【取引履歴（対象月）】");
+    expect(promptText).toContain("2026-03-25 収入 給与 ￥250,000 / 口座 Main");
+    expect(promptText).toContain("2026-03-20 支出 支出1 ￥1,001 / 口座 Main");
+    expect(promptText).toContain("他 1 件省略");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/transactions?page=1&limit=100&startDate=2026-03-01&endDate=2026-03-31",
+      body: undefined,
+    });
+  });
+
+  it("builds prompts without raw JSON key notation", async () => {
+    const prompts = await Promise.all([
+      client.getPrompt({ name: "monthly-report", arguments: { month: "2026-03" } }),
+      client.getPrompt({ name: "budget-advice", arguments: {} }),
+      client.getPrompt({ name: "forecast-analysis", arguments: { months: "6" } }),
+      client.getPrompt({ name: "expense-breakdown", arguments: { month: "2026-03" } }),
+    ]);
+
+    for (const prompt of prompts) {
+      const promptText = getPromptText(prompt);
+      expect(promptText).not.toContain("\"totalBalance\":");
+      expect(promptText).not.toMatch(rawJsonKeyPattern);
+    }
+  });
+
+  it("keeps prompt text substantially shorter than legacy JSON dumps", async () => {
+    const dateFor = (index: number) =>
+      `2026-${String(3 + (index % 9)).padStart(2, "0")}-${String(1 + (index % 27)).padStart(2, "0")}`;
+    const accounts = Array.from({ length: 4 }, (_, index) => ({
+      id: `account-${index + 1}`,
+      name: `口座${index + 1}`,
+      balance: 120000 + index * 30000,
+      balanceOffset: index * 1000,
+      lastReconciledAt: null,
+      currencyCode: "JPY",
+      exchangeRateToJpy: 1,
+      exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+      sortOrder: index + 1,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    }));
+    const forecast = Array.from({ length: 48 }, (_, index) => {
+      const type = index % 5 === 0 ? "income" : index % 7 === 0 ? "transfer" : "expense";
+      const amount = type === "income" ? 250000 : 18000 + index * 700;
+      const balance = 480000 - index * 8500 + (type === "income" ? amount : -amount);
+      return {
+        id: `forecast-${index + 1}`,
+        date: dateFor(index),
+        type,
+        description: `予測イベント${index + 1} ${"詳細".repeat(8)}`,
+        amount,
+        amountJpy: amount,
+        balance,
+        balanceJpy: balance,
+        currencyCode: "JPY",
+        accountId: accounts[index % accounts.length].id,
+        transferToAccountId: type === "transfer" ? accounts[(index + 1) % accounts.length].id : null,
+      };
+    });
+    const accountForecasts = accounts.map((account, accountIndex) => ({
+      accountId: account.id,
+      accountName: account.name,
+      currentBalance: account.balance,
+      currentBalanceJpy: account.balance,
+      currencyCode: "JPY",
+      exchangeRateToJpy: 1,
+      events: forecast.map((event, eventIndex) => ({
+        ...event,
+        id: `${account.id}-${event.id}`,
+        accountId: account.id,
+        description: `${event.description} ${account.name}側の重複明細`,
+        balance: event.balance - accountIndex * 25000 - eventIndex * 300,
+        balanceJpy: event.balance - accountIndex * 25000 - eventIndex * 300,
+      })),
+      minBalance: -50000 - accountIndex * 10000,
+      minBalanceJpy: -50000 - accountIndex * 10000,
+      minBalanceDate: "2026-10-27",
+      warningLevel: accountIndex % 2 === 0 ? "red" : "yellow",
+    }));
+    const dashboard = {
+      totalBalance: 540000,
+      minBalance: -50000,
+      nextIncome: forecast.find((event) => event.type === "income") ?? null,
+      nextExpense: forecast.find((event) => event.type === "expense") ?? null,
+      overdueForecast: forecast.slice(0, 4),
+      forecast,
+      accountForecasts,
+    };
+    const recurring = Array.from({ length: 20 }, (_, index) => ({
+      id: `recurring-${index + 1}`,
+      name: `固定費${index + 1}`,
+      type: index % 6 === 0 ? "income" : "expense",
+      amount: 5000 + index * 2000,
+      dayOfMonth: (index % 27) + 1,
+      startDate: "2026-01-01",
+      endDate: null,
+      dateShiftPolicy: index % 2 === 0 ? "previous" : "next",
+      accountId: accounts[index % accounts.length].id,
+      account: accounts[index % accounts.length],
+      transferToAccountId: null,
+      transferToAccount: null,
+      enabled: true,
+      sortOrder: index + 1,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    }));
+    const creditCards = Array.from({ length: 8 }, (_, index) => ({
+      id: `card-${index + 1}`,
+      name: `カード${index + 1}`,
+      settlementDay: (index % 27) + 1,
+      accountId: accounts[index % accounts.length].id,
+      account: accounts[index % accounts.length],
+      assumptionAmount: 30000 + index * 5000,
+      dateShiftPolicy: "next",
+      sortOrder: index + 1,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    }));
+    const loans = Array.from({ length: 6 }, (_, index) => ({
+      id: `loan-${index + 1}`,
+      name: `ローン${index + 1}`,
+      totalAmount: 240000 + index * 100000,
+      startDate: "2026-01-31",
+      paymentCount: 24,
+      dateShiftPolicy: "previous",
+      paymentMethod: index % 2 === 0 ? "account_withdrawal" : "credit_card",
+      accountId: accounts[index % accounts.length].id,
+      account: accounts[index % accounts.length],
+      remainingBalance: 180000 + index * 80000,
+      remainingPayments: 18 - index,
+      nextPaymentAmount: 10000 + index * 2500,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    }));
+    const billing = {
+      yearMonth: "2026-03",
+      settlementDate: "2026-03-27",
+      resolvedSettlementDate: "2026-03-27",
+      items: creditCards.map((card, index) => ({
+        creditCardId: card.id,
+        amount: 25000 + index * 3500,
+      })),
+      total: 298000,
+      appliedTotal: 298000,
+      safetyValveActive: false,
+      sourceType: "actual",
+      monthOffset: 0,
+    };
+    const transactions = {
+      items: Array.from({ length: 100 }, (_, index) => ({
+        id: `tx-${index + 1}`,
+        accountId: accounts[index % accounts.length].id,
+        transferToAccountId: index % 11 === 0 ? accounts[(index + 1) % accounts.length].id : null,
+        forecastEventId: index % 3 === 0 ? `forecast-${(index % forecast.length) + 1}` : null,
+        date: dateFor(index),
+        type: index % 13 === 0 ? "income" : index % 11 === 0 ? "transfer" : "expense",
+        description: `取引${index + 1} ${"メモ".repeat(10)}`,
+        amount: 1000 + index * 120,
+        amountJpy: 1000 + index * 120,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        currencyCode: "JPY",
+        accountName: accounts[index % accounts.length].name,
+        transferToAccountName: index % 11 === 0 ? accounts[(index + 1) % accounts.length].name : null,
+        transferToAccountCurrencyCode: index % 11 === 0 ? "JPY" : null,
+      })),
+      page: 1,
+      limit: 100,
+      total: 125,
+    };
+    const dashboardEvents = {
+      forecast: forecast.slice(0, 36),
+      accountForecasts: accountForecasts.map((forecastItem) => ({
+        accountId: forecastItem.accountId,
+        accountName: forecastItem.accountName,
+        events: forecastItem.events.slice(0, 36),
+      })),
+    };
+    const scopedDashboard = {
+      ...dashboard,
+      forecast: dashboardEvents.forecast,
+      accountForecasts: dashboard.accountForecasts.map((forecastItem) => ({
+        ...forecastItem,
+        events: dashboardEvents.accountForecasts.find((item) => item.accountId === forecastItem.accountId)?.events ?? [],
+      })),
+    };
+
+    addRoute("GET", "/api/dashboard?applyOffset=true", { body: dashboard });
+    addRoute("GET", "/api/dashboard/events?months=6&applyOffset=true", { body: dashboardEvents });
+    addRoute("GET", "/api/accounts", { body: accounts });
+    addRoute("GET", "/api/recurring-items", { body: recurring });
+    addRoute("GET", "/api/credit-cards", { body: creditCards });
+    addRoute("GET", "/api/loans", { body: loans });
+    addRoute("GET", "/api/billings?month=2026-03", { body: billing });
+    addRoute("GET", "/api/transactions?page=1&limit=100&startDate=2026-03-01&endDate=2026-03-31", {
+      body: transactions,
+    });
+
+    const [monthly, budget, forecastPrompt, expense] = await Promise.all([
+      client.getPrompt({ name: "monthly-report", arguments: { month: "2026-03" } }),
+      client.getPrompt({ name: "budget-advice", arguments: {} }),
+      client.getPrompt({ name: "forecast-analysis", arguments: { months: "6" } }),
+      client.getPrompt({ name: "expense-breakdown", arguments: { month: "2026-03" } }),
+    ]);
+
+    const legacyMonthly = [
+      "【ダッシュボードデータ】",
+      JSON.stringify(dashboard, null, 2),
+      "【請求データ】",
+      JSON.stringify(billing, null, 2),
+      "【口座一覧】",
+      JSON.stringify(accounts, null, 2),
+    ].join("\n");
+    const legacyBudget = [
+      JSON.stringify(dashboard, null, 2),
+      JSON.stringify(recurring, null, 2),
+      JSON.stringify(creditCards, null, 2),
+      JSON.stringify(loans, null, 2),
+    ].join("\n");
+    const legacyForecast = JSON.stringify(scopedDashboard, null, 2);
+    const legacyExpense = [
+      JSON.stringify(transactions, null, 2),
+      JSON.stringify(billing, null, 2),
+      JSON.stringify(recurring, null, 2),
+    ].join("\n");
+
+    expect(getPromptText(monthly).length).toBeLessThan(legacyMonthly.length / 2);
+    expect(getPromptText(budget).length).toBeLessThan(legacyBudget.length / 2);
+    expect(getPromptText(forecastPrompt).length).toBeLessThan(legacyForecast.length / 2);
+    expect(getPromptText(expense).length).toBeLessThan(legacyExpense.length / 2);
+  });
+
   it("builds forecast-analysis with month-scoped dashboard events", async () => {
     const prompt = await client.getPrompt({
       name: "forecast-analysis",
       arguments: { months: "6" },
     });
 
-    const promptText = prompt.messages[0]?.content.type === "text"
-      ? prompt.messages[0].content.text
-      : "";
+    const promptText = getPromptText(prompt);
     expect(promptText).toContain("今後 6 ヶ月");
-    expect(promptText).toContain("\"forecast\": [");
+    expect(promptText).toContain("【合計残高予測イベント】");
+    expect(promptText).toContain("2026-03-25 収入 給与 ￥250,000 残高 ￥373,456");
     expect(promptText).not.toContain("\"id\": \"event-2\"");
+    expect(promptText).not.toMatch(rawJsonKeyPattern);
 
     const requests = (globalThis as typeof globalThis & {
       __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;

--- a/packages/mcp/src/format.ts
+++ b/packages/mcp/src/format.ts
@@ -5,9 +5,12 @@ import type {
   BillingResponse,
   CreditCardsResponse,
   DashboardResponse,
+  ForecastEvent,
   LoansResponse,
   RecurringItemsResponse,
   SubscriptionsResponse,
+  SupportedCurrencyCode,
+  Transaction,
   TransactionsResponse,
 } from "@sui/shared";
 import { DEFAULT_SETTINGS } from "@sui/shared";
@@ -24,8 +27,20 @@ const SUBSCRIPTION_FORECAST_NOTE =
 const MANUAL_CONFIRM_NOTE =
   "予定日超過イベントも自動確定しません。実際の金額と口座を確認してから confirm_forecast で手動確定してください。";
 
-function formatCurrency(amount: number) {
-  return currencyFormatter.format(amount);
+function formatCurrency(amount: number | null | undefined, currencyCode?: SupportedCurrencyCode | null) {
+  if (typeof amount !== "number") {
+    return "未設定";
+  }
+
+  if (!currencyCode || currencyCode === "JPY") {
+    return currencyFormatter.format(amount);
+  }
+
+  return new Intl.NumberFormat("ja-JP", {
+    style: "currency",
+    currency: currencyCode,
+    maximumFractionDigits: 2,
+  }).format(amount);
 }
 
 function formatForecastEventType(type: "income" | "expense" | "transfer") {
@@ -40,6 +55,43 @@ function formatForecastEventType(type: "income" | "expense" | "transfer") {
   return "振替";
 }
 
+function formatTransactionType(type: Transaction["type"]) {
+  if (type === "adjustment") {
+    return "調整";
+  }
+
+  return formatForecastEventType(type);
+}
+
+function formatEnabled(enabled: boolean) {
+  return enabled ? "有効" : "無効";
+}
+
+function formatDateShiftPolicy(policy?: string | null) {
+  if (policy === "previous") {
+    return "前営業日";
+  }
+  if (policy === "next") {
+    return "翌営業日";
+  }
+  return "調整なし";
+}
+
+function formatAccountName(
+  account?: { name?: string | null } | null,
+  accountId?: string | null,
+) {
+  return account?.name ?? accountId ?? "未設定";
+}
+
+function formatTransferSuffix(
+  transferToAccount?: { name?: string | null } | null,
+  transferToAccountId?: string | null,
+) {
+  const transferTarget = formatAccountName(transferToAccount, transferToAccountId);
+  return transferTarget === "未設定" ? "" : ` -> ${transferTarget}`;
+}
+
 function formatAccountForecast(item: AccountForecast) {
   const warning = item.warningLevel === "red"
     ? " 🔴 実残高不足"
@@ -51,6 +103,10 @@ function formatAccountForecast(item: AccountForecast) {
 
 export function formatJson(data: unknown) {
   return JSON.stringify(data, null, 2);
+}
+
+function formatEmptyList(title: string) {
+  return `${title}: 0件\n  ありません`;
 }
 
 export function formatDashboardText(data: DashboardResponse, today: string) {
@@ -107,6 +163,25 @@ export function formatDashboardText(data: DashboardResponse, today: string) {
   lines.push(`未確定イベント総数: ${data.forecast.length}件（予定日超過 ${overdueForecast.length}件）`);
 
   return lines.join("\n");
+}
+
+function getAccountMinBalance(forecast: AccountForecast) {
+  return forecast.events.reduce<{
+    balance: number;
+    balanceJpy: number;
+    currencyCode: SupportedCurrencyCode | null;
+    date: string;
+  } | null>((current, event) => {
+    if (!current || event.balance < current.balance) {
+      return {
+        balance: event.balance,
+        balanceJpy: event.balanceJpy,
+        currencyCode: event.currencyCode,
+        date: event.date,
+      };
+    }
+    return current;
+  }, null);
 }
 
 export function formatForecastSummary(data: DashboardResponse, forecastMonths?: number) {
@@ -169,54 +244,174 @@ export function formatForecastSummary(data: DashboardResponse, forecastMonths?: 
   return lines.join("\n");
 }
 
-function summarizeList(title: string, count: number, data: unknown) {
-  return `${title}: ${count}件\n\n${formatJson(data)}`;
+export function formatForecastAnalysisText(data: DashboardResponse, forecastMonths?: number) {
+  const lines = [
+    formatForecastSummary(data, forecastMonths),
+    "",
+    "【合計残高予測イベント】",
+  ];
+
+  if (data.forecast.length === 0) {
+    lines.push("  イベントはありません");
+  } else {
+    for (const event of data.forecast) {
+      lines.push(formatForecastEventLine(event));
+    }
+  }
+
+  lines.push("", "【口座別最小残高】");
+  if (data.accountForecasts.length === 0) {
+    lines.push("  口座はありません");
+  } else {
+    for (const forecast of data.accountForecasts) {
+      const minEvent = getAccountMinBalance(forecast);
+      const minBalance = minEvent?.balance ?? forecast.minBalance;
+      const minDate = minEvent?.date ?? forecast.minBalanceDate;
+      const currencyCode = minEvent?.currencyCode ?? forecast.currencyCode;
+      const warning = forecast.warningLevel === "red"
+        ? " / 警告: 実残高不足"
+        : forecast.warningLevel === "yellow"
+          ? " / 警告: 可処分残高不足"
+          : "";
+      lines.push(
+        `  ${forecast.accountName}: 現在 ${formatCurrency(forecast.currentBalance, forecast.currencyCode)} / 最小 ${formatCurrency(minBalance, currencyCode)}（${minDate}）${warning}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function formatForecastEventLine(event: ForecastEvent) {
+  const typeLabel = formatForecastEventType(event.type);
+  return `  ${event.date} ${typeLabel} ${event.description} ${formatCurrency(event.amount, event.currencyCode)} 残高 ${formatCurrency(event.balance, event.currencyCode)}`;
 }
 
 export function formatAccountsText(accounts: AccountsResponse) {
-  return summarizeList("口座一覧", accounts.length, accounts);
+  if (accounts.length === 0) {
+    return formatEmptyList("口座一覧");
+  }
+
+  return [
+    `口座一覧: ${accounts.length}件`,
+    ...accounts.map((account) =>
+      `  ${account.name}: 残高 ${formatCurrency(account.balance, account.currencyCode)} / オフセット ${formatCurrency(account.balanceOffset, account.currencyCode)} / 並び順 ${account.sortOrder}`
+    ),
+  ].join("\n");
 }
 
 export function formatRecurringItemsText(items: RecurringItemsResponse) {
-  return summarizeList("固定収支一覧", items.length, items);
+  if (items.length === 0) {
+    return formatEmptyList("固定収支一覧");
+  }
+
+  return [
+    `固定収支一覧: ${items.length}件`,
+    ...items.map((item) => {
+      const transfer = item.type === "transfer"
+        ? formatTransferSuffix(item.transferToAccount, item.transferToAccountId)
+        : "";
+      return `  ${item.name}: ${formatForecastEventType(item.type)} ${formatCurrency(item.amount)} / 毎月${item.dayOfMonth}日 / ${formatEnabled(item.enabled)} / 口座 ${formatAccountName(item.account, item.accountId)}${transfer} / 期間 ${item.startDate ?? "指定なし"}〜${item.endDate ?? "継続"} / 日付調整 ${formatDateShiftPolicy(item.dateShiftPolicy)}`;
+    }),
+  ].join("\n");
 }
 
 export function formatCreditCardsText(cards: CreditCardsResponse) {
-  return summarizeList("クレジットカード一覧", cards.length, cards);
+  if (cards.length === 0) {
+    return formatEmptyList("クレジットカード一覧");
+  }
+
+  return [
+    `クレジットカード一覧: ${cards.length}件`,
+    ...cards.map((card) =>
+      `  ${card.name}: 引落日 ${card.settlementDay ?? "未設定"} / 仮定請求額 ${formatCurrency(card.assumptionAmount)} / 引落口座 ${formatAccountName(card.account, card.accountId)} / 日付調整 ${formatDateShiftPolicy(card.dateShiftPolicy)}`
+    ),
+  ].join("\n");
 }
 
 export function formatSubscriptionsText(subscriptions: SubscriptionsResponse) {
+  if (subscriptions.length === 0) {
+    return [
+      formatEmptyList("サブスク一覧"),
+      `注記: ${SUBSCRIPTION_FORECAST_NOTE}`,
+    ].join("\n");
+  }
+
   return [
     `サブスク一覧: ${subscriptions.length}件`,
     `注記: ${SUBSCRIPTION_FORECAST_NOTE}`,
     "",
-    formatJson(subscriptions),
+    ...subscriptions.map((subscription) =>
+      `  ${subscription.name}: ${formatCurrency(subscription.amount)} / ${subscription.intervalMonths}ヶ月ごと ${subscription.dayOfMonth}日 / 開始 ${subscription.startDate} / 終了 ${subscription.endDate ?? "なし"} / 支払元 ${subscription.paymentSource ?? "未設定"}`
+    ),
   ].join("\n");
 }
 
 export function formatLoansText(loans: LoansResponse) {
-  return summarizeList("ローン一覧", loans.length, loans);
+  if (loans.length === 0) {
+    return formatEmptyList("ローン一覧");
+  }
+
+  return [
+    `ローン一覧: ${loans.length}件`,
+    ...loans.map((loan) =>
+      `  ${loan.name}: 総額 ${formatCurrency(loan.totalAmount)} / 残高 ${formatCurrency(loan.remainingBalance)} / 次回 ${formatCurrency(loan.nextPaymentAmount)} / 残 ${loan.remainingPayments}/${loan.paymentCount}回 / 開始 ${loan.startDate} / 支払 ${loan.paymentMethod} / 口座 ${formatAccountName(loan.account, loan.accountId)} / 日付調整 ${formatDateShiftPolicy(loan.dateShiftPolicy)}`
+    ),
+  ].join("\n");
 }
 
 export function formatBillingText(billing: BillingResponse) {
-  return [
+  const lines = [
     `請求月: ${billing.yearMonth}`,
     `確定請求額合計: ${formatCurrency(billing.total)}`,
     `適用請求額合計: ${formatCurrency(billing.appliedTotal)}`,
     `請求ソース: ${billing.sourceType}`,
+    `引落予定日: ${billing.resolvedSettlementDate ?? billing.settlementDate ?? "未設定"}`,
+    `セーフティバルブ: ${billing.safetyValveActive ? "有効" : "無効"}`,
     "",
-    formatJson(billing),
-  ].join("\n");
+    "【請求明細】",
+  ];
+
+  if (billing.items.length === 0) {
+    lines.push("  明細はありません");
+  } else {
+    for (const item of billing.items) {
+      lines.push(`  カード ${item.creditCardId}: ${formatCurrency(item.amount)}`);
+    }
+  }
+
+  return lines.join("\n");
 }
 
 export function formatTransactionsText(transactions: TransactionsResponse) {
-  return [
-    `取引履歴: ${transactions.total}件中 ${transactions.items.length}件を表示`,
-    `ページ: ${transactions.page}`,
-    `件数: ${transactions.limit}`,
-    "",
-    formatJson(transactions),
-  ].join("\n");
+  const omittedCount = Math.max(transactions.total - transactions.items.length, 0);
+  const lines = [
+    `取引履歴: 全${transactions.total}件中 ${transactions.items.length}件を表示（ページ ${transactions.page}, 件数 ${transactions.limit}）`,
+  ];
+
+  if (transactions.items.length === 0) {
+    lines.push("  ありません");
+  } else {
+    for (const transaction of transactions.items) {
+      lines.push(formatTransactionLine(transaction));
+    }
+  }
+
+  if (omittedCount > 0) {
+    lines.push(`他 ${omittedCount} 件省略`);
+  }
+
+  return lines.join("\n");
+}
+
+export function formatTransactionLine(transaction: Transaction) {
+  const transfer = transaction.type === "transfer"
+    ? formatTransferSuffix(
+      transaction.transferToAccountName ? { name: transaction.transferToAccountName } : null,
+      transaction.transferToAccountId,
+    )
+    : "";
+  return `  ${transaction.date} ${formatTransactionType(transaction.type)} ${transaction.description} ${formatCurrency(transaction.amount, transaction.currencyCode)} / 口座 ${formatAccountName(transaction.accountName ? { name: transaction.accountName } : null, transaction.accountId)}${transfer}`;
 }
 
 export function formatBalanceHistory(data: BalanceHistoryResponse) {

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -1,4 +1,10 @@
-import type { BillingResponse, DashboardResponse } from "@sui/shared";
+import type { AccountsResponse, BillingResponse, DashboardResponse, TransactionsResponse } from "@sui/shared";
+import {
+  formatAccountsText,
+  formatBillingText,
+  formatForecastSummary,
+  formatTransactionsText,
+} from "./format";
 import { z } from "zod";
 
 export const uuidSchema = z.string().uuid();
@@ -40,9 +46,24 @@ export function textResource(uri: string, text: string) {
   };
 }
 
-export function buildMonthlyReportPrompt(month: string, dashboard: DashboardResponse, billing: BillingResponse, accounts: unknown) {
+export function toMonthDateRange(month: string) {
+  const [year, monthIndex] = month.split("-").map(Number);
+  const startDate = `${month}-01`;
+  const lastDay = new Date(Date.UTC(year, monthIndex, 0)).getUTCDate();
+  const endDate = `${month}-${String(lastDay).padStart(2, "0")}`;
+
+  return { startDate, endDate };
+}
+
+export function buildMonthlyReportPrompt(
+  month: string,
+  dashboard: DashboardResponse,
+  billing: BillingResponse,
+  accounts: AccountsResponse,
+  transactions: TransactionsResponse,
+) {
   return [
-    `以下のデータをもとに、${month} の月次収支レポートを日本語で作成してください。`,
+    `以下の要約データをもとに、${month} の月次収支レポートを日本語で作成してください。`,
     "",
     "レポートには以下を含めてください：",
     "1. 当月の確定済み収入・支出の一覧と合計",
@@ -50,13 +71,16 @@ export function buildMonthlyReportPrompt(month: string, dashboard: DashboardResp
     "3. 口座残高の変動",
     "4. 特筆すべき項目やアドバイス",
     "",
-    "【ダッシュボードデータ】",
-    JSON.stringify(dashboard, null, 2),
+    "【ダッシュボード要約】",
+    formatForecastSummary(dashboard),
     "",
-    "【請求データ】",
-    JSON.stringify(billing, null, 2),
+    "【取引履歴（対象月）】",
+    formatTransactionsText(transactions),
+    "",
+    "【請求データ要約】",
+    formatBillingText(billing),
     "",
     "【口座一覧】",
-    JSON.stringify(accounts, null, 2),
+    formatAccountsText(accounts),
   ].join("\n");
 }

--- a/packages/mcp/src/prompts/budget-advice.ts
+++ b/packages/mcp/src/prompts/budget-advice.ts
@@ -9,17 +9,17 @@ import type {
   TransactionsResponse,
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
-import { booleanFlagSchema, yearMonthSchema } from "../helpers";
+import {
+  formatBillingText,
+  formatCreditCardsText,
+  formatForecastAnalysisText,
+  formatForecastSummary,
+  formatLoansText,
+  formatRecurringItemsText,
+  formatTransactionsText,
+} from "../format";
+import { booleanFlagSchema, toMonthDateRange, yearMonthSchema } from "../helpers";
 import { z } from "zod";
-
-function toMonthDateRange(month: string) {
-  const [year, monthIndex] = month.split("-").map(Number);
-  const startDate = `${month}-01`;
-  const lastDay = new Date(Date.UTC(year, monthIndex, 0)).getUTCDate();
-  const endDate = `${month}-${String(lastDay).padStart(2, "0")}`;
-
-  return { startDate, endDate };
-}
 
 function replaceDashboardEvents(
   dashboard: DashboardResponse,
@@ -62,7 +62,7 @@ export function registerAnalysisPrompts(server: McpServer, apiClient: SuiApiClie
           content: {
             type: "text" as const,
             text: [
-              "以下の家計データを分析し、日本語で具体的な改善アドバイスをしてください。",
+              "以下の要約データを分析し、日本語で具体的な改善アドバイスをしてください。",
               "",
               "分析の観点：",
               "- 収入に対する固定費の割合",
@@ -71,17 +71,17 @@ export function registerAnalysisPrompts(server: McpServer, apiClient: SuiApiClie
               "- 残高がマイナスになるリスク",
               "- 節約できそうな項目",
               "",
-              "【ダッシュボード】",
-              JSON.stringify(dashboard, null, 2),
+              "【ダッシュボード要約】",
+              formatForecastSummary(dashboard),
               "",
               "【固定収支】",
-              JSON.stringify(recurring, null, 2),
+              formatRecurringItemsText(recurring),
               "",
               "【クレジットカード】",
-              JSON.stringify(creditCards, null, 2),
+              formatCreditCardsText(creditCards),
               "",
               "【ローン】",
-              JSON.stringify(loans, null, 2),
+              formatLoansText(loans),
             ].join("\n"),
           },
         }],
@@ -118,8 +118,8 @@ export function registerAnalysisPrompts(server: McpServer, apiClient: SuiApiClie
               "3. 影響の大きい定期収支や請求",
               "4. 具体的な対策案",
               "",
-              "【ダッシュボード】",
-              JSON.stringify(scopedDashboard, null, 2),
+              "【残高予測要約】",
+              formatForecastAnalysisText(scopedDashboard, months),
             ].join("\n"),
           },
         }],
@@ -159,13 +159,13 @@ export function registerAnalysisPrompts(server: McpServer, apiClient: SuiApiClie
               "3. 特徴的な支出や改善余地",
               "",
               "【取引履歴】",
-              JSON.stringify(transactions, null, 2),
+              formatTransactionsText(transactions),
               "",
-              "【請求データ】",
-              JSON.stringify(billing, null, 2),
+              "【請求データ要約】",
+              formatBillingText(billing),
               "",
               "【固定収支】",
-              JSON.stringify(recurring, null, 2),
+              formatRecurringItemsText(recurring),
             ].join("\n"),
           },
         }],

--- a/packages/mcp/src/prompts/monthly-report.ts
+++ b/packages/mcp/src/prompts/monthly-report.ts
@@ -1,7 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { AccountsResponse, BillingResponse, DashboardResponse } from "@sui/shared";
+import type { AccountsResponse, BillingResponse, DashboardResponse, TransactionsResponse } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
-import { booleanFlagSchema, buildMonthlyReportPrompt, yearMonthSchema } from "../helpers";
+import {
+  booleanFlagSchema,
+  buildMonthlyReportPrompt,
+  toMonthDateRange,
+  yearMonthSchema,
+} from "../helpers";
 
 export function registerMonthlyReportPrompt(server: McpServer, apiClient: SuiApiClient) {
   server.prompt(
@@ -12,10 +17,14 @@ export function registerMonthlyReportPrompt(server: McpServer, apiClient: SuiApi
       applyOffset: booleanFlagSchema.optional().describe("残高オフセットを適用するか"),
     },
     async ({ month, applyOffset = true }) => {
-      const [dashboard, billing, accounts] = await Promise.all([
+      const { startDate, endDate } = toMonthDateRange(month);
+      const [dashboard, billing, accounts, transactions] = await Promise.all([
         apiClient.get<DashboardResponse>(`/api/dashboard?applyOffset=${String(applyOffset)}`),
         apiClient.get<BillingResponse>(`/api/billings?month=${month}`),
         apiClient.get<AccountsResponse>("/api/accounts"),
+        apiClient.get<TransactionsResponse>(
+          `/api/transactions?page=1&limit=100&startDate=${startDate}&endDate=${endDate}`,
+        ),
       ]);
 
       return {
@@ -23,7 +32,7 @@ export function registerMonthlyReportPrompt(server: McpServer, apiClient: SuiApi
           role: "user" as const,
           content: {
             type: "text" as const,
-            text: buildMonthlyReportPrompt(month, dashboard, billing, accounts),
+            text: buildMonthlyReportPrompt(month, dashboard, billing, accounts, transactions),
           },
         }],
       };


### PR DESCRIPTION
## 背景

プロダクトレビュー（20260702-review.md）指摘 B-3。prompts は `JSON.stringify(data, null, 2)` の全量埋め込みでトークンが爆発し、monthly-report は「当月の確定済み収入・支出の一覧」を LLM に要求しながら**取引履歴を一切渡していなかった**（無いデータから一覧を作れという指示 = 幻覚の設計的保証）。

## 変更内容

- **monthly-report**: 対象月の取引履歴（`limit=100`、超過分は「他 N 件省略」明示）を取得してプロンプトに含める
- **JSON 全ダンプ廃止**: 全 prompt のデータ埋め込みを 1行/件のコンパクト整形テキストに置換（dashboard は既存 `formatDashboardText` / `formatForecastSummary` を再利用、明細系は format.ts に整形関数を追加）
- resources の `jsonResource`（機械可読 JSON）は意図どおり維持
- expense-breakdown の「厳密なカテゴリがない」等の意図的な前提文は保持

## 検証

- `make lint` / `make typecheck` / `make test-unit`（mcp 42 tests）通過
- テストで担保: monthly-report に取引明細が含まれる / 生 JSON キー記法が全 prompt に含まれない / 従来ダンプ比で全 prompt の文字数が半分未満 / 整形関数のユニットテスト
- 変更は packages/mcp のみ

Implemented-by: Codex (gpt-5.5) / Reviewed-by: Claude (Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)