### PR TITLE
feat: MCP 破壊操作の2段階ガードと監査ログを導入

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { logger } from "./lib/logger";
 import { accountsRoutes } from "./routes/accounts";
+import { auditLogsRoutes } from "./routes/audit-logs";
 import { billingsRoutes } from "./routes/billings";
 import { creditCardsRoutes } from "./routes/credit-cards";
 import { dataTransferRoutes } from "./routes/data-transfer";
@@ -23,6 +24,7 @@ export interface CreateAppOptions {
 }
 
 const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const AUDIT_CLIENT_SOURCES = new Set(["mcp", "web"]);
 
 function parseAllowedOrigins(value: string | undefined) {
   return value
@@ -78,6 +80,15 @@ function getContentType(filePath: string) {
   return "application/octet-stream";
 }
 
+function normalizeClientSource(value: string | undefined) {
+  return value && AUDIT_CLIENT_SOURCES.has(value) ? value : "unknown";
+}
+
+function getRequestId(value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length <= 40 ? trimmed : randomUUID();
+}
+
 export function createApp({
   enableStaticFallback = true,
   staticDir = process.env.STATIC_DIR ?? path.resolve(process.cwd(), "../frontend/dist"),
@@ -93,7 +104,7 @@ export function createApp({
     app.use("/api/*", cors({ origin: normalizedAllowedOrigins }));
   }
   app.use("/api/*", async (c, next) => {
-    const requestId = randomUUID();
+    const requestId = getRequestId(c.req.header("x-request-id"));
     const startedAt = performance.now();
     let status = 500;
 
@@ -130,6 +141,35 @@ export function createApp({
     return c.json({ error: "Origin not allowed" }, 403);
   });
   app.use("/api/*", async (c, next) => {
+    await next();
+
+    if (!STATE_CHANGING_METHODS.has(c.req.method) || c.res.status < 200 || c.res.status >= 300) {
+      return;
+    }
+
+    try {
+      await prisma.auditLog.create({
+        data: {
+          method: c.req.method,
+          path: c.req.path,
+          status: c.res.status,
+          clientSource: normalizeClientSource(c.req.header("x-sui-client")),
+          requestId: c.res.headers.get("x-request-id") ?? null,
+        },
+      });
+    } catch (error) {
+      logger.error(
+        {
+          err: error,
+          method: c.req.method,
+          path: c.req.path,
+          "request-id": c.res.headers.get("x-request-id") ?? undefined,
+        },
+        "Failed to write audit log",
+      );
+    }
+  });
+  app.use("/api/*", async (c, next) => {
     if (c.req.method === "GET" && c.req.path !== "/api/export") {
       try {
         await refreshExchangeRatesToJpy(prisma);
@@ -150,6 +190,7 @@ export function createApp({
   });
 
   app.route("/api", dataTransferRoutes);
+  app.route("/api/audit-logs", auditLogsRoutes);
   app.route("/api/dashboard", dashboardRoutes);
   app.route("/api/accounts", accountsRoutes);
   app.route("/api/recurring-items", recurringItemsRoutes);

--- a/packages/backend/src/routes/audit-logs.integration.test.ts
+++ b/packages/backend/src/routes/audit-logs.integration.test.ts
@@ -1,0 +1,143 @@
+import type { AuditLogsResponse } from "@sui/shared";
+import { describe, expect, it } from "vitest";
+import { createTestClient, parseJson } from "../test-helpers/app";
+import { testPrisma } from "../test-helpers/db";
+
+const client = createTestClient();
+
+function accountPayload(name: string, balance = 1000) {
+  return {
+    name,
+    balance,
+    balanceOffset: 0,
+    sortOrder: 1,
+  };
+}
+
+describe("audit log routes", () => {
+  it("records successful POST, PUT, and DELETE requests with client source", async () => {
+    const createdResponse = await client.post("/api/accounts", accountPayload("Main"), {
+      headers: {
+        "x-sui-client": "mcp",
+        "x-request-id": "req-create",
+      },
+    });
+    const created = await parseJson<{ id: string }>(createdResponse);
+
+    expect(createdResponse.status).toBe(201);
+
+    const updateResponse = await client.put(`/api/accounts/${created.id}`, accountPayload("Main updated", 2000), {
+      headers: {
+        "x-sui-client": "web",
+        "x-request-id": "req-update",
+      },
+    });
+    const deleteResponse = await client.delete(`/api/accounts/${created.id}`, {
+      headers: {
+        "x-sui-client": "mobile",
+        "x-request-id": "req-delete",
+      },
+    });
+
+    expect(updateResponse.status).toBe(200);
+    expect(deleteResponse.status).toBe(204);
+    expect(await testPrisma.auditLog.count()).toBe(3);
+
+    await expect(testPrisma.auditLog.findFirstOrThrow({
+      where: { method: "POST", path: "/api/accounts" },
+    })).resolves.toMatchObject({
+      status: 201,
+      clientSource: "mcp",
+      requestId: "req-create",
+    });
+    await expect(testPrisma.auditLog.findFirstOrThrow({
+      where: { method: "PUT", path: `/api/accounts/${created.id}` },
+    })).resolves.toMatchObject({
+      status: 200,
+      clientSource: "web",
+      requestId: "req-update",
+    });
+    await expect(testPrisma.auditLog.findFirstOrThrow({
+      where: { method: "DELETE", path: `/api/accounts/${created.id}` },
+    })).resolves.toMatchObject({
+      status: 204,
+      clientSource: "unknown",
+      requestId: "req-delete",
+    });
+  });
+
+  it("does not record GET requests", async () => {
+    const response = await client.get("/api/accounts", {
+      headers: { "x-sui-client": "web" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await testPrisma.auditLog.count()).toBe(0);
+  });
+
+  it("does not record failed state-changing requests", async () => {
+    const response = await client.post("/api/accounts", {
+      name: "",
+      balance: 0,
+      balanceOffset: 0,
+      sortOrder: 1,
+    }, {
+      headers: { "x-sui-client": "mcp" },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await testPrisma.auditLog.count()).toBe(0);
+  });
+
+  it("returns paginated audit logs ordered by createdAt desc", async () => {
+    await testPrisma.auditLog.create({
+      data: {
+        createdAt: new Date("2026-07-01T00:00:00.000Z"),
+        method: "POST",
+        path: "/api/accounts",
+        status: 201,
+        clientSource: "web",
+        requestId: "req-1",
+      },
+    });
+    await testPrisma.auditLog.create({
+      data: {
+        createdAt: new Date("2026-07-02T00:00:00.000Z"),
+        method: "PUT",
+        path: "/api/accounts/account-id",
+        status: 200,
+        clientSource: "mcp",
+        requestId: "req-2",
+      },
+    });
+    await testPrisma.auditLog.create({
+      data: {
+        createdAt: new Date("2026-07-03T00:00:00.000Z"),
+        method: "DELETE",
+        path: "/api/accounts/account-id",
+        status: 204,
+        clientSource: "unknown",
+        requestId: null,
+      },
+    });
+
+    const response = await client.get("/api/audit-logs?page=2&limit=2");
+    const body = await parseJson<AuditLogsResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      page: 2,
+      limit: 2,
+      total: 3,
+    });
+    expect(body.items).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/accounts",
+        clientSource: "web",
+        requestId: "req-1",
+      }),
+    ]);
+    expect(body.items[0]?.createdAt).toBe("2026-07-01T00:00:00.000Z");
+  });
+});

--- a/packages/backend/src/routes/audit-logs.ts
+++ b/packages/backend/src/routes/audit-logs.ts
@@ -1,0 +1,40 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { prisma } from "../lib/db";
+import { handleRouteError } from "../lib/http";
+
+const listQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+export const auditLogsRoutes = new Hono()
+  .get("/", async (c) => {
+    try {
+      const { page, limit } = listQuerySchema.parse({
+        page: c.req.query("page"),
+        limit: c.req.query("limit"),
+      });
+
+      const [items, total] = await Promise.all([
+        prisma.auditLog.findMany({
+          orderBy: { createdAt: "desc" },
+          skip: (page - 1) * limit,
+          take: limit,
+        }),
+        prisma.auditLog.count(),
+      ]);
+
+      return c.json({
+        items: items.map((item) => ({
+          ...item,
+          createdAt: item.createdAt.toISOString(),
+        })),
+        page,
+        limit,
+        total,
+      });
+    } catch (error) {
+      return handleRouteError(c, error);
+    }
+  });

--- a/packages/db/prisma/migrations/20260705000000_add_audit_logs/migration.sql
+++ b/packages/db/prisma/migrations/20260705000000_add_audit_logs/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "audit_logs" (
+  "id" UUID NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "method" VARCHAR(10) NOT NULL,
+  "path" VARCHAR(300) NOT NULL,
+  "status" INTEGER NOT NULL,
+  "client_source" VARCHAR(20) NOT NULL,
+  "request_id" VARCHAR(40),
+  CONSTRAINT "audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "audit_logs_created_at_idx" ON "audit_logs"("created_at");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -177,3 +177,16 @@ model Setting {
 
   @@map("settings")
 }
+
+model AuditLog {
+  id           String   @id @default(uuid()) @db.Uuid
+  createdAt    DateTime @default(now()) @map("created_at")
+  method       String   @db.VarChar(10)
+  path         String   @db.VarChar(300)
+  status       Int
+  clientSource String   @map("client_source") @db.VarChar(20)
+  requestId    String?  @map("request_id") @db.VarChar(40)
+
+  @@index([createdAt])
+  @@map("audit_logs")
+}

--- a/packages/db/src/reset.ts
+++ b/packages/db/src/reset.ts
@@ -12,6 +12,7 @@ const TRUNCATE_TABLES_SQL = `
     "credit_cards",
     "loans",
     "accounts",
+    "audit_logs",
     "settings"
   RESTART IDENTITY CASCADE
 `;

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 const JSON_HEADERS = {
   "Content-Type": "application/json",
+  "x-sui-client": "web",
 };
 
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -119,7 +119,7 @@ SUI_API_URL=https://sui.example.com docker compose -f compose.mcp.yaml up -d --b
 | `create_account` | 口座を作成（`balanceOffset` 指定可） |
 | `update_account` | 口座を更新（`balanceOffset` 指定可）。`balance` の変更差分は `adjustment` 取引として記録 |
 | `reconcile_account` | 実残高で口座を照合し、差分を `adjustment` 取引として記録 |
-| `delete_account` | 口座を削除 |
+| `delete_account` | 口座を削除。`confirm: true` がない場合は対象要約と再実行案内だけを返す |
 
 `Account` は実残高 `balance`、オフセット `balanceOffset`、最終照合日時 `lastReconciledAt` を持ちます。ダッシュボード系の残高はデフォルトで `balance - balanceOffset` を基準に計算され、`applyOffset=false` を指定すると実残高ベースに切り替えられます。
 
@@ -133,6 +133,7 @@ SUI_API_URL=https://sui.example.com docker compose -f compose.mcp.yaml up -d --b
 | `get_balance_history` | 口座または全体の過去残高推移を取得（`applyOffset` 指定可） |
 | `create_transaction` | 手動で取引を記録（振替対応） |
 | `update_transaction` | 既存の取引を更新（振替対応） |
+| `delete_transaction` | 手動登録取引を削除。`confirm: true` がない場合は対象要約と再実行案内だけを返す |
 
 ### 固定収支
 
@@ -141,7 +142,7 @@ SUI_API_URL=https://sui.example.com docker compose -f compose.mcp.yaml up -d --b
 | `list_recurring_items` | 固定収支一覧を取得 |
 | `create_recurring_item` | 固定収支を作成 |
 | `update_recurring_item` | 固定収支を更新 |
-| `delete_recurring_item` | 固定収支を削除 |
+| `delete_recurring_item` | 固定収支を削除。`confirm: true` がない場合は対象要約と再実行案内だけを返す |
 
 ### サブスク
 
@@ -150,7 +151,7 @@ SUI_API_URL=https://sui.example.com docker compose -f compose.mcp.yaml up -d --b
 | `list_subscriptions` | サブスク台帳の一覧を取得（残高予測には直接反映しない） |
 | `create_subscription` | サブスク台帳を作成 |
 | `update_subscription` | サブスク台帳を更新 |
-| `delete_subscription` | サブスク台帳から削除 |
+| `delete_subscription` | サブスク台帳から削除。`confirm: true` がない場合は対象要約と再実行案内だけを返す |
 
 サブスクの大半はクレジットカード払いで、カード請求額の仮定値または実績額に既に含まれる前提です。サブスクを残高予測へ直接入れると二重計上になるため、ここでは支払い元と金額を把握する台帳として扱います。カード払いではない定額支払いを予測に入れる場合は、現時点では固定収支として登録してください。
 
@@ -161,7 +162,7 @@ SUI_API_URL=https://sui.example.com docker compose -f compose.mcp.yaml up -d --b
 | `list_credit_cards` | クレジットカード一覧を取得 |
 | `create_credit_card` | クレジットカードを作成 |
 | `update_credit_card` | クレジットカードを更新 |
-| `delete_credit_card` | クレジットカードを削除 |
+| `delete_credit_card` | クレジットカードを削除。`confirm: true` がない場合は対象要約と再実行案内だけを返す |
 | `get_billing` | 月別請求データを取得 |
 | `update_billing` | 請求データを更新 |
 
@@ -172,7 +173,13 @@ SUI_API_URL=https://sui.example.com docker compose -f compose.mcp.yaml up -d --b
 | `list_loans` | ローン一覧を取得 |
 | `create_loan` | ローンを作成 |
 | `update_loan` | ローンを更新 |
-| `delete_loan` | ローンを削除 |
+| `delete_loan` | ローンを削除。`confirm: true` がない場合は対象要約と再実行案内だけを返す |
+
+### 監査ログ
+
+| ツール | 説明 |
+|--------|------|
+| `list_recent_changes` | 最近の変更監査ログを一覧する（読み取り専用） |
 
 ## リソース
 

--- a/packages/mcp/src/__tests__/api-client.test.ts
+++ b/packages/mcp/src/__tests__/api-client.test.ts
@@ -15,6 +15,7 @@ describe("SuiApiClient", () => {
     await expect(client.get("/api/dashboard")).resolves.toEqual({ ok: true });
     expect(fetchImpl).toHaveBeenCalledWith(new URL("/api/dashboard", "http://example.test"), {
       method: "GET",
+      headers: { "x-sui-client": "mcp" },
     });
   });
 
@@ -68,8 +69,9 @@ describe("SuiApiClient", () => {
 
     expect(fetchImpl.mock.calls).toHaveLength(4);
     for (const call of fetchImpl.mock.calls) {
-      const init = call[1] as { dispatcher?: unknown };
+      const init = call[1] as { dispatcher?: unknown; headers?: HeadersInit };
       expect(init.dispatcher).toBe(dispatcher);
+      expect(new Headers(init.headers).get("x-sui-client")).toBe("mcp");
     }
   });
 

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -76,6 +76,51 @@ function getStructuredContent(result: unknown) {
 
 const rawJsonKeyPattern = /"[^"\n]+":/;
 
+const deleteToolCases = [
+  {
+    tool: "delete_account",
+    id: "11111111-1111-4111-a111-111111111111",
+    previewPath: "/api/accounts",
+    deletePath: "/api/accounts/11111111-1111-4111-a111-111111111111",
+    summary: "Main",
+  },
+  {
+    tool: "delete_transaction",
+    id: "33333333-3333-4333-a333-333333333333",
+    previewPath: "/api/transactions?page=1&limit=100",
+    deletePath: "/api/transactions/33333333-3333-4333-a333-333333333333",
+    summary: "ランチ",
+  },
+  {
+    tool: "delete_recurring_item",
+    id: "66666666-6666-4666-a666-666666666666",
+    previewPath: "/api/recurring-items",
+    deletePath: "/api/recurring-items/66666666-6666-4666-a666-666666666666",
+    summary: "家賃",
+  },
+  {
+    tool: "delete_subscription",
+    id: "77777777-7777-4777-a777-777777777777",
+    previewPath: "/api/subscriptions",
+    deletePath: "/api/subscriptions/77777777-7777-4777-a777-777777777777",
+    summary: "Cloud",
+  },
+  {
+    tool: "delete_credit_card",
+    id: "44444444-4444-4444-8444-444444444444",
+    previewPath: "/api/credit-cards",
+    deletePath: "/api/credit-cards/44444444-4444-4444-8444-444444444444",
+    summary: "Visa",
+  },
+  {
+    tool: "delete_loan",
+    id: "55555555-5555-4555-8555-555555555555",
+    previewPath: "/api/loans",
+    deletePath: "/api/loans/55555555-5555-4555-8555-555555555555",
+    summary: "PCローン",
+  },
+] as const;
+
 function createFetchStub() {
   const requests: Array<{ method: string; path: string; body?: unknown }> = [];
   const routes = new Map<string, RouteResponse>();
@@ -314,11 +359,18 @@ describe("MCP server", () => {
         id: "11111111-1111-4111-a111-111111111111",
         name: "Main",
         balance: 123456,
+        balanceOffset: 0,
+        currencyCode: "JPY",
+        exchangeRateToJpy: 1,
+        exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
         sortOrder: 1,
         deletedAt: null,
         createdAt: "2026-03-01T00:00:00.000Z",
         updatedAt: "2026-03-01T00:00:00.000Z",
       }],
+    });
+    addRoute("DELETE", "/api/accounts/11111111-1111-4111-a111-111111111111", {
+      status: 204,
     });
     addRoute("POST", "/api/accounts", {
       status: 201,
@@ -363,7 +415,27 @@ describe("MCP server", () => {
         },
       },
     });
-    addRoute("GET", "/api/recurring-items", { body: [] });
+    addRoute("GET", "/api/recurring-items", {
+      body: [{
+        id: "66666666-6666-4666-a666-666666666666",
+        name: "家賃",
+        type: "expense",
+        amount: 80000,
+        dayOfMonth: 31,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "previous",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        account: { name: "Main" },
+        transferToAccountId: null,
+        transferToAccount: null,
+        enabled: true,
+        sortOrder: 3,
+        deletedAt: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }],
+    });
     addRoute("POST", "/api/recurring-items", {
       status: 201,
       body: {
@@ -380,8 +452,42 @@ describe("MCP server", () => {
         sortOrder: 3,
       },
     });
-    addRoute("GET", "/api/subscriptions", { body: [] });
-    addRoute("GET", "/api/credit-cards", { body: [] });
+    addRoute("DELETE", "/api/recurring-items/66666666-6666-4666-a666-666666666666", {
+      status: 204,
+    });
+    addRoute("GET", "/api/subscriptions", {
+      body: [{
+        id: "77777777-7777-4777-a777-777777777777",
+        name: "Cloud",
+        amount: 1200,
+        intervalMonths: 1,
+        startDate: "2026-01-01",
+        dayOfMonth: 10,
+        endDate: null,
+        paymentSource: "Visa",
+        deletedAt: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }],
+    });
+    addRoute("DELETE", "/api/subscriptions/77777777-7777-4777-a777-777777777777", {
+      status: 204,
+    });
+    addRoute("GET", "/api/credit-cards", {
+      body: [{
+        id: "44444444-4444-4444-8444-444444444444",
+        name: "Visa",
+        settlementDay: 27,
+        dateShiftPolicy: "next",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        account: { name: "Main" },
+        assumptionAmount: 50000,
+        sortOrder: 4,
+        deletedAt: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }],
+    });
     addRoute("POST", "/api/credit-cards", {
       status: 201,
       body: {
@@ -404,7 +510,28 @@ describe("MCP server", () => {
         suggestedAmount: 42000,
       },
     });
-    addRoute("GET", "/api/loans", { body: [] });
+    addRoute("DELETE", "/api/credit-cards/44444444-4444-4444-8444-444444444444", {
+      status: 204,
+    });
+    addRoute("GET", "/api/loans", {
+      body: [{
+        id: "55555555-5555-4555-8555-555555555555",
+        name: "PCローン",
+        totalAmount: 240000,
+        startDate: "2026-04-30",
+        paymentCount: 12,
+        dateShiftPolicy: "previous",
+        paymentMethod: "account_withdrawal",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        account: { name: "Main" },
+        remainingBalance: 200000,
+        remainingPayments: 10,
+        nextPaymentAmount: 20000,
+        deletedAt: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }],
+    });
     addRoute("PUT", "/api/loans/55555555-5555-4555-8555-555555555555", {
       body: {
         id: "55555555-5555-4555-8555-555555555555",
@@ -415,6 +542,52 @@ describe("MCP server", () => {
         dateShiftPolicy: "previous",
         paymentMethod: "account_withdrawal",
         accountId: "11111111-1111-4111-a111-111111111111",
+      },
+    });
+    addRoute("DELETE", "/api/loans/55555555-5555-4555-8555-555555555555", {
+      status: 204,
+    });
+    addRoute("GET", "/api/audit-logs?limit=20", {
+      body: {
+        items: [{
+          id: "audit-1",
+          createdAt: "2026-07-05T01:02:03.000Z",
+          method: "DELETE",
+          path: "/api/transactions/33333333-3333-4333-a333-333333333333",
+          status: 204,
+          clientSource: "mcp",
+          requestId: "request-1",
+        }],
+        page: 1,
+        limit: 20,
+        total: 1,
+      },
+    });
+    addRoute("GET", "/api/audit-logs?limit=2", {
+      body: {
+        items: [
+          {
+            id: "audit-2",
+            createdAt: "2026-07-05T02:02:03.000Z",
+            method: "POST",
+            path: "/api/accounts",
+            status: 201,
+            clientSource: "web",
+            requestId: "request-2",
+          },
+          {
+            id: "audit-1",
+            createdAt: "2026-07-05T01:02:03.000Z",
+            method: "DELETE",
+            path: "/api/transactions/33333333-3333-4333-a333-333333333333",
+            status: 204,
+            clientSource: "mcp",
+            requestId: "request-1",
+          },
+        ],
+        page: 1,
+        limit: 2,
+        total: 2,
       },
     });
     addRoute("GET", "/api/billings?month=2026-03", {
@@ -452,6 +625,29 @@ describe("MCP server", () => {
         page: 2,
         limit: 10,
         total: 0,
+      },
+    });
+    addRoute("GET", "/api/transactions?page=1&limit=100", {
+      body: {
+        items: [{
+          id: "33333333-3333-4333-a333-333333333333",
+          accountId: "11111111-1111-4111-a111-111111111111",
+          transferToAccountId: null,
+          forecastEventId: null,
+          date: "2026-03-20",
+          type: "expense",
+          description: "ランチ",
+          amount: 1200,
+          amountJpy: 1200,
+          currencyCode: "JPY",
+          createdAt: "2026-03-20T00:00:00.000Z",
+          accountName: "Main",
+          transferToAccountCurrencyCode: null,
+          transferToAccountName: null,
+        }],
+        page: 1,
+        limit: 100,
+        total: 1,
       },
     });
     addRoute("GET", "/api/transactions?page=2&limit=10&startDate=2026-03-01&endDate=2026-03-31", {
@@ -578,6 +774,7 @@ describe("MCP server", () => {
       "update_billing",
       "confirm_forecast",
       "get_credit_card_assumption_suggestion",
+      "list_recent_changes",
     ]));
     expect(resources.resources.map((resource) => resource.uri)).toEqual(expect.arrayContaining([
       "sui://dashboard",
@@ -631,6 +828,74 @@ describe("MCP server", () => {
       ? monthlyReport.messages[0].content.text
       : "";
     expect(reportText).toContain("2026-03 の月次収支レポート");
+  });
+
+  it("publishes annotations for every tool", async () => {
+    const tools = await client.listTools();
+    const annotationsByName = new Map(tools.tools.map((tool) => [tool.name, tool.annotations]));
+    const readOnlyTools = [
+      "get_dashboard",
+      "review_overdue_events",
+      "list_accounts",
+      "list_transactions",
+      "get_balance_history",
+      "list_recurring_items",
+      "list_subscriptions",
+      "list_credit_cards",
+      "get_credit_card_assumption_suggestion",
+      "get_billing",
+      "list_loans",
+      "list_recent_changes",
+    ];
+    const createTools = [
+      "create_account",
+      "create_transaction",
+      "create_recurring_item",
+      "create_subscription",
+      "create_credit_card",
+      "create_loan",
+    ];
+    const updateTools = [
+      "confirm_forecast",
+      "update_account",
+      "reconcile_account",
+      "update_transaction",
+      "update_recurring_item",
+      "update_subscription",
+      "update_credit_card",
+      "update_billing",
+      "update_loan",
+    ];
+    const deleteTools = deleteToolCases.map((item) => item.tool);
+    const expectedTools = [
+      ...readOnlyTools,
+      ...createTools,
+      ...updateTools,
+      ...deleteTools,
+    ].sort();
+
+    expect([...annotationsByName.keys()].sort()).toEqual(expectedTools);
+    for (const name of readOnlyTools) {
+      expect(annotationsByName.get(name)).toMatchObject({ readOnlyHint: true });
+    }
+    for (const name of createTools) {
+      expect(annotationsByName.get(name)).toMatchObject({
+        destructiveHint: false,
+        idempotentHint: false,
+      });
+    }
+    for (const name of updateTools) {
+      expect(annotationsByName.get(name)).toMatchObject({
+        destructiveHint: false,
+        idempotentHint: false,
+      });
+    }
+    for (const name of deleteTools) {
+      expect(annotationsByName.get(name)).toMatchObject({
+        destructiveHint: true,
+        idempotentHint: false,
+      });
+    }
   });
 
   it("forwards tool arguments to the REST API", async () => {
@@ -696,15 +961,43 @@ describe("MCP server", () => {
     });
   });
 
-  it("forwards transaction deletes to the REST API", async () => {
+  it.each(deleteToolCases)("previews $tool without calling DELETE when confirm is absent", async ({ tool, id, previewPath, deletePath, summary }) => {
     const result = await client.callTool({
-      name: "delete_transaction",
+      name: tool,
       arguments: {
-        id: "33333333-3333-4333-a333-333333333333",
+        id,
       },
     });
 
-    expect(getToolText(result)).toContain("33333333-3333-4333-a333-333333333333");
+    expect(getToolText(result)).toContain(summary);
+    expect(getToolText(result)).toContain("削除するには confirm: true");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: previewPath,
+      body: undefined,
+    });
+    expect(requests).not.toContainEqual({
+      method: "DELETE",
+      path: deletePath,
+      body: undefined,
+    });
+  });
+
+  it.each(deleteToolCases)("forwards $tool deletes when confirm is true", async ({ tool, id, previewPath, deletePath }) => {
+    const result = await client.callTool({
+      name: tool,
+      arguments: {
+        id,
+        confirm: true,
+      },
+    });
+
+    expect(getToolText(result)).toContain(id);
 
     const requests = (globalThis as typeof globalThis & {
       __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
@@ -712,7 +1005,12 @@ describe("MCP server", () => {
 
     expect(requests).toContainEqual({
       method: "DELETE",
-      path: "/api/transactions/33333333-3333-4333-a333-333333333333",
+      path: deletePath,
+      body: undefined,
+    });
+    expect(requests).not.toContainEqual({
+      method: "GET",
+      path: previewPath,
       body: undefined,
     });
   });
@@ -739,6 +1037,29 @@ describe("MCP server", () => {
       body: {
         actualBalance: 130000,
       },
+    });
+  });
+
+  it("lists recent changes from audit logs", async () => {
+    const result = await client.callTool({
+      name: "list_recent_changes",
+      arguments: {
+        limit: 2,
+      },
+    });
+
+    const text = getToolText(result);
+    expect(text).toContain("2026-07-05T02:02:03.000Z POST /api/accounts web");
+    expect(text).toContain("2026-07-05T01:02:03.000Z DELETE /api/transactions/33333333-3333-4333-a333-333333333333 mcp");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "GET",
+      path: "/api/audit-logs?limit=2",
+      body: undefined,
     });
   });
 

--- a/packages/mcp/src/api-client.ts
+++ b/packages/mcp/src/api-client.ts
@@ -4,6 +4,15 @@ export type FetchLike = typeof fetch;
 
 type FetchInit = RequestInit & { dispatcher?: Dispatcher };
 
+const CLIENT_HEADERS = {
+  "x-sui-client": "mcp",
+};
+
+const JSON_HEADERS = {
+  ...CLIENT_HEADERS,
+  "content-type": "application/json",
+};
+
 async function parseErrorMessage(response: Response) {
   const body = await response.json().catch(() => null);
   if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
@@ -27,7 +36,7 @@ export class SuiApiClient {
   async get<T>(path: string): Promise<T> {
     const response = await this.fetchImpl(
       new URL(path, this.baseUrl),
-      this.buildInit({ method: "GET" }),
+      this.buildInit({ method: "GET", headers: CLIENT_HEADERS }),
     );
     if (!response.ok) {
       throw new Error(await parseErrorMessage(response));
@@ -40,7 +49,7 @@ export class SuiApiClient {
       new URL(path, this.baseUrl),
       this.buildInit({
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: JSON_HEADERS,
         body: JSON.stringify(body),
       }),
     );
@@ -58,7 +67,7 @@ export class SuiApiClient {
       new URL(path, this.baseUrl),
       this.buildInit({
         method: "PUT",
-        headers: { "content-type": "application/json" },
+        headers: JSON_HEADERS,
         body: JSON.stringify(body),
       }),
     );
@@ -71,7 +80,7 @@ export class SuiApiClient {
   async delete(path: string): Promise<void> {
     const response = await this.fetchImpl(
       new URL(path, this.baseUrl),
-      this.buildInit({ method: "DELETE" }),
+      this.buildInit({ method: "DELETE", headers: CLIENT_HEADERS }),
     );
     if (!response.ok) {
       throw new Error(await parseErrorMessage(response));

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -19,11 +19,27 @@ export const nonNegativeMoneySchema = z.number().int().min(0);
 export const positiveMoneySchema = z.number().int().positive();
 export const booleanFlagSchema = z.union([z.boolean(), z.enum(["true", "false"])])
   .transform((value) => value === true || value === "true");
+export const confirmDeleteSchema = z.boolean().optional().describe("true の場合のみ削除を実行する。未指定または false では削除前確認だけを返す");
+
+export const readOnlyToolAnnotations = { readOnlyHint: true };
+export const createToolAnnotations = { destructiveHint: false, idempotentHint: false };
+export const updateToolAnnotations = { destructiveHint: false, idempotentHint: false };
+export const deleteToolAnnotations = { destructiveHint: true, idempotentHint: false };
 
 export function textContent(text: string) {
   return {
     content: [{ type: "text" as const, text }],
   };
+}
+
+export function formatDeletePreview(label: string, id: string, summary: string | null) {
+  return [
+    `${label}の削除確認`,
+    `ID: ${id}`,
+    `対象: ${summary ?? "一覧 API で対象を見つけられませんでした"}`,
+    "",
+    "削除するには confirm: true を付けて再実行してください。",
+  ].join("\n");
 }
 
 export function jsonResource(uri: string, data: unknown) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -8,6 +8,7 @@ import { registerForecastResources } from "./resources/forecast";
 import { registerSubscriptionResources } from "./resources/subscriptions";
 import { registerTransactionResources } from "./resources/transactions";
 import { registerAccountTools } from "./tools/accounts";
+import { registerAuditLogTools } from "./tools/audit-logs";
 import { registerBillingTools } from "./tools/billings";
 import { registerCreditCardTools } from "./tools/credit-cards";
 import { registerDashboardTools } from "./tools/dashboard";
@@ -37,6 +38,7 @@ export function buildServer({
   registerCreditCardTools(server, apiClient);
   registerBillingTools(server, apiClient);
   registerLoanTools(server, apiClient);
+  registerAuditLogTools(server, apiClient);
 
   registerDashboardResources(server, apiClient);
   registerDataResources(server, apiClient);

--- a/packages/mcp/src/tools/accounts.ts
+++ b/packages/mcp/src/tools/accounts.ts
@@ -9,7 +9,18 @@ import type {
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatAccountsText } from "../format";
-import { moneySchema, supportedCurrencyCodeSchema, textContent, uuidSchema } from "../helpers";
+import {
+  confirmDeleteSchema,
+  createToolAnnotations,
+  deleteToolAnnotations,
+  formatDeletePreview,
+  moneySchema,
+  readOnlyToolAnnotations,
+  supportedCurrencyCodeSchema,
+  textContent,
+  updateToolAnnotations,
+  uuidSchema,
+} from "../helpers";
 import { z } from "zod";
 
 const accountPayload = {
@@ -24,12 +35,12 @@ const accountPayload = {
 };
 
 export function registerAccountTools(server: McpServer, apiClient: SuiApiClient) {
-  server.tool("list_accounts", "口座一覧を取得する", {}, async () => {
+  server.tool("list_accounts", "口座一覧を取得する", {}, readOnlyToolAnnotations, async () => {
     const data = await apiClient.get<AccountsResponse>("/api/accounts");
     return textContent(formatAccountsText(data));
   });
 
-  server.tool("create_account", "口座を作成する", accountPayload, async (args) => {
+  server.tool("create_account", "口座を作成する", accountPayload, createToolAnnotations, async (args) => {
     const account = await apiClient.post<Account>("/api/accounts", args as CreateAccountPayload);
     return textContent(`口座を作成しました: ${account.name}（残高 ${account.balance.toLocaleString("ja-JP")}円）`);
   });
@@ -41,6 +52,7 @@ export function registerAccountTools(server: McpServer, apiClient: SuiApiClient)
       id: uuidSchema.describe("口座 ID"),
       ...accountPayload,
     },
+    updateToolAnnotations,
     async ({ id, ...payload }) => {
       const account = await apiClient.put<Account>(`/api/accounts/${id}`, payload as UpdateAccountPayload);
       return textContent(`口座を更新しました: ${account.name}（残高 ${account.balance.toLocaleString("ja-JP")}円）`);
@@ -54,6 +66,7 @@ export function registerAccountTools(server: McpServer, apiClient: SuiApiClient)
       accountId: uuidSchema.describe("口座 ID"),
       actualBalance: moneySchema.describe("実残高（通貨の最小単位）"),
     },
+    updateToolAnnotations,
     async ({ accountId, actualBalance }) => {
       const payload: ReconcileAccountPayload = { actualBalance };
       const result = await apiClient.post<ReconcileAccountResponse>(
@@ -69,9 +82,23 @@ export function registerAccountTools(server: McpServer, apiClient: SuiApiClient)
 
   server.tool(
     "delete_account",
-    "口座を削除する",
-    { id: uuidSchema.describe("口座 ID") },
-    async ({ id }) => {
+    "口座を削除する。confirm が true でない場合は API の DELETE を呼ばず、対象口座の要約と再実行案内だけを返す。confirm: true の場合のみ削除を実行する",
+    {
+      id: uuidSchema.describe("口座 ID"),
+      confirm: confirmDeleteSchema,
+    },
+    deleteToolAnnotations,
+    async ({ id, confirm }) => {
+      if (confirm !== true) {
+        const accounts = await apiClient.get<AccountsResponse>("/api/accounts");
+        const account = accounts.find((item) => item.id === id);
+        return textContent(formatDeletePreview(
+          "口座",
+          id,
+          account ? `${account.name}（残高 ${account.balance.toLocaleString("ja-JP")}円）` : null,
+        ));
+      }
+
       await apiClient.delete(`/api/accounts/${id}`);
       return textContent(`口座を削除しました: ${id}`);
     },

--- a/packages/mcp/src/tools/audit-logs.ts
+++ b/packages/mcp/src/tools/audit-logs.ts
@@ -1,0 +1,30 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuditLogsResponse } from "@sui/shared";
+import { z } from "zod";
+import type { SuiApiClient } from "../api-client";
+import { readOnlyToolAnnotations, textContent } from "../helpers";
+
+function formatRecentChanges(data: AuditLogsResponse) {
+  if (data.items.length === 0) {
+    return "最近の変更はありません。";
+  }
+
+  return data.items
+    .map((item) => `${item.createdAt} ${item.method} ${item.path} ${item.clientSource}`)
+    .join("\n");
+}
+
+export function registerAuditLogTools(server: McpServer, apiClient: SuiApiClient) {
+  server.tool(
+    "list_recent_changes",
+    "監査ログから最近の変更を一覧する（読み取り専用）。日時・メソッド・パス・clientSource を1件1行で返す",
+    {
+      limit: z.number().int().min(1).max(100).optional().describe("取得件数（既定 20）"),
+    },
+    readOnlyToolAnnotations,
+    async ({ limit = 20 }) => {
+      const data = await apiClient.get<AuditLogsResponse>(`/api/audit-logs?limit=${limit}`);
+      return textContent(formatRecentChanges(data));
+    },
+  );
+}

--- a/packages/mcp/src/tools/billings.ts
+++ b/packages/mcp/src/tools/billings.ts
@@ -2,7 +2,15 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { BillingResponse, BillingUpdatePayload } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatBillingText } from "../format";
-import { dateSchema, nonNegativeMoneySchema, textContent, uuidSchema, yearMonthSchema } from "../helpers";
+import {
+  dateSchema,
+  nonNegativeMoneySchema,
+  readOnlyToolAnnotations,
+  textContent,
+  updateToolAnnotations,
+  uuidSchema,
+  yearMonthSchema,
+} from "../helpers";
 import { z } from "zod";
 
 const billingItemsSchema = z.array(
@@ -19,6 +27,7 @@ export function registerBillingTools(server: McpServer, apiClient: SuiApiClient)
     {
       month: yearMonthSchema.describe("対象月（YYYY-MM）"),
     },
+    readOnlyToolAnnotations,
     async ({ month }) => {
       const billing = await apiClient.get<BillingResponse>(`/api/billings?month=${month}`);
       return textContent(formatBillingText(billing));
@@ -33,6 +42,7 @@ export function registerBillingTools(server: McpServer, apiClient: SuiApiClient)
       settlementDate: dateSchema.optional().describe("引き落とし日"),
       items: billingItemsSchema,
     },
+    updateToolAnnotations,
     async ({ yearMonth, ...payload }) => {
       const billing = await apiClient.put<BillingResponse>(
         `/api/billings/${yearMonth}`,

--- a/packages/mcp/src/tools/credit-cards.ts
+++ b/packages/mcp/src/tools/credit-cards.ts
@@ -8,7 +8,18 @@ import type {
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatCreditCardsText, formatJson } from "../format";
-import { dateShiftPolicySchema, nonNegativeMoneySchema, textContent, uuidSchema } from "../helpers";
+import {
+  confirmDeleteSchema,
+  createToolAnnotations,
+  dateShiftPolicySchema,
+  deleteToolAnnotations,
+  formatDeletePreview,
+  nonNegativeMoneySchema,
+  readOnlyToolAnnotations,
+  textContent,
+  updateToolAnnotations,
+  uuidSchema,
+} from "../helpers";
 import { z } from "zod";
 
 const creditCardPayload = {
@@ -21,7 +32,7 @@ const creditCardPayload = {
 };
 
 export function registerCreditCardTools(server: McpServer, apiClient: SuiApiClient) {
-  server.tool("list_credit_cards", "クレジットカード一覧を取得する", {}, async () => {
+  server.tool("list_credit_cards", "クレジットカード一覧を取得する", {}, readOnlyToolAnnotations, async () => {
     const data = await apiClient.get<CreditCardsResponse>("/api/credit-cards");
     return textContent(formatCreditCardsText(data));
   });
@@ -33,6 +44,7 @@ export function registerCreditCardTools(server: McpServer, apiClient: SuiApiClie
       id: uuidSchema.describe("クレジットカード ID"),
       months: z.number().int().min(1).max(60).optional().describe("集計対象月数"),
     },
+    readOnlyToolAnnotations,
     async ({ id, months = 6 }) => {
       const suggestion = await apiClient.get<CreditCardAssumptionSuggestionResponse>(
         `/api/credit-cards/${id}/assumption-suggestion?months=${months}`,
@@ -49,7 +61,7 @@ export function registerCreditCardTools(server: McpServer, apiClient: SuiApiClie
     },
   );
 
-  server.tool("create_credit_card", "クレジットカードを作成する", creditCardPayload, async (args) => {
+  server.tool("create_credit_card", "クレジットカードを作成する", creditCardPayload, createToolAnnotations, async (args) => {
     const card = await apiClient.post<CreditCard>("/api/credit-cards", args as CreateCreditCardPayload);
     return textContent(`クレジットカードを作成しました: ${card.name}`);
   });
@@ -61,6 +73,7 @@ export function registerCreditCardTools(server: McpServer, apiClient: SuiApiClie
       id: uuidSchema.describe("クレジットカード ID"),
       ...creditCardPayload,
     },
+    updateToolAnnotations,
     async ({ id, ...payload }) => {
       const card = await apiClient.put<CreditCard>(`/api/credit-cards/${id}`, payload as UpdateCreditCardPayload);
       return textContent(`クレジットカードを更新しました: ${card.name}`);
@@ -69,9 +82,23 @@ export function registerCreditCardTools(server: McpServer, apiClient: SuiApiClie
 
   server.tool(
     "delete_credit_card",
-    "クレジットカードを削除する",
-    { id: uuidSchema.describe("クレジットカード ID") },
-    async ({ id }) => {
+    "クレジットカードを削除する。confirm が true でない場合は API の DELETE を呼ばず、対象カードの要約と再実行案内だけを返す。confirm: true の場合のみ削除を実行する",
+    {
+      id: uuidSchema.describe("クレジットカード ID"),
+      confirm: confirmDeleteSchema,
+    },
+    deleteToolAnnotations,
+    async ({ id, confirm }) => {
+      if (confirm !== true) {
+        const cards = await apiClient.get<CreditCardsResponse>("/api/credit-cards");
+        const card = cards.find((entry) => entry.id === id);
+        return textContent(formatDeletePreview(
+          "クレジットカード",
+          id,
+          card ? `${card.name}（仮定請求額 ¥${card.assumptionAmount.toLocaleString("ja-JP")}）` : null,
+        ));
+      }
+
       await apiClient.delete(`/api/credit-cards/${id}`);
       return textContent(`クレジットカードを削除しました: ${id}`);
     },

--- a/packages/mcp/src/tools/dashboard.ts
+++ b/packages/mcp/src/tools/dashboard.ts
@@ -8,7 +8,15 @@ import type {
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatDashboardText } from "../format";
-import { booleanFlagSchema, positiveMoneySchema, supportedCurrencyCodeSchema, textContent, uuidSchema } from "../helpers";
+import {
+  booleanFlagSchema,
+  positiveMoneySchema,
+  readOnlyToolAnnotations,
+  supportedCurrencyCodeSchema,
+  textContent,
+  updateToolAnnotations,
+  uuidSchema,
+} from "../helpers";
 import { z } from "zod";
 
 const reviewOverdueEventSchema = z.object({
@@ -104,6 +112,7 @@ export function registerDashboardTools(server: McpServer, apiClient: SuiApiClien
       months: z.number().int().min(1).max(24).optional().describe("予測イベントの取得期間（月数、省略時は既定の24ヶ月）"),
       applyOffset: booleanFlagSchema.optional().describe("残高オフセットを適用するか"),
     },
+    readOnlyToolAnnotations,
     async ({ months, applyOffset = true }) => {
       const dashboard = await apiClient.get<DashboardResponse>(buildDashboardPath(applyOffset));
       const data = months
@@ -170,6 +179,7 @@ export function registerDashboardTools(server: McpServer, apiClient: SuiApiClien
       amount: positiveMoneySchema.describe("実績確認後の確定金額（円単位）"),
       accountId: uuidSchema.optional().describe("実績確認後の口座 ID（イベント設定口座から変更する場合のみ指定）"),
     },
+    updateToolAnnotations,
     async (args) => {
       const result = await apiClient.post<Transaction>("/api/dashboard/confirm", args as ConfirmForecastPayload);
       return textContent(`手動確認済みの予測を確定しました: ${result.description} ¥${result.amount.toLocaleString("ja-JP")}`);

--- a/packages/mcp/src/tools/loans.ts
+++ b/packages/mcp/src/tools/loans.ts
@@ -2,7 +2,19 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CreateLoanPayload, Loan, LoansResponse, UpdateLoanPayload } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatLoansText } from "../format";
-import { dateSchema, dateShiftPolicySchema, positiveMoneySchema, textContent, uuidSchema } from "../helpers";
+import {
+  confirmDeleteSchema,
+  createToolAnnotations,
+  dateSchema,
+  dateShiftPolicySchema,
+  deleteToolAnnotations,
+  formatDeletePreview,
+  positiveMoneySchema,
+  readOnlyToolAnnotations,
+  textContent,
+  updateToolAnnotations,
+  uuidSchema,
+} from "../helpers";
 import { z } from "zod";
 
 const paymentMethodSchema = z.enum(["account_withdrawal", "credit_card"]);
@@ -27,12 +39,12 @@ const updateLoanPayload = {
 };
 
 export function registerLoanTools(server: McpServer, apiClient: SuiApiClient) {
-  server.tool("list_loans", "ローン一覧を取得する", {}, async () => {
+  server.tool("list_loans", "ローン一覧を取得する", {}, readOnlyToolAnnotations, async () => {
     const data = await apiClient.get<LoansResponse>("/api/loans");
     return textContent(formatLoansText(data));
   });
 
-  server.tool("create_loan", "ローンを作成する", createLoanPayload, async (args) => {
+  server.tool("create_loan", "ローンを作成する", createLoanPayload, createToolAnnotations, async (args) => {
     const loan = await apiClient.post<Loan>("/api/loans", args as CreateLoanPayload);
     return textContent(`ローンを作成しました: ${loan.name}`);
   });
@@ -44,6 +56,7 @@ export function registerLoanTools(server: McpServer, apiClient: SuiApiClient) {
       id: uuidSchema.describe("ローン ID"),
       ...updateLoanPayload,
     },
+    updateToolAnnotations,
     async ({ id, ...payload }) => {
       const loan = await apiClient.put<Loan>(`/api/loans/${id}`, payload as UpdateLoanPayload);
       return textContent(`ローンを更新しました: ${loan.name}`);
@@ -52,9 +65,23 @@ export function registerLoanTools(server: McpServer, apiClient: SuiApiClient) {
 
   server.tool(
     "delete_loan",
-    "ローンを削除する",
-    { id: uuidSchema.describe("ローン ID") },
-    async ({ id }) => {
+    "ローンを削除する。confirm が true でない場合は API の DELETE を呼ばず、対象ローンの要約と再実行案内だけを返す。confirm: true の場合のみ削除を実行する",
+    {
+      id: uuidSchema.describe("ローン ID"),
+      confirm: confirmDeleteSchema,
+    },
+    deleteToolAnnotations,
+    async ({ id, confirm }) => {
+      if (confirm !== true) {
+        const loans = await apiClient.get<LoansResponse>("/api/loans");
+        const loan = loans.find((entry) => entry.id === id);
+        return textContent(formatDeletePreview(
+          "ローン",
+          id,
+          loan ? `${loan.name}（総額 ¥${loan.totalAmount.toLocaleString("ja-JP")}、残 ${loan.remainingPayments}回）` : null,
+        ));
+      }
+
       await apiClient.delete(`/api/loans/${id}`);
       return textContent(`ローンを削除しました: ${id}`);
     },

--- a/packages/mcp/src/tools/recurring-items.ts
+++ b/packages/mcp/src/tools/recurring-items.ts
@@ -7,7 +7,19 @@ import type {
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
 import { formatRecurringItemsText } from "../format";
-import { dateSchema, dateShiftPolicySchema, nonNegativeMoneySchema, textContent, uuidSchema } from "../helpers";
+import {
+  confirmDeleteSchema,
+  createToolAnnotations,
+  dateSchema,
+  dateShiftPolicySchema,
+  deleteToolAnnotations,
+  formatDeletePreview,
+  nonNegativeMoneySchema,
+  readOnlyToolAnnotations,
+  textContent,
+  updateToolAnnotations,
+  uuidSchema,
+} from "../helpers";
 import { z } from "zod";
 
 const recurringPayload = {
@@ -25,15 +37,21 @@ const recurringPayload = {
 };
 
 export function registerRecurringItemTools(server: McpServer, apiClient: SuiApiClient) {
-  server.tool("list_recurring_items", "固定収支一覧を取得する", {}, async () => {
+  server.tool("list_recurring_items", "固定収支一覧を取得する", {}, readOnlyToolAnnotations, async () => {
     const data = await apiClient.get<RecurringItemsResponse>("/api/recurring-items");
     return textContent(formatRecurringItemsText(data));
   });
 
-  server.tool("create_recurring_item", "固定収支を作成する。type=transfer の定期振替は口座別予測に反映され、合計残高には中立", recurringPayload, async (args) => {
-    const item = await apiClient.post<RecurringItem>("/api/recurring-items", args as CreateRecurringItemPayload);
-    return textContent(`固定収支を作成しました: ${item.name} ¥${item.amount.toLocaleString("ja-JP")}`);
-  });
+  server.tool(
+    "create_recurring_item",
+    "固定収支を作成する。type=transfer の定期振替は口座別予測に反映され、合計残高には中立",
+    recurringPayload,
+    createToolAnnotations,
+    async (args) => {
+      const item = await apiClient.post<RecurringItem>("/api/recurring-items", args as CreateRecurringItemPayload);
+      return textContent(`固定収支を作成しました: ${item.name} ¥${item.amount.toLocaleString("ja-JP")}`);
+    },
+  );
 
   server.tool(
     "update_recurring_item",
@@ -42,6 +60,7 @@ export function registerRecurringItemTools(server: McpServer, apiClient: SuiApiC
       id: uuidSchema.describe("固定収支 ID"),
       ...recurringPayload,
     },
+    updateToolAnnotations,
     async ({ id, ...payload }) => {
       const item = await apiClient.put<RecurringItem>(
         `/api/recurring-items/${id}`,
@@ -53,9 +72,23 @@ export function registerRecurringItemTools(server: McpServer, apiClient: SuiApiC
 
   server.tool(
     "delete_recurring_item",
-    "固定収支を削除する",
-    { id: uuidSchema.describe("固定収支 ID") },
-    async ({ id }) => {
+    "固定収支を削除する。confirm が true でない場合は API の DELETE を呼ばず、対象固定収支の要約と再実行案内だけを返す。confirm: true の場合のみ削除を実行する",
+    {
+      id: uuidSchema.describe("固定収支 ID"),
+      confirm: confirmDeleteSchema,
+    },
+    deleteToolAnnotations,
+    async ({ id, confirm }) => {
+      if (confirm !== true) {
+        const items = await apiClient.get<RecurringItemsResponse>("/api/recurring-items");
+        const item = items.find((entry) => entry.id === id);
+        return textContent(formatDeletePreview(
+          "固定収支",
+          id,
+          item ? `${item.name} ${item.type} ¥${item.amount.toLocaleString("ja-JP")}（毎月${item.dayOfMonth}日）` : null,
+        ));
+      }
+
       await apiClient.delete(`/api/recurring-items/${id}`);
       return textContent(`固定収支を削除しました: ${id}`);
     },

--- a/packages/mcp/src/tools/subscriptions.ts
+++ b/packages/mcp/src/tools/subscriptions.ts
@@ -8,7 +8,18 @@ import type {
 import { z } from "zod";
 import type { SuiApiClient } from "../api-client";
 import { formatSubscriptionsText } from "../format";
-import { dateSchema, positiveMoneySchema, textContent, uuidSchema } from "../helpers";
+import {
+  confirmDeleteSchema,
+  createToolAnnotations,
+  dateSchema,
+  deleteToolAnnotations,
+  formatDeletePreview,
+  positiveMoneySchema,
+  readOnlyToolAnnotations,
+  textContent,
+  updateToolAnnotations,
+  uuidSchema,
+} from "../helpers";
 
 const subscriptionPayload = {
   name: z.string().min(1).max(100).describe("サービス名"),
@@ -25,6 +36,7 @@ export function registerSubscriptionTools(server: McpServer, apiClient: SuiApiCl
     "list_subscriptions",
     "サブスク台帳の一覧を取得する。サブスクは残高予測に直接反映されず、カード払い分はクレジットカード請求額に含めて扱う",
     {},
+    readOnlyToolAnnotations,
     async () => {
       const data = await apiClient.get<SubscriptionsResponse>("/api/subscriptions");
       return textContent(formatSubscriptionsText(data));
@@ -35,6 +47,7 @@ export function registerSubscriptionTools(server: McpServer, apiClient: SuiApiCl
     "create_subscription",
     "サブスク台帳を作成する。残高予測へ直接追加する操作ではない",
     subscriptionPayload,
+    createToolAnnotations,
     async (args) => {
       const subscription = await apiClient.post<Subscription>(
         "/api/subscriptions",
@@ -53,6 +66,7 @@ export function registerSubscriptionTools(server: McpServer, apiClient: SuiApiCl
       id: uuidSchema.describe("サブスク ID"),
       ...subscriptionPayload,
     },
+    updateToolAnnotations,
     async ({ id, ...payload }) => {
       const subscription = await apiClient.put<Subscription>(
         `/api/subscriptions/${id}`,
@@ -66,9 +80,23 @@ export function registerSubscriptionTools(server: McpServer, apiClient: SuiApiCl
 
   server.tool(
     "delete_subscription",
-    "サブスク台帳から削除する。残高予測へ直接反映する操作ではない",
-    { id: uuidSchema.describe("サブスク ID") },
-    async ({ id }) => {
+    "サブスク台帳から削除する。残高予測へ直接反映する操作ではない。confirm が true でない場合は API の DELETE を呼ばず、対象サブスクの要約と再実行案内だけを返す。confirm: true の場合のみ削除を実行する",
+    {
+      id: uuidSchema.describe("サブスク ID"),
+      confirm: confirmDeleteSchema,
+    },
+    deleteToolAnnotations,
+    async ({ id, confirm }) => {
+      if (confirm !== true) {
+        const subscriptions = await apiClient.get<SubscriptionsResponse>("/api/subscriptions");
+        const subscription = subscriptions.find((entry) => entry.id === id);
+        return textContent(formatDeletePreview(
+          "サブスク",
+          id,
+          subscription ? `${subscription.name} ¥${subscription.amount.toLocaleString("ja-JP")}（${subscription.intervalMonths}ヶ月ごと）` : null,
+        ));
+      }
+
       await apiClient.delete(`/api/subscriptions/${id}`);
       return textContent(`サブスクを削除しました: ${id}`);
     },

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -10,11 +10,17 @@ import type { SuiApiClient } from "../api-client";
 import { formatBalanceHistory, formatTransactionsText } from "../format";
 import {
   booleanFlagSchema,
+  confirmDeleteSchema,
+  createToolAnnotations,
   dateSchema,
+  deleteToolAnnotations,
+  formatDeletePreview,
   limitSchema,
   pageSchema,
   positiveMoneySchema,
+  readOnlyToolAnnotations,
   textContent,
+  updateToolAnnotations,
   uuidSchema,
 } from "../helpers";
 import { z } from "zod";
@@ -67,6 +73,32 @@ const transactionPayloadSchema = z.object({
   }
 });
 
+async function findTransactionForDeletion(apiClient: SuiApiClient, id: string) {
+  const limit = 100;
+  let page = 1;
+
+  while (true) {
+    const data = await apiClient.get<TransactionsResponse>(`/api/transactions?page=${page}&limit=${limit}`);
+    const transaction = data.items.find((item) => item.id === id);
+    if (transaction) {
+      return transaction;
+    }
+    if (page * limit >= data.total || data.items.length === 0) {
+      return null;
+    }
+    page += 1;
+  }
+}
+
+function formatTransactionDeleteSummary(transaction: Transaction) {
+  const account =
+    transaction.type === "transfer"
+      ? `${transaction.accountName ?? transaction.accountId ?? "未設定"} -> ${transaction.transferToAccountName ?? transaction.transferToAccountId ?? "未設定"}`
+      : transaction.accountName ?? transaction.accountId ?? "未設定";
+
+  return `${transaction.date} ${transaction.description} ¥${transaction.amount.toLocaleString("ja-JP")}（${account}）`;
+}
+
 export function registerTransactionTools(server: McpServer, apiClient: SuiApiClient) {
   server.tool(
     "list_transactions",
@@ -78,6 +110,7 @@ export function registerTransactionTools(server: McpServer, apiClient: SuiApiCli
       startDate: dateSchema.optional().describe("開始日（YYYY-MM-DD）"),
       endDate: dateSchema.optional().describe("終了日（YYYY-MM-DD）"),
     },
+    readOnlyToolAnnotations,
     async ({ page = 1, limit = 50, accountId, startDate, endDate }) => {
       const params = new URLSearchParams({
         page: String(page),
@@ -101,6 +134,7 @@ export function registerTransactionTools(server: McpServer, apiClient: SuiApiCli
     "create_transaction",
     "手動で取引（入金・出金・振替）を記録する",
     transactionPayload,
+    createToolAnnotations,
     async (args) => {
       const parsed = transactionPayloadSchema.parse(args);
 
@@ -116,6 +150,7 @@ export function registerTransactionTools(server: McpServer, apiClient: SuiApiCli
       id: uuidSchema.describe("取引 ID"),
       ...transactionPayload,
     },
+    updateToolAnnotations,
     async ({ id, ...args }) => {
       const payload = transactionPayloadSchema.parse(args);
       const result = await apiClient.put<Transaction>(`/api/transactions/${id}`, payload as UpdateTransactionPayload);
@@ -125,11 +160,22 @@ export function registerTransactionTools(server: McpServer, apiClient: SuiApiCli
 
   server.tool(
     "delete_transaction",
-    "手動で登録された取引を削除する（soft delete。口座残高は自動的に元に戻る。予測確定で自動生成された取引は削除不可）",
+    "手動で登録された取引を削除する（soft delete。口座残高は自動的に元に戻る。予測確定で自動生成された取引は削除不可）。confirm が true でない場合は API の DELETE を呼ばず、対象取引の要約と再実行案内だけを返す。confirm: true の場合のみ削除を実行する",
     {
       id: uuidSchema.describe("取引 ID"),
+      confirm: confirmDeleteSchema,
     },
-    async ({ id }) => {
+    deleteToolAnnotations,
+    async ({ id, confirm }) => {
+      if (confirm !== true) {
+        const transaction = await findTransactionForDeletion(apiClient, id);
+        return textContent(formatDeletePreview(
+          "取引",
+          id,
+          transaction ? formatTransactionDeleteSummary(transaction) : null,
+        ));
+      }
+
       await apiClient.delete(`/api/transactions/${id}`);
       return textContent(`取引を削除しました: ${id}`);
     },
@@ -144,6 +190,7 @@ export function registerTransactionTools(server: McpServer, apiClient: SuiApiCli
       endDate: dateSchema.optional().describe("終了日 (YYYY-MM-DD)"),
       applyOffset: booleanFlagSchema.optional().describe("残高オフセットを適用するか"),
     },
+    readOnlyToolAnnotations,
     async ({ accountId, startDate, endDate, applyOffset = true }) => {
       const params = new URLSearchParams();
       if (accountId) {

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -156,6 +156,23 @@ export interface BalanceHistoryResponse {
   points: BalanceHistoryPoint[];
 }
 
+export interface AuditLogEntry {
+  id: string;
+  createdAt: string;
+  method: string;
+  path: string;
+  status: number;
+  clientSource: "mcp" | "web" | "unknown";
+  requestId: string | null;
+}
+
+export interface AuditLogsResponse {
+  items: AuditLogEntry[];
+  page: number;
+  limit: number;
+  total: number;
+}
+
 export interface DataExportAccount {
   id: string;
   name: string;


### PR DESCRIPTION
## 背景

プロダクトレビュー（20260702-review.md）指摘 B-2。MCP の削除系ツールは無確認・無監査で即実行され、tool annotations も未使用。LLM の誤ツール呼び出し1回で口座がソフト削除され、合計残高が黙って変わる状態だった。

## 変更内容

### 監査ログ（backend で記録 = Web UI 経由の変更も捕捉）
- `AuditLog` テーブル追加（マイグレーション同梱、createdAt index）
- `/api/*` の POST/PUT/PATCH/DELETE が 2xx のときのみミドルウェアで記録。**リクエストボディは記録しない**（機微データをログへ複製しない方針）。insert 失敗は logger.error のみでレスポンス非影響
- クライアント識別: frontend `x-sui-client: web` / MCP `x-sui-client: mcp`（許可リスト外は unknown に正規化）
- `GET /api/audit-logs`（limit/page、createdAt desc）

### MCP ガード
- **全ツールに annotations 付与**（readOnlyHint / destructiveHint / idempotentHint）
- **削除系ツール全部を2段階制に**: `confirm: true` でない場合は API を呼ばず、対象の要約（名称・金額等）と再実行案内のみ返す。description にも挙動を明記
- `list_recent_changes` ツール新設（監査ログを 1行/件で返す。LLM 自身が直近の変更を確認できる）

## 検証

- `make lint` / `make typecheck` / `make test-unit` / `make test-integration` / `make test-e2e` すべて通過
- 統合: 2xx 変更系で audit 行が増える（clientSource 反映含む）/ GET・400 では増えない / audit-logs のページング
- MCP ユニット: confirm なし削除で fetch stub に DELETE が記録されないことを assert / confirm: true で DELETE 実行 / annotations を全ツール列挙で assert / list_recent_changes

Implemented-by: Codex (gpt-5.5) / Reviewed-by: Claude (Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)