### PR TITLE
feat: フロントエンド再設計 Stage 2 — ダッシュボード再構成

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -59,7 +59,7 @@ test.beforeEach(async () => {
 test("shows zero summaries and none labels on an empty dashboard", async ({ page }) => {
   await navigateTo(page, "/");
 
-  await expect(page.getByText("総所持金").locator("..")).toContainText(formatCurrency(0));
+  await expect(page.getByText("総資産").locator("..")).toContainText(formatCurrency(0));
   await expect(page.getByText("次の収入").locator("..")).toContainText("なし");
   await expect(page.getByText("次の支出").locator("..")).toContainText("なし");
 });
@@ -86,12 +86,12 @@ test("shows summaries, events, and chart when data exists", async ({ page }) => 
 
   await navigateTo(page, "/");
 
-  await expect(page.getByText("総所持金").locator("..")).toContainText(formatCurrency(100000));
+  await expect(page.getByText("総資産").locator("..")).toContainText(formatCurrency(100000));
   await expect(page.getByRole("cell", { name: "Salary" }).first()).toBeVisible();
   await expect(page.locator("svg.recharts-surface")).toBeVisible();
 });
 
-test("opens the forecast contribution explanation from the minimum balance card", async ({ page }) => {
+test("opens the forecast contribution explanation from the level header", async ({ page }) => {
   const account = await seedAccount({ name: "Main Account", balance: 100000, sortOrder: 1 });
   const eventDate = getDateString(7);
 
@@ -108,7 +108,7 @@ test("opens the forecast contribution explanation from the minimum balance card"
 
   await navigateTo(page, "/");
 
-  await page.getByRole("button", { name: /全体の最小残高/ }).click();
+  await page.getByRole("button", { name: "期間内最小の寄与分解を表示" }).click();
   const dialog = page.getByRole("dialog");
   await expect(dialog.getByRole("heading", { name: "全体の最小残高の寄与分解" })).toBeVisible();
   await expect(dialog.getByText("source 別小計")).toBeVisible();
@@ -137,7 +137,7 @@ test("shows foreign-currency account totals in JPY with source amounts on foreca
 
   await navigateTo(page, "/");
 
-  await expect(page.getByText("総所持金").locator("..")).toContainText(formatCurrency(150000));
+  await expect(page.getByText("総資産").locator("..")).toContainText(formatCurrency(150000));
   const forecastTable = page.locator("table").last();
   const totalRow = forecastTable.getByRole("row", { name: /USD Hosting/ }).first();
   await expect(totalRow).toContainText(formatCurrency(25, "USD"));
@@ -208,7 +208,7 @@ test("confirms a forecast event from the dialog", async ({ page }) => {
   await expect(page.locator("table").last().getByRole("cell", { name: "Salary" })).toHaveCount(beforeCount - 1);
 });
 
-test("forces overdue forecast confirmation from the dashboard", async ({ page }) => {
+test("confirms overdue forecast events from the confirm queue", async ({ page }) => {
   const account = await seedAccount({ name: "Main Account", balance: 100000, sortOrder: 1 });
   const firstCard = await seedCreditCard({
     name: "Past Card",
@@ -235,27 +235,23 @@ test("forces overdue forecast confirmation from the dashboard", async ({ page })
 
   await navigateTo(page, "/");
 
-  await expect(page.getByRole("heading", { name: "予定日超過イベントを確認" })).toBeVisible();
+  // モーダルは自動で開かず、ダッシュボード内の確定キューに件数バッジ付きで表示される
+  await expect(page.getByRole("heading", { name: "確定キュー" })).toBeVisible();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByText("2 件", { exact: true })).toBeVisible();
   await expect(page.getByText("予定日を過ぎた未確定イベントです")).toBeVisible();
   await expect(page.getByRole("button", { name: "選択した 2 件を確定" })).toBeVisible();
   await expect(page.getByText("Past Card 引き落とし").first()).toBeVisible();
   await expect(page.getByText("Backup Card 引き落とし").first()).toBeVisible();
 
-  await page.getByRole("button", { name: "あとで" }).click();
-  await expect(page.getByRole("heading", { name: "予定日超過イベントを確認" })).toHaveCount(0);
-  await expect(page.getByText("⏳ 予定日超過の未確定イベントが 2 件あります")).toBeVisible();
-
-  await page.getByRole("button", { name: "確認する" }).click();
-  const dialog = page.getByRole("dialog");
-  await expect(dialog.getByRole("heading", { name: "予定日超過イベントを確認" })).toBeVisible();
-
-  await dialog.getByRole("row", { name: /Past Card 引き落とし/ }).getByRole("spinbutton").fill("9000");
-  await dialog.getByRole("button", { name: "選択した 2 件を確定" }).click();
+  const queueTable = page.locator("table").first();
+  await queueTable.getByRole("row", { name: /Past Card 引き落とし/ }).getByRole("spinbutton").fill("9000");
+  await page.getByRole("button", { name: "選択した 2 件を確定" }).click();
   await waitForReload(page);
 
-  await expect(page.getByRole("heading", { name: "予定日超過イベントを確認" })).toHaveCount(0);
-  await expect(page.getByText("⏳ 予定日超過の未確定イベントが")).toHaveCount(0);
-  await expect(page.getByText("総所持金").locator("..").first()).toContainText(formatCurrency(86000));
+  await expect(page.getByText("2 件を確定しました", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "確定キュー" })).toHaveCount(0);
+  await expect(page.getByText("総資産").locator("..").first()).toContainText(formatCurrency(86000));
 
   await navigateTo(page, "/transactions");
   await page.getByLabel("期間プリセット").selectOption("all");
@@ -264,7 +260,7 @@ test("forces overdue forecast confirmation from the dashboard", async ({ page })
   await expect(page.getByRole("row", { name: /Backup Card 引き落とし/ }).first()).toContainText(formatCurrency(5000));
 });
 
-test("shows a red balance warning card", async ({ page }) => {
+test("shows a critical judgement when an account is forecast to go negative", async ({ page }) => {
   const account = await seedAccount({ name: "Warning Account", balance: 1000, sortOrder: 1 });
 
   await seedRecurringItem({
@@ -278,11 +274,14 @@ test("shows a red balance warning card", async ({ page }) => {
 
   await navigateTo(page, "/");
 
-  await expect(page.getByText("🔴 実残高がマイナスになる見込み")).toBeVisible();
-  await expect(page.getByText(/Warning Account（/).first()).toBeVisible();
+  // 水位ヘッダーが危険の言い切り文と「あと N 日」を表示する
+  await expect(page.getByText(/に Warning Account が赤字になります/)).toBeVisible();
+  await expect(page.getByText("危険")).toBeVisible();
+  // 口座別水位リストにも同じ 3 値が反映される
+  await expect(page.getByRole("button", { name: /Warning Account/ })).toContainText("赤字見込み");
 });
 
-test("shows a yellow disposable balance warning card without the red warning", async ({ page }) => {
+test("shows a warning judgement for disposable balance without the critical one", async ({ page }) => {
   const account = await seedAccount({
     name: "Disposable Warning Account",
     balance: 100000,
@@ -303,9 +302,11 @@ test("shows a yellow disposable balance warning card without the red warning", a
 
   await navigateTo(page, "/");
 
-  await expect(page.getByText("⚠️ 可処分残高がマイナスになる見込み")).toBeVisible();
-  await expect(page.getByText(/Disposable Warning Account（/).first()).toBeVisible();
-  await expect(page.getByText("🔴 実残高がマイナスになる見込み")).toHaveCount(0);
+  // 水位ヘッダーが警告（黄）の言い切り文を表示し、危険（朱）の文は出さない
+  await expect(page.getByText(/に Disposable Warning Account の可処分残高がマイナスになります/)).toBeVisible();
+  await expect(page.getByText("警告")).toBeVisible();
+  await expect(page.getByText(/が赤字になります/)).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /Disposable Warning Account/ })).toContainText("可処分注意");
 });
 
 test("shows actual and assumed credit card events together with loan events", async ({ page }) => {

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -35,5 +35,5 @@ test("redirects unknown paths to the dashboard", async ({ page }) => {
   await page.goto("/nonexistent");
 
   await expect(page).toHaveURL(/\/$/);
-  await expect(page.getByRole("heading", { name: "所持金推移" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "残高推移" })).toBeVisible();
 });

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -81,7 +81,7 @@ test("keeps primary screens inside the viewport at responsive sizes", async ({ p
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
 
     await navigateTo(page, "/");
-    await expect(page.getByRole("heading", { name: "所持金推移" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "残高推移" })).toBeVisible();
     await expectNoDocumentHorizontalScroll(page);
 
     if (viewport.width < 1024) {

--- a/e2e/scenarios/confirm-flow.spec.ts
+++ b/e2e/scenarios/confirm-flow.spec.ts
@@ -33,7 +33,7 @@ test("confirms a forecast event and reflects it in balances and transactions", a
   await waitForReload(page);
 
   await expect(page.locator("table").last().getByRole("cell", { name: "家賃" })).toHaveCount(0);
-  await expect(page.locator(".text-sm").filter({ hasText: "総所持金" }).locator("..").locator(".text-3xl")).toContainText(formatCurrency(250000));
+  await expect(page.getByText("総資産").locator("..")).toContainText(formatCurrency(250000));
 
   await navigateTo(page, "/accounts");
   await expect(page.getByRole("row", { name: /生活口座/ }).first()).toContainText(formatCurrency(250000));

--- a/e2e/scenarios/forecast-flow.spec.ts
+++ b/e2e/scenarios/forecast-flow.spec.ts
@@ -46,7 +46,7 @@ test("reflects newly created accounts and recurring items on the dashboard forec
 
   await navigateTo(page, "/");
 
-  await expect(page.getByText("総所持金").locator("..")).toContainText(formatCurrency(500000));
+  await expect(page.getByText("総資産").locator("..")).toContainText(formatCurrency(500000));
   await expect(page.getByText("次の収入").locator("..")).toContainText("給料");
   await expect(page.getByText("次の支出").locator("..")).toContainText("家賃");
 
@@ -92,7 +92,7 @@ test("reflects recurring transfers in account forecasts and confirms them as tra
   await expect(recurringRow).toContainText("給与口座 → 引落口座");
 
   await navigateTo(page, "/");
-  await expect(page.getByText("総所持金").locator("..")).toContainText(formatCurrency(310000));
+  await expect(page.getByText("総資産").locator("..")).toContainText(formatCurrency(310000));
 
   await page.getByRole("button", { name: "引落口座" }).click();
   const transferRow = page.locator("table").last().getByRole("row", { name: /資金移動/ });

--- a/e2e/scenarios/transfer-flow.spec.ts
+++ b/e2e/scenarios/transfer-flow.spec.ts
@@ -43,7 +43,5 @@ test("keeps the total balance unchanged while reflecting transfers across accoun
   await expect(page.getByRole("row", { name: /貯蓄口座/ }).first()).toContainText(formatCurrency(200000));
 
   await navigateTo(page, "/");
-  await expect(page.locator(".text-sm").filter({ hasText: "総所持金" }).locator("..").locator(".text-3xl")).toContainText(
-    formatCurrency(600000),
-  );
+  await expect(page.getByText("総資産").locator("..")).toContainText(formatCurrency(600000));
 });

--- a/packages/frontend/src/components/account-level-list.tsx
+++ b/packages/frontend/src/components/account-level-list.tsx
@@ -1,0 +1,95 @@
+import type { SupportedCurrencyCode } from "@sui/shared";
+import { formatCurrencyWithJpy, formatDateWithYear } from "../lib/format";
+import { cn } from "../lib/utils";
+import { StatusChip, type StatusChipTone } from "./ui/status-chip";
+
+export type AccountLevelRow = {
+  id: string | "total";
+  name: string;
+  currentBalance: number;
+  currentBalanceJpy: number;
+  currencyCode: SupportedCurrencyCode;
+  minBalance: number;
+  minBalanceJpy: number;
+  minBalanceDate: string;
+  warningLevel: "none" | "yellow" | "red";
+};
+
+const toneByWarningLevel: Record<AccountLevelRow["warningLevel"], StatusChipTone> = {
+  none: "success",
+  yellow: "warning",
+  red: "danger",
+};
+
+const labelByWarningLevel: Record<AccountLevelRow["warningLevel"], string> = {
+  none: "安全",
+  yellow: "可処分注意",
+  red: "赤字見込み",
+};
+
+const barColorByWarningLevel: Record<AccountLevelRow["warningLevel"], string> = {
+  none: "bg-positive",
+  yellow: "bg-warning",
+  red: "bg-critical",
+};
+
+/**
+ * 口座別の水位リスト（B-3）。口座名・現在残高・期間内最小残高・最小日をバー付きで 1 行ずつ表示する。
+ * 行クリックでチャートの対象口座を切り替える。AccountSelector のボタン列をここに吸収する。
+ */
+export function AccountLevelList({
+  rows,
+  selectedId,
+  onSelect,
+}: {
+  rows: AccountLevelRow[];
+  selectedId: string | "total";
+  onSelect: (id: string | "total") => void;
+}) {
+  const maxBalance = Math.max(1, ...rows.map((row) => Math.abs(row.currentBalanceJpy)));
+
+  return (
+    <div className="grid gap-2">
+      {rows.map((row) => {
+        const ratio = Math.min(1, Math.abs(row.currentBalanceJpy) / maxBalance);
+        const isSelected = selectedId === row.id;
+
+        return (
+          <button
+            key={row.id}
+            type="button"
+            onClick={() => onSelect(row.id)}
+            className={cn(
+              "grid min-w-0 gap-2 rounded-[var(--radius-m)] border p-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4",
+              isSelected ? "border-brand bg-surface-2" : "border-line bg-surface-1 hover:border-line-strong",
+            )}
+          >
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="truncate text-sm font-medium">{row.name}</span>
+                <StatusChip tone={toneByWarningLevel[row.warningLevel]}>
+                  {labelByWarningLevel[row.warningLevel]}
+                </StatusChip>
+              </div>
+              <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-surface-2">
+                <div
+                  className={cn("h-full rounded-full", barColorByWarningLevel[row.warningLevel])}
+                  style={{ width: `${Math.max(ratio * 100, 3)}%` }}
+                />
+              </div>
+            </div>
+            <div className="grid min-w-0 gap-0.5 text-right">
+              <div className="font-data overflow-x-auto whitespace-nowrap text-sm font-semibold">
+                {formatCurrencyWithJpy(row.currentBalance, row.currencyCode, row.currentBalanceJpy)}
+              </div>
+              <div className="font-data overflow-x-auto whitespace-nowrap text-xs text-ink-2">
+                期間内最小 {formatCurrencyWithJpy(row.minBalance, row.currencyCode, row.minBalanceJpy)}（
+                {formatDateWithYear(row.minBalanceDate)}）
+              </div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/balance-chart.tsx
+++ b/packages/frontend/src/components/balance-chart.tsx
@@ -1,4 +1,5 @@
 import {
+  CartesianGrid,
   Line,
   LineChart,
   ReferenceArea,
@@ -11,16 +12,19 @@ import {
 } from "recharts";
 import { useEffect, useRef, useState } from "react";
 import type { SupportedCurrencyCode } from "@sui/shared";
-import { formatChartDateWithYear, formatCurrency, formatDateWithYear } from "../lib/format";
+import { convertCurrencyInputToJpy, formatCurrency, formatDate, formatManUnit } from "../lib/format";
 import {
   buildBalanceChartSegments,
-  buildBalanceChartYDomain,
+  buildNiceYAxis,
   buildTimeScaleTicks,
   dateOnlyToTimestamp,
+  formatChartAxisTick,
+  isMoreThanThreeMonths,
   timestampToDateOnly,
   type BalanceChartInputPoint,
   type DailyBalanceChartPoint,
 } from "../lib/balance-chart";
+import { cn } from "../lib/utils";
 
 type BalanceChartPoint = BalanceChartInputPoint;
 
@@ -34,6 +38,11 @@ type BalanceChartDatum = {
   forecastDescription?: string;
 };
 
+const CHART_MARGIN = { left: 12, right: 12, top: 12, bottom: 8 };
+const Y_AXIS_WIDTH = 56;
+const X_AXIS_HEIGHT = 28;
+const INITIAL_ANIMATION_MS = 400;
+
 function useElementSize() {
   const ref = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
@@ -43,6 +52,8 @@ function useElementSize() {
     if (!element) {
       return;
     }
+
+    let frame = 0;
 
     const updateSize = () => {
       const nextSize = {
@@ -56,23 +67,66 @@ function useElementSize() {
       );
     };
 
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(updateSize);
+    };
+
     updateSize();
 
     if (typeof ResizeObserver === "undefined") {
-      window.addEventListener("resize", updateSize);
-      return () => window.removeEventListener("resize", updateSize);
+      window.addEventListener("resize", scheduleUpdate);
+      return () => {
+        cancelAnimationFrame(frame);
+        window.removeEventListener("resize", scheduleUpdate);
+      };
     }
 
-    const observer = new ResizeObserver(updateSize);
+    const observer = new ResizeObserver(scheduleUpdate);
     observer.observe(element);
-    return () => observer.disconnect();
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
   }, []);
 
   return [ref, size] as const;
 }
 
-function formatTimestampTick(value: number) {
-  return formatChartDateWithYear(timestampToDateOnly(value));
+function getPrefersReducedMotion() {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : false;
+}
+
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(getPrefersReducedMotion);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const listener = (event: MediaQueryListEvent) => setReduced(event.matches);
+    query.addEventListener("change", listener);
+    return () => query.removeEventListener("change", listener);
+  }, []);
+
+  return reduced;
+}
+
+function isInDomain(point: DailyBalanceChartPoint, domain: [number, number]) {
+  return point.timestamp >= domain[0] && point.timestamp <= domain[1];
+}
+
+function getMinimumForecastPoint(points: DailyBalanceChartPoint[], domain: [number, number]) {
+  return points
+    .filter((point) => isInDomain(point, domain))
+    .reduce<DailyBalanceChartPoint | null>(
+      (minimum, point) => (!minimum || point.balance < minimum.balance ? point : minimum),
+      null,
+    );
 }
 
 function getTooltipEntry(
@@ -86,9 +140,11 @@ function BalanceTooltip({
   active,
   payload,
   currencyCode,
+  exchangeRateToJpy,
   showSeriesLabel,
 }: TooltipContentProps & {
   currencyCode: SupportedCurrencyCode;
+  exchangeRateToJpy: number;
   showSeriesLabel: boolean;
 }) {
   if (!active || payload.length === 0) {
@@ -107,31 +163,50 @@ function BalanceTooltip({
     return null;
   }
 
-  const seriesLabel = actualEntry && forecastEntry ? "実績 / 予測" : forecastEntry ? "予測" : "実績";
-  const description =
-    selectedEntry.dataKey === "forecastBalance" ? point.forecastDescription : point.actualDescription;
+  const isForecast = selectedEntry.dataKey === "forecastBalance";
+  const seriesLabel = isForecast ? "予測" : "実績";
+  const description = isForecast ? point.forecastDescription : point.actualDescription;
+  const jpyValue =
+    currencyCode === "JPY" ? null : convertCurrencyInputToJpy(selectedEntry.value, currencyCode, exchangeRateToJpy);
 
   return (
-    <div className="max-w-64 rounded-2xl border border-line bg-[rgba(18,22,30,0.96)] px-3 py-2 text-sm shadow-xl">
-      {showSeriesLabel ? <div className="mb-1 text-xs font-medium text-ink-3">{seriesLabel}</div> : null}
-      <div className="font-data text-ink-2">{formatDateWithYear(point.date)}</div>
-      <div className="font-data mt-1 font-semibold text-ink">{formatCurrency(selectedEntry.value, currencyCode)}</div>
-      {description ? <div className="mt-1 break-words text-xs text-ink-2">{description}</div> : null}
+    <div className="max-w-64 rounded-2xl border border-line bg-[rgba(18,22,30,0.96)] px-3 py-2 shadow-xl">
+      {showSeriesLabel ? (
+        <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-ink-3">
+          <span
+            className={cn(
+              "inline-block h-0 w-3 border-t-2",
+              isForecast ? "border-dashed border-chart-forecast" : "border-solid border-chart-actual",
+            )}
+          />
+          {seriesLabel}
+        </div>
+      ) : null}
+      <div className="font-data text-xs text-ink-2">{formatDate(point.date)}</div>
+      <div className="font-data mt-0.5 text-base font-semibold text-ink">
+        {formatCurrency(selectedEntry.value, currencyCode)}
+      </div>
+      {jpyValue !== null ? (
+        <div className="font-data mt-0.5 text-xs text-ink-2">{formatCurrency(jpyValue, "JPY")}</div>
+      ) : null}
+      {description ? <div className="mt-1 max-w-56 break-words text-xs text-ink-2">{description}</div> : null}
     </div>
   );
 }
 
-function isInDomain(point: DailyBalanceChartPoint, domain: [number, number]) {
-  return point.timestamp >= domain[0] && point.timestamp <= domain[1];
-}
-
-function getMinimumForecastPoint(points: DailyBalanceChartPoint[], domain: [number, number]) {
-  return points
-    .filter((point) => isInDomain(point, domain))
-    .reduce<DailyBalanceChartPoint | null>(
-      (minimum, point) => (!minimum || point.balance < minimum.balance ? point : minimum),
-      null,
-    );
+function ChartLegend() {
+  return (
+    <div className="pointer-events-none absolute right-2 top-2 flex items-center gap-3 rounded-full border border-line bg-[rgba(17,21,28,0.72)] px-2.5 py-1 text-[11px] text-ink-2">
+      <span className="flex items-center gap-1.5">
+        <span className="inline-block h-0 w-3 border-t-2 border-solid border-chart-actual" />
+        実績
+      </span>
+      <span className="flex items-center gap-1.5">
+        <span className="inline-block h-0 w-3 border-t-2 border-dashed border-chart-forecast" />
+        予測
+      </span>
+    </div>
+  );
 }
 
 export function BalanceChart({
@@ -144,6 +219,8 @@ export function BalanceChart({
   currentBalance,
   label,
   currencyCode = "JPY",
+  exchangeRateToJpy = 1,
+  disposableZero = false,
 }: {
   data: BalanceChartPoint[];
   forecastData?: BalanceChartPoint[];
@@ -154,8 +231,13 @@ export function BalanceChart({
   currentBalance: number;
   label: string;
   currencyCode?: SupportedCurrencyCode;
+  exchangeRateToJpy?: number;
+  disposableZero?: boolean;
 }) {
   const [chartRef, chartSize] = useElementSize();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const hasAnimatedRef = useRef(false);
+
   const {
     actualLineSeries,
     forecastEventSeries,
@@ -170,6 +252,14 @@ export function BalanceChart({
     currentBalance,
   });
 
+  useEffect(() => {
+    if (hasAnimatedRef.current) {
+      return;
+    }
+
+    hasAnimatedRef.current = true;
+  }, []);
+
   if (actualLineSeries.length === 0 && forecastLineSeries.length === 0) {
     return (
       <div ref={chartRef} className="flex h-full min-h-0 min-w-0 items-center justify-center text-ink-2">
@@ -181,7 +271,7 @@ export function BalanceChart({
   const visibleBalances = [...actualLineSeries, ...forecastLineSeries]
     .filter((point) => isInDomain(point, xDomain))
     .map((point) => point.balance);
-  const chartDomain = buildBalanceChartYDomain(visibleBalances, currentBalance);
+  const { domain: chartDomain, ticks: yTicks } = buildNiceYAxis(visibleBalances, currentBalance);
   const visibleMinBalance = Math.min(...(visibleBalances.length > 0 ? visibleBalances : [currentBalance]));
   const showZeroLine = chartDomain[0] <= 0 && chartDomain[1] >= 0;
   const showNegativeArea = visibleMinBalance < 0 && showZeroLine;
@@ -193,10 +283,7 @@ export function BalanceChart({
   const showTodayLine =
     todayTimestamp !== undefined && todayTimestamp >= xDomain[0] && todayTimestamp <= xDomain[1];
   const minimumForecastPoint = getMinimumForecastPoint(forecastEventSeries, xDomain);
-  const minimumForecastLabelPosition =
-    minimumForecastPoint && minimumForecastPoint.timestamp > xDomain[0] + (xDomain[1] - xDomain[0]) * 0.85
-      ? "left"
-      : "right";
+  const forecastEventTimestamps = new Set(forecastEventSeries.map((point) => point.timestamp));
   const chartData: BalanceChartDatum[] = [
     ...actualLineSeries.map((point) => ({
       date: point.date,
@@ -213,110 +300,196 @@ export function BalanceChart({
       forecastDescription: point.description,
     })),
   ].sort((left, right) => left.timestamp - right.timestamp || left.order - right.order);
+  const useMonthTicks = isMoreThanThreeMonths(
+    timestampToDateOnly(xDomain[0]),
+    timestampToDateOnly(xDomain[1]),
+  );
   const xTicks = buildTimeScaleTicks(timestampToDateOnly(xDomain[0]), timestampToDateOnly(xDomain[1]));
-  const primaryColor = "var(--color-primary)";
+  const zeroLineLabel = disposableZero ? "¥0（可処分ゼロ）" : "¥0";
+
+  const plotLeft = CHART_MARGIN.left + Y_AXIS_WIDTH;
+  const plotRight = chartSize.width - CHART_MARGIN.right;
+  const plotTop = CHART_MARGIN.top;
+  const plotBottom = chartSize.height - CHART_MARGIN.bottom - X_AXIS_HEIGHT;
+  const plotWidth = Math.max(plotRight - plotLeft, 0);
+  const plotHeight = Math.max(plotBottom - plotTop, 0);
+
+  const scaleX = (timestamp: number) => {
+    if (xDomain[1] === xDomain[0]) {
+      return plotLeft;
+    }
+
+    return plotLeft + ((timestamp - xDomain[0]) / (xDomain[1] - xDomain[0])) * plotWidth;
+  };
+
+  const scaleY = (value: number) => {
+    if (chartDomain[1] === chartDomain[0]) {
+      return plotTop + plotHeight / 2;
+    }
+
+    return plotTop + (1 - (value - chartDomain[0]) / (chartDomain[1] - chartDomain[0])) * plotHeight;
+  };
+
+  const shouldAnimate = !prefersReducedMotion;
 
   return (
-    <div ref={chartRef} className="h-full min-h-0 min-w-0">
+    <div ref={chartRef} className="relative h-full min-h-0 min-w-0">
       {chartSize.width > 0 && chartSize.height > 0 ? (
-        <LineChart
-          data={chartData}
-          height={chartSize.height}
-          margin={{ left: 12, right: 12, top: 12, bottom: 8 }}
-          width={chartSize.width}
-        >
-          {showNegativeArea ? (
-            <ReferenceArea
-              x1={xDomain[0]}
-              x2={xDomain[1]}
-              y1={chartDomain[0]}
-              y2={0}
-              fill="rgba(244, 63, 94, 0.08)"
-              strokeOpacity={0}
+        <>
+          <LineChart
+            data={chartData}
+            height={chartSize.height}
+            margin={CHART_MARGIN}
+            width={chartSize.width}
+          >
+            <CartesianGrid horizontal vertical={false} stroke="var(--line)" strokeOpacity={0.4} />
+            {showNegativeArea ? (
+              <ReferenceArea
+                x1={xDomain[0]}
+                x2={xDomain[1]}
+                y1={chartDomain[0]}
+                y2={0}
+                fill="var(--critical)"
+                fillOpacity={0.1}
+                strokeOpacity={0}
+              />
+            ) : null}
+            {showZeroLine ? (
+              <ReferenceLine
+                y={0}
+                stroke="var(--line-strong)"
+                strokeDasharray="4 4"
+                label={
+                  showNegativeArea
+                    ? {
+                        value: zeroLineLabel,
+                        position: "insideBottomLeft",
+                        fill: "var(--critical)",
+                        fontSize: 11,
+                      }
+                    : undefined
+                }
+              />
+            ) : null}
+            {showTodayLine ? (
+              <ReferenceLine x={todayTimestamp} stroke="var(--line-strong)" strokeDasharray="3 5" />
+            ) : null}
+            {minimumForecastPoint ? (
+              <ReferenceDot
+                x={minimumForecastPoint.timestamp}
+                y={minimumForecastPoint.balance}
+                r={3}
+                fill={minimumForecastPoint.balance < 0 ? "var(--critical)" : "var(--chart-forecast)"}
+                stroke="var(--ink)"
+                strokeWidth={1}
+              />
+            ) : null}
+            <XAxis
+              dataKey="timestamp"
+              type="number"
+              domain={xDomain}
+              ticks={xTicks}
+              stroke="var(--line-strong)"
+              height={X_AXIS_HEIGHT}
+              tick={{ fontSize: 11, fill: "var(--ink-3)", fontFamily: "var(--font-data)" }}
+              tickLine={false}
+              tickMargin={6}
+              minTickGap={24}
+              interval="preserveStartEnd"
+              tickFormatter={(value: number) => formatChartAxisTick(value, xTicks, useMonthTicks)}
+              allowDataOverflow
             />
-          ) : null}
-          {showZeroLine ? <ReferenceLine y={0} stroke="rgba(255,255,255,0.2)" strokeDasharray="4 4" /> : null}
+            <YAxis
+              stroke="var(--line-strong)"
+              tickFormatter={(value: number) => formatManUnit(value)}
+              width={Y_AXIS_WIDTH}
+              domain={chartDomain}
+              ticks={yTicks}
+              tick={{ fontSize: 11, fill: "var(--ink-3)", fontFamily: "var(--font-data)" }}
+              tickLine={false}
+              allowDataOverflow
+            />
+            <Tooltip
+              content={(props) => (
+                <BalanceTooltip
+                  {...props}
+                  currencyCode={currencyCode}
+                  exchangeRateToJpy={exchangeRateToJpy}
+                  showSeriesLabel={forecastData !== undefined}
+                />
+              )}
+              cursor={{ stroke: "var(--line-strong)", strokeDasharray: "4 4" }}
+            />
+            {actualLineSeries.length > 0 ? (
+              <Line
+                type="stepAfter"
+                dataKey="actualBalance"
+                stroke="var(--chart-actual)"
+                strokeWidth={2}
+                strokeOpacity={0.55}
+                dot={false}
+                activeDot={{ r: 4 }}
+                isAnimationActive={shouldAnimate}
+                animationDuration={INITIAL_ANIMATION_MS}
+                connectNulls
+              />
+            ) : null}
+            {forecastLineSeries.length > 0 ? (
+              <Line
+                type="stepAfter"
+                dataKey="forecastBalance"
+                stroke="var(--chart-forecast)"
+                strokeDasharray="7 6"
+                strokeWidth={2}
+                dot={(dotProps: { cx?: number; cy?: number; payload?: BalanceChartDatum; index?: number }) => {
+                  const { cx, cy, payload, index } = dotProps;
+                  if (
+                    cx === undefined ||
+                    cy === undefined ||
+                    !payload ||
+                    !forecastEventTimestamps.has(payload.timestamp)
+                  ) {
+                    return <g key={`forecast-dot-${index}`} />;
+                  }
+
+                  return (
+                    <g key={`forecast-dot-${index}`}>
+                      <circle cx={cx} cy={cy} r={8} fill="transparent" />
+                      <circle cx={cx} cy={cy} r={3} fill="var(--chart-forecast)" />
+                    </g>
+                  );
+                }}
+                activeDot={{ r: 4 }}
+                isAnimationActive={shouldAnimate}
+                animationDuration={INITIAL_ANIMATION_MS}
+                connectNulls
+              />
+            ) : null}
+          </LineChart>
+          <ChartLegend />
           {showTodayLine ? (
-            <ReferenceLine
-              x={todayTimestamp}
-              stroke="rgba(255,255,255,0.32)"
-              strokeDasharray="3 5"
-              label={{ value: "今日", position: "insideTop", fill: "rgba(255,255,255,0.68)", fontSize: 12 }}
-            />
+            <div
+              className="pointer-events-none absolute -translate-x-1/2 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-[11px] text-ink-2"
+              style={{ left: scaleX(todayTimestamp), top: plotTop }}
+            >
+              今日
+            </div>
           ) : null}
           {minimumForecastPoint ? (
-            <ReferenceDot
-              x={minimumForecastPoint.timestamp}
-              y={minimumForecastPoint.balance}
-              r={4}
-              fill={primaryColor}
-              stroke="rgba(255,255,255,0.75)"
-              strokeWidth={1.5}
-              label={{
-                value: `表示期間の最小 ${formatCurrency(minimumForecastPoint.balance, currencyCode)} / ${formatDateWithYear(minimumForecastPoint.date)}`,
-                position: minimumForecastLabelPosition,
-                fill: "rgba(255,255,255,0.72)",
-                fontSize: 12,
+            <div
+              className={cn(
+                "pointer-events-none absolute -translate-x-1/2 -translate-y-full rounded-full px-2 py-0.5 text-[11px] font-medium",
+                minimumForecastPoint.balance < 0 ? "bg-critical/20 text-critical" : "bg-surface-2 text-ink-2",
+              )}
+              style={{
+                left: scaleX(minimumForecastPoint.timestamp),
+                top: scaleY(minimumForecastPoint.balance) - 6,
               }}
-            />
+            >
+              最小
+            </div>
           ) : null}
-          <XAxis
-            dataKey="timestamp"
-            type="number"
-            domain={xDomain}
-            ticks={xTicks}
-            stroke="rgba(255,255,255,0.28)"
-            height={28}
-            tick={{ fontSize: 10, fill: "rgba(255,255,255,0.58)" }}
-            tickLine={false}
-            tickMargin={6}
-            minTickGap={24}
-            interval="preserveStartEnd"
-            tickFormatter={formatTimestampTick}
-            allowDataOverflow
-          />
-          <YAxis
-            stroke="rgba(255,255,255,0.4)"
-            tickFormatter={(value) => formatCurrency(value, currencyCode)}
-            width={110}
-            domain={chartDomain}
-            tickCount={6}
-            tick={{ fontSize: 11, fill: "rgba(255,255,255,0.58)" }}
-            tickLine={false}
-            allowDataOverflow
-          />
-          <Tooltip
-            content={(props) => (
-              <BalanceTooltip {...props} currencyCode={currencyCode} showSeriesLabel={forecastData !== undefined} />
-            )}
-            cursor={{ stroke: "rgba(255,255,255,0.18)", strokeDasharray: "4 4" }}
-          />
-          {actualLineSeries.length > 0 ? (
-            <Line
-              type="stepAfter"
-              dataKey="actualBalance"
-              stroke={primaryColor}
-              strokeWidth={3}
-              dot={false}
-              activeDot={{ r: 4 }}
-              isAnimationActive={false}
-              connectNulls
-            />
-          ) : null}
-          {forecastLineSeries.length > 0 ? (
-            <Line
-              type="stepAfter"
-              dataKey="forecastBalance"
-              stroke={primaryColor}
-              strokeDasharray="7 6"
-              strokeWidth={3}
-              dot={false}
-              activeDot={{ r: 4 }}
-              isAnimationActive={false}
-              connectNulls
-            />
-          ) : null}
-        </LineChart>
+        </>
       ) : null}
     </div>
   );

--- a/packages/frontend/src/components/level-header.tsx
+++ b/packages/frontend/src/components/level-header.tsx
@@ -78,6 +78,7 @@ export function LevelHeader({
             {onMinBalanceClick ? (
               <button
                 type="button"
+                aria-label="期間内最小の寄与分解を表示"
                 onClick={onMinBalanceClick}
                 className="font-data mt-1 block overflow-x-auto whitespace-nowrap text-ink-2 underline decoration-dotted underline-offset-4 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
               >

--- a/packages/frontend/src/components/level-header.tsx
+++ b/packages/frontend/src/components/level-header.tsx
@@ -1,0 +1,102 @@
+import { cn } from "../lib/utils";
+import { StatusChip } from "./ui/status-chip";
+
+export type LevelHeaderStatus = "safe" | "warning" | "critical";
+
+const statusTone = {
+  safe: "success",
+  warning: "warning",
+  critical: "danger",
+} as const;
+
+const statusLabel = {
+  safe: "安全",
+  warning: "警告",
+  critical: "危険",
+} as const;
+
+/**
+ * 水位ヘッダー（C-3）。3 値判定を最上部で言い切り、危険時のみ「あと N 日」を
+ * 判定ヒーローサイズ（40px Mono）で示す。総資産・期間内最小・次の収入・次の支出は
+ * 従属位置に格下げして残す。ヒーロー背後にのみ 1px 横罫パターンを敷く。
+ */
+export function LevelHeader({
+  status,
+  heroText,
+  criticalDays,
+  totalBalanceLabel,
+  minBalanceLabel,
+  onMinBalanceClick,
+  nextIncomeLabel,
+  nextExpenseLabel,
+}: {
+  status: LevelHeaderStatus;
+  heroText: string;
+  criticalDays?: number;
+  totalBalanceLabel: string;
+  minBalanceLabel: string;
+  onMinBalanceClick?: () => void;
+  nextIncomeLabel: string;
+  nextExpenseLabel: string;
+}) {
+  return (
+    <div className="relative overflow-hidden">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(to bottom, rgba(233,228,218,0.03) 0px, rgba(233,228,218,0.03) 1px, transparent 1px, transparent 9px)",
+        }}
+      />
+      <div className="relative grid gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <StatusChip tone={statusTone[status]}>{statusLabel[status]}</StatusChip>
+          <div className="text-right">
+            <div className="text-xs font-medium text-ink-3">総資産</div>
+            <div className="font-data overflow-x-auto whitespace-nowrap text-lg font-semibold">
+              {totalBalanceLabel}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-end gap-x-4 gap-y-1 min-w-0">
+          <p className={cn("min-w-0 break-words text-lg font-semibold sm:text-xl", status === "critical" && "text-critical", status === "warning" && "text-warning")}>
+            {heroText}
+          </p>
+          {status === "critical" && typeof criticalDays === "number" ? (
+            <div className="flex items-baseline gap-1 text-critical">
+              <span className="font-data text-[40px] font-semibold leading-[48px]">{criticalDays}</span>
+              <span className="text-sm font-medium">日</span>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="grid gap-3 text-sm sm:grid-cols-3">
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-ink-3">期間内最小</div>
+            {onMinBalanceClick ? (
+              <button
+                type="button"
+                onClick={onMinBalanceClick}
+                className="font-data mt-1 block overflow-x-auto whitespace-nowrap text-ink-2 underline decoration-dotted underline-offset-4 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              >
+                {minBalanceLabel}
+              </button>
+            ) : (
+              <div className="font-data mt-1 overflow-x-auto whitespace-nowrap text-ink-2">{minBalanceLabel}</div>
+            )}
+          </div>
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-ink-3">次の収入</div>
+            <div className="font-data mt-1 overflow-x-auto whitespace-nowrap text-ink-2">{nextIncomeLabel}</div>
+          </div>
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-ink-3">次の支出</div>
+            <div className="font-data mt-1 overflow-x-auto whitespace-nowrap text-ink-2">{nextExpenseLabel}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/balance-chart.ts
+++ b/packages/frontend/src/lib/balance-chart.ts
@@ -207,6 +207,55 @@ export function buildBalanceChartYDomain(values: number[], currentBalance: numbe
   return [minBalance - padding, maxBalance + padding];
 }
 
+const NICE_FRACTIONS = [1, 2, 2.5, 5, 10];
+
+function niceStep(roughStep: number) {
+  if (roughStep <= 0) {
+    return 1;
+  }
+
+  const exponent = Math.floor(Math.log10(roughStep));
+  const base = 10 ** exponent;
+
+  for (const fraction of NICE_FRACTIONS) {
+    const candidate = fraction * base;
+    if (candidate >= roughStep - Number.EPSILON) {
+      return candidate;
+    }
+  }
+
+  return 10 * base;
+}
+
+/**
+ * Y ドメインを 1 / 2 / 2.5 / 5 × 10^n の nice ticks に丸める。
+ * ¥1,843,972 のようなきりの悪い目盛りを避けるため、生のパディング済みドメインを
+ * step 単位に切り上げ/切り下げる。
+ */
+export function buildNiceYAxis(
+  values: number[],
+  currentBalance: number,
+  targetTickCount = 5,
+): { domain: [number, number]; ticks: number[] } {
+  const [rawMin, rawMax] = buildBalanceChartYDomain(values, currentBalance);
+  const span = rawMax - rawMin;
+
+  if (!(span > 0)) {
+    return { domain: [rawMin, rawMax], ticks: [rawMin, rawMax] };
+  }
+
+  const step = niceStep(span / targetTickCount);
+  const niceMin = Math.floor(rawMin / step) * step;
+  const niceMax = Math.ceil(rawMax / step) * step;
+  const ticks: number[] = [];
+
+  for (let value = niceMin; value <= niceMax + step * 0.5; value += step) {
+    ticks.push(Math.round(value));
+  }
+
+  return { domain: [niceMin, niceMax], ticks };
+}
+
 export function buildBalanceChartSegments({
   actualPoints,
   forecastPoints = [],
@@ -264,7 +313,7 @@ export function buildBalanceChartSegments({
   };
 }
 
-function isMoreThanThreeMonths(startDate: string, endDate: string) {
+export function isMoreThanThreeMonths(startDate: string, endDate: string) {
   return endDate > addMonthsToDateOnly(startDate, 3);
 }
 
@@ -293,6 +342,29 @@ export function buildTimeScaleTicks(startDate: string, endDate: string) {
   }
 
   return ticks;
+}
+
+/**
+ * X 軸ラベル。年の繰り返しをやめ、先頭と年替わりのみ「'26 7月」を出し、以降は「8月」。
+ * 月内表示（週次ティック）のときは「7/6」形式。
+ */
+export function formatChartAxisTick(value: number, ticks: number[], useMonthTicks: boolean) {
+  const dateOnly = timestampToDateOnly(value);
+  const { year, month, day } = parseDateParts(dateOnly);
+
+  if (!useMonthTicks) {
+    return `${month}/${day}`;
+  }
+
+  const index = ticks.indexOf(value);
+  const previousYear =
+    index > 0 ? parseDateParts(timestampToDateOnly(ticks[index - 1])).year : null;
+
+  if (index <= 0 || year !== previousYear) {
+    return `'${String(year).slice(-2)} ${month}月`;
+  }
+
+  return `${month}月`;
 }
 
 export function getDashboardChartStartDate(today: string) {

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -77,6 +77,21 @@ export function formatDateWithYear(value: string) {
   }).format(new Date(`${value}T00:00:00+09:00`));
 }
 
+/**
+ * Y 軸ラベル用の万単位短縮表記（「120万」「-5万」「¥0」）。Mono で組む前提。
+ */
+export function formatManUnit(value: number) {
+  if (value === 0) {
+    return "¥0";
+  }
+
+  const manValue = value / 10_000;
+  const rounded = Math.round(manValue * 10) / 10;
+  const formatted = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+
+  return `${formatted}万`;
+}
+
 export function formatChartDateWithYear(value: string) {
   const date = new Date(`${value}T00:00:00+09:00`);
   const parts = new Intl.DateTimeFormat("ja-JP", {

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -113,7 +113,7 @@ function formatSummaryEvent(event: DashboardResponse["nextIncome"] | DashboardRe
     return "なし";
   }
 
-  return `${formatDateWithYear(event.date)} ${formatCurrencyWithJpy(
+  return `${formatDateWithYear(event.date)} ${event.description} ${formatCurrencyWithJpy(
     event.amount,
     event.currencyCode,
     event.amountJpy,

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -7,9 +7,10 @@ import type {
   ForecastEvent,
   SupportedCurrencyCode,
 } from "@sui/shared";
-import { useState, startTransition } from "react";
-import { AccountSelector } from "../components/account-selector";
+import { useEffect, useMemo, useState, startTransition } from "react";
+import { AccountLevelList, type AccountLevelRow } from "../components/account-level-list";
 import { BalanceChart } from "../components/balance-chart";
+import { LevelHeader, type LevelHeaderStatus } from "../components/level-header";
 import { OffsetToggle } from "../components/offset-toggle";
 import { PeriodSelector } from "../components/period-selector";
 import { Badge } from "../components/ui/badge";
@@ -26,6 +27,7 @@ import { Input } from "../components/ui/input";
 import { Select } from "../components/ui/select";
 import { Table, TableWrapper } from "../components/ui/table";
 import { useResource } from "../hooks/use-resource";
+import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import {
   formatCurrency,
@@ -34,7 +36,12 @@ import {
   formatDateWithYear,
   parseCurrencyInputValue,
 } from "../lib/format";
-import { getDashboardChartEndDate, getDashboardChartStartDate } from "../lib/balance-chart";
+import {
+  DAY_MS,
+  dateOnlyToTimestamp,
+  getDashboardChartEndDate,
+  getDashboardChartStartDate,
+} from "../lib/balance-chart";
 import { cn, getTodayDate } from "../lib/utils";
 
 type DashboardPeriodPreset = "next1Month" | "next3Months" | "next6Months" | "next1Year" | "all";
@@ -113,6 +120,14 @@ function formatSummaryEvent(event: DashboardResponse["nextIncome"] | DashboardRe
   )}`;
 }
 
+function formatMonthDay(value: string) {
+  return new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(`${value}T00:00:00+09:00`));
+}
+
 type OverdueConfirmDraft = {
   selected: boolean;
   amount: number;
@@ -127,6 +142,20 @@ type ExplainDialogState = {
   data: DashboardExplainResponse | null;
   loading: boolean;
   error: string | null;
+};
+
+type ChartSnapshot = {
+  data: Array<{ date: string; description?: string; balance: number }>;
+  forecastData: Array<{ date: string; description?: string; balance: number }>;
+  todayPoint: { date: string; description: string; balance: number };
+  todayDate: string;
+  displayStartDate: string;
+  displayEndDate: string;
+  currentBalance: number;
+  label: string;
+  currencyCode: SupportedCurrencyCode;
+  exchangeRateToJpy: number;
+  disposableZero: boolean;
 };
 
 function getDefaultConfirmAccountId(event: ForecastEvent, accounts: Account[]) {
@@ -238,17 +267,27 @@ function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "確定に失敗しました。";
 }
 
+function pickEarliestWarning<T extends { firstNegativeDate: string }>(list: T[]): T | null {
+  return list.reduce<T | null>(
+    (earliest, item) => (!earliest || item.firstNegativeDate < earliest.firstNegativeDate ? item : earliest),
+    null,
+  );
+}
+
 export function DashboardPage() {
+  const { toast } = useToast();
   const [reloadKey, setReloadKey] = useState(0);
   const [selectedAccountId, setSelectedAccountId] = useState<string | "total">("total");
   const [periodPreset, setPeriodPreset] = useState<DashboardPeriodPreset>(DEFAULT_DASHBOARD_PERIOD);
   const [applyOffset, setApplyOffset] = useState(true);
   const [manualSelectedEvent, setManualSelectedEvent] = useState<ForecastEvent | null>(null);
   const [explainDialog, setExplainDialog] = useState<ExplainDialogState | null>(null);
-  const [dismissedOverdueSignature, setDismissedOverdueSignature] = useState<string | null>(null);
+  const [isQueueCollapsed, setIsQueueCollapsed] = useState(false);
   const [overdueDrafts, setOverdueDrafts] = useState<Record<string, OverdueConfirmDraft>>({});
   const [hiddenOverdueIds, setHiddenOverdueIds] = useState<string[]>([]);
+  const [optimisticConfirmedIds, setOptimisticConfirmedIds] = useState<string[]>([]);
   const [isBatchConfirming, setIsBatchConfirming] = useState(false);
+  const [renderedChart, setRenderedChart] = useState<ChartSnapshot | null>(null);
   const [confirmDraft, setConfirmDraft] = useState<{
     eventId: string;
     amount: number;
@@ -306,34 +345,44 @@ export function DashboardPage() {
     selectedAccountId === "total"
       ? null
       : eventsData?.accountForecasts.find((forecast) => forecast.accountId === selectedAccountId) ?? null;
-  const chartForecast =
-    selectedAccountId === "total"
-      ? eventsData?.forecast ?? dashboardData?.dashboard.forecast ?? []
-      : selectedAccountEvents?.events ?? selectedAccountForecast?.events ?? [];
+  const chartForecast = useMemo(
+    () =>
+      selectedAccountId === "total"
+        ? eventsData?.forecast ?? dashboardData?.dashboard.forecast ?? []
+        : selectedAccountEvents?.events ?? selectedAccountForecast?.events ?? [],
+    [selectedAccountId, eventsData, dashboardData, selectedAccountEvents, selectedAccountForecast],
+  );
   const tableForecast = selectedAccountEvents?.events ?? eventsData?.forecast ?? [];
   const overdueForecast = dashboardData?.dashboard.overdueForecast ?? [];
   const visibleOverdueForecast = overdueForecast.filter((event) => !hiddenOverdueIds.includes(event.id));
-  const visibleOverdueSignature = visibleOverdueForecast.map((event) => event.id).join("|");
-  const isOverdueDialogOpen =
-    visibleOverdueForecast.length > 0 && dismissedOverdueSignature !== visibleOverdueSignature;
   const currentBalance =
     selectedAccountForecast?.currentBalance ?? dashboardData?.dashboard.totalBalance ?? 0;
   const displayCurrencyCode: SupportedCurrencyCode = selectedAccountForecast?.currencyCode ?? "JPY";
+  const chartExchangeRateToJpy = selectedAccountForecast?.exchangeRateToJpy ?? 1;
+  const chartLabel = selectedAccountForecast?.accountName ?? "総所持金";
   const todayChartPoint = {
     date: today,
     description: selectedAccountForecast ? `${selectedAccountForecast.accountName} 現在残高` : "総所持金",
     balance: currentBalance,
   };
-  const chartData = (balanceHistoryData?.points ?? []).map((point) => ({
-    date: point.date,
-    description: point.description,
-    balance: point.balance,
-  }));
-  const chartForecastData = chartForecast.map((point) => ({
-    date: point.date,
-    description: point.description,
-    balance: point.balance,
-  }));
+  const chartData = useMemo(
+    () =>
+      (balanceHistoryData?.points ?? []).map((point) => ({
+        date: point.date,
+        description: point.description,
+        balance: point.balance,
+      })),
+    [balanceHistoryData],
+  );
+  const chartForecastData = useMemo(
+    () =>
+      chartForecast.map((point) => ({
+        date: point.date,
+        description: point.description,
+        balance: point.balance,
+      })),
+    [chartForecast],
+  );
   const yellowForecasts = accountForecasts
     .filter((forecast) => forecast.warningLevel === "yellow")
     .map((forecast) => ({
@@ -346,6 +395,17 @@ export function DashboardPage() {
       accountName: forecast.accountName,
       firstNegativeDate: forecast.events.find((event) => event.balance < 0)?.date ?? forecast.minBalanceDate,
     }));
+  const worstRed = pickEarliestWarning(redForecasts);
+  const worstYellow = pickEarliestWarning(yellowForecasts);
+  const levelStatus: LevelHeaderStatus = worstRed ? "critical" : worstYellow ? "warning" : "safe";
+  const criticalDays = worstRed
+    ? Math.max(0, Math.round((dateOnlyToTimestamp(worstRed.firstNegativeDate) - dateOnlyToTimestamp(today)) / DAY_MS))
+    : undefined;
+  const heroText = worstRed
+    ? `${formatMonthDay(worstRed.firstNegativeDate)} に ${worstRed.accountName} が赤字になります`
+    : worstYellow
+      ? `${formatMonthDay(worstYellow.firstNegativeDate)} に ${worstYellow.accountName} の可処分残高がマイナスになります`
+      : `${formatMonthDay(chartDisplayEndDate)}まで水位は保たれます`;
   const selectedEvent = manualSelectedEvent;
   const defaultAccountId = selectedEvent ? getDefaultConfirmAccountId(selectedEvent, accounts) : "";
   const activeDraft = confirmDraft?.eventId === selectedEvent?.id ? confirmDraft : null;
@@ -362,6 +422,68 @@ export function DashboardPage() {
         today,
       )
     : today;
+
+  const isChartLoading = dashboardLoading || balanceHistoryLoading || eventsLoading;
+  const hasChartError = Boolean(dashboardError || balanceHistoryError || eventsError);
+
+  useEffect(() => {
+    if (isChartLoading || hasChartError) {
+      return;
+    }
+
+    setRenderedChart({
+      data: chartData,
+      forecastData: chartForecastData,
+      todayPoint: todayChartPoint,
+      todayDate: today,
+      displayStartDate: chartDisplayStartDate,
+      displayEndDate: chartDisplayEndDate,
+      currentBalance,
+      label: chartLabel,
+      currencyCode: displayCurrencyCode,
+      exchangeRateToJpy: chartExchangeRateToJpy,
+      disposableZero: applyOffset,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- todayChartPoint はプリミティブから毎レンダー再構築されるため依存に含めない。
+  }, [
+    isChartLoading,
+    hasChartError,
+    chartData,
+    chartForecastData,
+    currentBalance,
+    today,
+    chartDisplayStartDate,
+    chartDisplayEndDate,
+    chartLabel,
+    displayCurrencyCode,
+    chartExchangeRateToJpy,
+    applyOffset,
+  ]);
+
+  const accountLevelRows: AccountLevelRow[] = [
+    {
+      id: "total" as const,
+      name: "全体",
+      currentBalance: dashboardData?.dashboard.totalBalance ?? 0,
+      currentBalanceJpy: dashboardData?.dashboard.totalBalance ?? 0,
+      currencyCode: "JPY" as const,
+      minBalance: dashboardData?.dashboard.minBalance ?? 0,
+      minBalanceJpy: dashboardData?.dashboard.minBalance ?? 0,
+      minBalanceDate: totalMinBalanceDate,
+      warningLevel: worstRed ? "red" : worstYellow ? "yellow" : "none",
+    },
+    ...accountForecasts.map((forecast) => ({
+      id: forecast.accountId,
+      name: forecast.accountName,
+      currentBalance: forecast.currentBalance,
+      currentBalanceJpy: forecast.currentBalanceJpy,
+      currencyCode: forecast.currencyCode,
+      minBalance: forecast.minBalance,
+      minBalanceJpy: forecast.minBalanceJpy,
+      minBalanceDate: forecast.minBalanceDate,
+      warningLevel: forecast.warningLevel,
+    })),
+  ];
 
   const openExplain = async ({
     title,
@@ -440,6 +562,10 @@ export function DashboardPage() {
   };
 
   const openConfirm = (event: ForecastEvent) => {
+    if (optimisticConfirmedIds.includes(event.id)) {
+      return;
+    }
+
     setManualSelectedEvent(event);
     setConfirmDraft({
       eventId: event.id,
@@ -458,17 +584,29 @@ export function DashboardPage() {
       return;
     }
 
-    await apiFetch("/api/dashboard/confirm", {
-      method: "POST",
-      body: JSON.stringify({
-        forecastEventId: selectedEvent.id,
-        amount: confirmAmount,
-        accountId: selectedEvent.type === "transfer" ? undefined : accountId || undefined,
-      }),
-    });
+    const event = selectedEvent;
+    const amount = confirmAmount;
+    const targetAccountId = accountId;
 
     closeConfirm();
-    startTransition(() => setReloadKey((value) => value + 1));
+    setOptimisticConfirmedIds((ids) => [...ids, event.id]);
+
+    try {
+      await apiFetch("/api/dashboard/confirm", {
+        method: "POST",
+        body: JSON.stringify({
+          forecastEventId: event.id,
+          amount,
+          accountId: event.type === "transfer" ? undefined : targetAccountId || undefined,
+        }),
+      });
+
+      toast({ title: "確定しました", description: event.description, variant: "success" });
+      startTransition(() => setReloadKey((value) => value + 1));
+    } catch (error) {
+      setOptimisticConfirmedIds((ids) => ids.filter((id) => id !== event.id));
+      toast({ title: "確定に失敗しました", description: getErrorMessage(error), variant: "error" });
+    }
   };
 
   const handleBatchConfirm = async () => {
@@ -520,144 +658,226 @@ export function DashboardPage() {
       return next;
     });
     setHiddenOverdueIds((ids) => Array.from(new Set([...ids, ...confirmedIds])));
-    setDismissedOverdueSignature(failedById.size > 0 ? null : visibleOverdueSignature);
+    setOptimisticConfirmedIds((ids) => Array.from(new Set([...ids, ...confirmedIds])));
     setIsBatchConfirming(false);
+
+    if (confirmedIds.length > 0) {
+      toast({
+        title: `${confirmedIds.length} 件を確定しました`,
+        description: failedById.size > 0 ? `${failedById.size} 件は失敗しました。` : undefined,
+        variant: failedById.size > 0 ? "error" : "success",
+      });
+    } else {
+      toast({
+        title: "確定に失敗しました",
+        description: `${failedById.size} 件のエラーを確認してください。`,
+        variant: "error",
+      });
+    }
+
     startTransition(() => setReloadKey((value) => value + 1));
   };
 
   return (
     <div className="grid gap-6">
-      {redForecasts.length > 0 ? (
-        <Card className="border-critical/40 bg-critical/15">
-          <div className="break-words text-sm font-medium text-ink">
-            🔴 実残高がマイナスになる見込み:{" "}
-            {redForecasts
-              .map((forecast) => `${forecast.accountName}（${formatDateWithYear(forecast.firstNegativeDate)}）`)
-              .join("、")}
-          </div>
-        </Card>
-      ) : null}
-      {yellowForecasts.length > 0 ? (
-        <Card className="border-warning/40 bg-warning/15">
-          <div className="break-words text-sm font-medium text-ink">
-            ⚠️ 可処分残高がマイナスになる見込み:{" "}
-            {yellowForecasts
-              .map((forecast) => `${forecast.accountName}（${formatDateWithYear(forecast.firstNegativeDate)}）`)
-              .join("、")}
-          </div>
-        </Card>
-      ) : null}
-      {visibleOverdueForecast.length > 0 && !isOverdueDialogOpen ? (
-        <Card className="border-warning/40 bg-warning/15">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="break-words text-sm font-medium text-ink">
-              ⏳ 予定日超過の未確定イベントが {visibleOverdueForecast.length} 件あります
+      <Card className="grid gap-6">
+        <LevelHeader
+          status={levelStatus}
+          heroText={heroText}
+          criticalDays={criticalDays}
+          totalBalanceLabel={formatCurrency(dashboardData?.dashboard.totalBalance ?? 0)}
+          minBalanceLabel={formatCurrency(dashboardData?.dashboard.minBalance ?? 0)}
+          onMinBalanceClick={
+            dashboardData
+              ? () =>
+                  openExplain({
+                    title: "全体の最小残高の寄与分解",
+                    date: totalMinBalanceDate,
+                  })
+              : undefined
+          }
+          nextIncomeLabel={formatSummaryEvent(dashboardData?.dashboard.nextIncome ?? null)}
+          nextExpenseLabel={formatSummaryEvent(dashboardData?.dashboard.nextExpense ?? null)}
+        />
+
+        <div className="border-t border-line pt-4">
+          <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="break-words text-lg font-semibold">
+                {selectedAccountForecast ? `${selectedAccountForecast.accountName} の残高推移` : "残高推移"}
+              </h2>
+              <p className="text-sm text-ink-2">
+                {selectedAccountForecast ? "選択した口座に影響するイベントのみ表示します。" : "全口座合計の残高チェーンです。"}
+              </p>
             </div>
-            <Button variant="ghost" onClick={() => setDismissedOverdueSignature(null)}>
-              確認する
+            <div className="flex flex-wrap items-center gap-3">
+              <OffsetToggle checked={applyOffset} onChange={setApplyOffset} />
+              <Button variant="ghost" onClick={() => setReloadKey((value) => value + 1)}>
+                再読込
+              </Button>
+            </div>
+          </div>
+          <div className="h-[320px] min-w-0 sm:h-[420px]">
+            {!renderedChart && isChartLoading ? (
+              <ChartSkeleton />
+            ) : !renderedChart && hasChartError ? (
+              <StateMessage
+                message={dashboardError ?? balanceHistoryError ?? eventsError ?? "読み込みに失敗しました。"}
+                tone="danger"
+              />
+            ) : renderedChart ? (
+              <div className={cn("h-full min-h-0 min-w-0 transition-opacity duration-200", isChartLoading && "opacity-40")}>
+                <BalanceChart {...renderedChart} />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <h2 className="mb-4 text-lg font-semibold">口座別の水位</h2>
+        <AccountLevelList rows={accountLevelRows} selectedId={selectedAccountId} onSelect={setSelectedAccountId} />
+      </Card>
+
+      {visibleOverdueForecast.length > 0 ? (
+        <Card>
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <h2 className="text-lg font-semibold">確定キュー</h2>
+              <Badge tone="warning">{visibleOverdueForecast.length} 件</Badge>
+            </div>
+            <Button variant="ghost" onClick={() => setIsQueueCollapsed((value) => !value)}>
+              {isQueueCollapsed ? "開く" : "閉じる"}
             </Button>
           </div>
+          <p className="mb-4 max-w-4xl text-sm text-ink-2">
+            予定日を過ぎた未確定イベントです。予定額と実績額が一致するとは限らないため、実際の金額と対象口座を確認して確定してください。
+          </p>
+          {isQueueCollapsed ? null : (
+            <>
+              <TableWrapper className="max-h-[55dvh] overflow-y-auto rounded-xl border border-line">
+                <Table className="min-w-[58rem]">
+                  <thead>
+                    <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
+                      <th scope="col" className="px-3 py-3">選択</th>
+                      <th scope="col" className="px-3 py-3">日付</th>
+                      <th scope="col" className="px-3 py-3">説明</th>
+                      <th scope="col" className="px-3 py-3">種別</th>
+                      <th scope="col" className="px-3 py-3">金額</th>
+                      <th scope="col" className="px-3 py-3">対象口座</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {visibleOverdueForecast.map((event) => {
+                      const draft = overdueDrafts[event.id] ?? createOverdueConfirmDraft(event, accounts);
+                      const isConfirmed = optimisticConfirmedIds.includes(event.id);
+
+                      return (
+                        <tr
+                          key={event.id}
+                          className={cn(
+                            "border-b border-line align-top",
+                            !isConfirmed && "cursor-pointer hover:bg-surface-2",
+                            isConfirmed && "opacity-50",
+                          )}
+                          onClick={() => openConfirm(event)}
+                        >
+                          <td className="px-3 py-3" onClick={(clickEvent) => clickEvent.stopPropagation()}>
+                            <input
+                              type="checkbox"
+                              aria-label={`${event.description} を確定対象にする`}
+                              checked={draft.selected}
+                              onChange={(changeEvent) =>
+                                updateOverdueDraft(event, {
+                                  selected: changeEvent.target.checked,
+                                })}
+                              className="h-4 w-4 rounded border-line-strong bg-surface-2"
+                              disabled={isBatchConfirming || isConfirmed}
+                            />
+                          </td>
+                          <td className="whitespace-nowrap px-3 py-3 text-ink-2">
+                            {formatDateWithYear(event.date)}
+                          </td>
+                          <td className="min-w-48 px-3 py-3">
+                            <div className="break-words">{event.description}</div>
+                            {isConfirmed ? (
+                              <div className="mt-1 text-xs text-ink-3">確定済み</div>
+                            ) : draft.error ? (
+                              <div role="alert" className="mt-2 break-words text-xs text-critical">
+                                {draft.error}
+                              </div>
+                            ) : null}
+                          </td>
+                          <td className="whitespace-nowrap px-3 py-3">
+                            <span className={getForecastTypeClassName(event.type)}>
+                              {getForecastTypeLabel(event.type)}
+                            </span>
+                          </td>
+                          <td className="px-3 py-3" onClick={(clickEvent) => clickEvent.stopPropagation()}>
+                            <Input
+                              type="number"
+                              inputMode="decimal"
+                              step={event.currencyCode === "JPY" ? 1 : 0.01}
+                              aria-label={`${event.description} の実際の金額`}
+                              value={formatCurrencyInputValue(draft.amount, event.currencyCode)}
+                              onChange={(changeEvent) =>
+                                updateOverdueDraft(event, {
+                                  amount: parseCurrencyInputValue(changeEvent.target.value, event.currencyCode),
+                                })}
+                              className="w-36"
+                              disabled={isBatchConfirming || isConfirmed}
+                            />
+                          </td>
+                          <td className="px-3 py-3" onClick={(clickEvent) => clickEvent.stopPropagation()}>
+                            {event.type === "transfer" ? (
+                              <Select
+                                aria-label={`${event.description} の対象口座`}
+                                value="fixed"
+                                className="w-56"
+                                disabled
+                              >
+                                <option value="fixed">{formatForecastAccounts(event, accounts)}</option>
+                              </Select>
+                            ) : (
+                              <Select
+                                aria-label={`${event.description} の対象口座`}
+                                value={draft.accountId}
+                                onChange={(changeEvent) =>
+                                  updateOverdueDraft(event, {
+                                    accountId: changeEvent.target.value,
+                                  })}
+                                className="w-48"
+                                disabled={isBatchConfirming || isConfirmed}
+                              >
+                                <option value="">イベント設定口座を使用</option>
+                                {accounts
+                                  .filter((account) => account.currencyCode === event.currencyCode)
+                                  .map((account) => (
+                                    <option key={account.id} value={account.id}>
+                                      {account.name}
+                                    </option>
+                                  ))}
+                              </Select>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </Table>
+              </TableWrapper>
+              <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+                <div className="text-sm text-ink-2">
+                  選択中 {selectedOverdueCount} / {visibleOverdueForecast.length} 件
+                </div>
+                <Button onClick={handleBatchConfirm} disabled={isBatchConfirming || selectedOverdueCount === 0}>
+                  選択した {selectedOverdueCount} 件を確定
+                </Button>
+              </div>
+            </>
+          )}
         </Card>
       ) : null}
-
-      <section className="grid min-w-0 grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <SummaryCard title="総所持金" value={formatCurrency(dashboardData?.dashboard.totalBalance ?? 0)} />
-        <SummaryCard
-          title="全体の最小残高"
-          value={formatCurrency(dashboardData?.dashboard.minBalance ?? 0)}
-          onClick={dashboardData
-            ? () =>
-                openExplain({
-                  title: "全体の最小残高の寄与分解",
-                  date: totalMinBalanceDate,
-                })
-            : undefined}
-        />
-        <SummaryCard
-          title="次の収入"
-          value={formatSummaryEvent(dashboardData?.dashboard.nextIncome ?? null)}
-          detail={dashboardData?.dashboard.nextIncome?.description}
-        />
-        <SummaryCard
-          title="次の支出"
-          value={formatSummaryEvent(dashboardData?.dashboard.nextExpense ?? null)}
-          detail={dashboardData?.dashboard.nextExpense?.description}
-        />
-      </section>
-
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <AccountSelector
-            accounts={accounts}
-            selected={selectedAccountId}
-            onChange={(next) => setSelectedAccountId(next)}
-          />
-        </div>
-        <div className="ml-auto min-w-0 shrink">
-          <OffsetToggle checked={applyOffset} onChange={setApplyOffset} />
-        </div>
-      </div>
-
-      <Card className="flex h-[360px] flex-col overflow-hidden px-4 pt-4 pb-2 sm:h-[450px] sm:px-5 sm:pt-5">
-        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
-            <h2 className="break-words text-xl font-semibold">
-              {selectedAccountForecast ? `${selectedAccountForecast.accountName} の残高推移` : "所持金推移"}
-            </h2>
-            <p className="text-sm text-ink-2">
-              {selectedAccountForecast ? "選択した口座に影響するイベントのみ表示します。" : "全口座合計の残高チェーンです。"}
-            </p>
-          </div>
-          {selectedAccountForecast ? (
-            <Button
-              variant="ghost"
-              className={cn(
-                "max-w-full justify-start rounded-full px-3 py-1 text-xs",
-                selectedAccountForecast.warningLevel === "red" && "bg-critical/15 text-critical hover:bg-critical/25",
-                selectedAccountForecast.warningLevel === "yellow" &&
-                  "bg-warning/15 text-warning hover:bg-warning/25",
-                selectedAccountForecast.warningLevel === "none" &&
-                  "bg-positive/15 text-positive hover:bg-positive/25",
-              )}
-              onClick={() =>
-                openExplain({
-                  title: `${selectedAccountForecast.accountName} の最小残高の寄与分解`,
-                  date: selectedAccountForecast.minBalanceDate,
-                  accountId: selectedAccountForecast.accountId,
-                })}
-            >
-              最小残高 {formatCurrencyWithJpy(
-                selectedAccountForecast.minBalance,
-                selectedAccountForecast.currencyCode,
-                selectedAccountForecast.minBalanceJpy,
-              )}
-            </Button>
-          ) : (
-            <Button variant="ghost" onClick={() => setReloadKey((value) => value + 1)}>
-              再読込
-            </Button>
-          )}
-        </div>
-        {dashboardLoading || balanceHistoryLoading || eventsLoading ? (
-          <StateMessage message="読み込み中..." />
-        ) : dashboardError || balanceHistoryError || eventsError ? (
-          <StateMessage message={dashboardError ?? balanceHistoryError ?? eventsError ?? "読み込みに失敗しました。"} tone="danger" />
-        ) : (
-          <div className="min-h-0 min-w-0 flex-1">
-            <BalanceChart
-              data={chartData}
-              forecastData={chartForecastData}
-              todayPoint={todayChartPoint}
-              todayDate={today}
-              displayStartDate={chartDisplayStartDate}
-              displayEndDate={chartDisplayEndDate}
-              currentBalance={currentBalance}
-              label={selectedAccountForecast?.accountName ?? "総所持金"}
-              currencyCode={displayCurrencyCode}
-            />
-          </div>
-        )}
-      </Card>
 
       <Card>
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
@@ -687,48 +907,64 @@ export function DashboardPage() {
             <Table className="min-w-[60rem]">
               <thead>
                 <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                  <th className="px-3 py-3">日付</th>
-                  <th className="px-3 py-3">種別</th>
-                  <th className="px-3 py-3">内容</th>
-                  <th className="px-3 py-3">金額</th>
-                  <th className="px-3 py-3">残高</th>
-                  <th className="px-3 py-3">対象口座</th>
-                  <th className="px-3 py-3" />
+                  <th scope="col" className="px-3 py-3">日付</th>
+                  <th scope="col" className="px-3 py-3">種別</th>
+                  <th scope="col" className="px-3 py-3">内容</th>
+                  <th scope="col" className="px-3 py-3">金額</th>
+                  <th scope="col" className="px-3 py-3">残高</th>
+                  <th scope="col" className="px-3 py-3">対象口座</th>
+                  <th scope="col" className="px-3 py-3" />
                 </tr>
               </thead>
               <tbody>
-                {tableForecast.map((event) => (
-                  <tr key={event.id} className="border-b border-line">
-                    <td className="font-data px-3 py-3 text-ink-2">{formatDateWithYear(event.date)}</td>
-                    <td className="px-3 py-3">
-                      <span className={getForecastTypeClassName(event.type)}>
-                        {getForecastTypeLabel(event.type)}
-                      </span>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <span className="break-words">{event.description}</span>
-                        {event.isAssumption ? <Badge tone="warning">仮定</Badge> : null}
-                      </div>
-                    </td>
-                    <td className="font-data px-3 py-3">
-                      {formatCurrencyWithJpy(event.amount, event.currencyCode, event.amountJpy)}
-                    </td>
-                    <td className="font-data px-3 py-3">
-                      {selectedAccountForecast
-                        ? formatCurrencyWithJpy(event.balance, event.currencyCode, event.balanceJpy)
-                        : formatCurrency(event.balanceJpy)}
-                    </td>
-                    <td className="px-3 py-3">
-                      {formatForecastAccounts(event, accounts)}
-                    </td>
-                    <td className="px-3 py-3 text-right">
-                      <Button variant="ghost" onClick={() => openConfirm(event)}>
-                        確定
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
+                {tableForecast.map((event) => {
+                  const isConfirmed = optimisticConfirmedIds.includes(event.id);
+
+                  return (
+                    <tr
+                      key={event.id}
+                      className={cn(
+                        "border-b border-line",
+                        !isConfirmed && "cursor-pointer hover:bg-surface-2",
+                        isConfirmed && "opacity-50",
+                      )}
+                      onClick={() => openConfirm(event)}
+                    >
+                      <td className="font-data px-3 py-3 text-ink-2">{formatDateWithYear(event.date)}</td>
+                      <td className="px-3 py-3">
+                        <span className={getForecastTypeClassName(event.type)}>
+                          {getForecastTypeLabel(event.type)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3">
+                        <div className="flex min-w-0 flex-wrap items-center gap-2">
+                          <span className="break-words">{event.description}</span>
+                          {event.isAssumption ? <Badge tone="warning">仮定</Badge> : null}
+                        </div>
+                      </td>
+                      <td className="font-data px-3 py-3">
+                        {formatCurrencyWithJpy(event.amount, event.currencyCode, event.amountJpy)}
+                      </td>
+                      <td className="font-data px-3 py-3">
+                        {selectedAccountForecast
+                          ? formatCurrencyWithJpy(event.balance, event.currencyCode, event.balanceJpy)
+                          : formatCurrency(event.balanceJpy)}
+                      </td>
+                      <td className="px-3 py-3">
+                        {formatForecastAccounts(event, accounts)}
+                      </td>
+                      <td className="px-3 py-3 text-right" onClick={(clickEvent) => clickEvent.stopPropagation()}>
+                        {isConfirmed ? (
+                          <span className="text-xs text-ink-3">確定済み</span>
+                        ) : (
+                          <Button variant="ghost" onClick={() => openConfirm(event)}>
+                            確定
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </Table>
           </TableWrapper>
@@ -801,12 +1037,12 @@ export function DashboardPage() {
                       <Table className="min-w-[52rem]">
                         <thead>
                           <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                            <th className="px-3 py-3">日付</th>
-                            <th className="px-3 py-3">種別</th>
-                            <th className="px-3 py-3">source</th>
-                            <th className="px-3 py-3">内容</th>
-                            <th className="px-3 py-3">金額</th>
-                            <th className="px-3 py-3">残高</th>
+                            <th scope="col" className="px-3 py-3">日付</th>
+                            <th scope="col" className="px-3 py-3">種別</th>
+                            <th scope="col" className="px-3 py-3">source</th>
+                            <th scope="col" className="px-3 py-3">内容</th>
+                            <th scope="col" className="px-3 py-3">金額</th>
+                            <th scope="col" className="px-3 py-3">残高</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -849,139 +1085,6 @@ export function DashboardPage() {
       </Dialog>
 
       <Dialog
-        open={isOverdueDialogOpen}
-        onOpenChange={(open) => {
-          setDismissedOverdueSignature(open ? null : visibleOverdueSignature);
-        }}
-      >
-        <DialogContent className="w-[min(96vw,72rem)]">
-          <DialogTitle className="text-lg font-semibold">予定日超過イベントを確認</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            予定日を過ぎた未確定イベントです。予定額と実績額が一致するとは限らないため、実際の金額と対象口座を確認して確定してください。
-          </DialogDescription>
-          <div className="mt-6">
-            <TableWrapper className="max-h-[55dvh] overflow-y-auto rounded-xl border border-line">
-              <Table className="min-w-[58rem]">
-                <thead>
-                  <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                    <th className="px-3 py-3">選択</th>
-                    <th className="px-3 py-3">日付</th>
-                    <th className="px-3 py-3">説明</th>
-                    <th className="px-3 py-3">種別</th>
-                    <th className="px-3 py-3">金額</th>
-                    <th className="px-3 py-3">対象口座</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {visibleOverdueForecast.map((event) => {
-                    const draft = overdueDrafts[event.id] ?? createOverdueConfirmDraft(event, accounts);
-
-                    return (
-                      <tr key={event.id} className="border-b border-line align-top">
-                        <td className="px-3 py-3">
-                          <input
-                            type="checkbox"
-                            aria-label={`${event.description} を確定対象にする`}
-                            checked={draft.selected}
-                            onChange={(changeEvent) =>
-                              updateOverdueDraft(event, {
-                                selected: changeEvent.target.checked,
-                              })}
-                            className="h-4 w-4 rounded border-line-strong bg-surface-2"
-                            disabled={isBatchConfirming}
-                          />
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-3 text-ink-2">
-                          {formatDateWithYear(event.date)}
-                        </td>
-                        <td className="min-w-48 px-3 py-3">
-                          <div className="break-words">{event.description}</div>
-                          {draft.error ? (
-                            <div role="alert" className="mt-2 break-words text-xs text-critical">
-                              {draft.error}
-                            </div>
-                          ) : null}
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-3">
-                          <span className={getForecastTypeClassName(event.type)}>
-                            {getForecastTypeLabel(event.type)}
-                          </span>
-                        </td>
-                        <td className="px-3 py-3">
-                          <Input
-                            type="number"
-                            inputMode="decimal"
-                            step={event.currencyCode === "JPY" ? 1 : 0.01}
-                            aria-label={`${event.description} の実際の金額`}
-                            value={formatCurrencyInputValue(draft.amount, event.currencyCode)}
-                            onChange={(changeEvent) =>
-                              updateOverdueDraft(event, {
-                                amount: parseCurrencyInputValue(changeEvent.target.value, event.currencyCode),
-                              })}
-                            className="w-36"
-                            disabled={isBatchConfirming}
-                          />
-                        </td>
-                        <td className="px-3 py-3">
-                          {event.type === "transfer" ? (
-                            <Select
-                              aria-label={`${event.description} の対象口座`}
-                              value="fixed"
-                              className="w-56"
-                              disabled
-                            >
-                              <option value="fixed">{formatForecastAccounts(event, accounts)}</option>
-                            </Select>
-                          ) : (
-                            <Select
-                              aria-label={`${event.description} の対象口座`}
-                              value={draft.accountId}
-                              onChange={(changeEvent) =>
-                                updateOverdueDraft(event, {
-                                  accountId: changeEvent.target.value,
-                                })}
-                              className="w-48"
-                              disabled={isBatchConfirming}
-                            >
-                              <option value="">イベント設定口座を使用</option>
-                              {accounts
-                                .filter((account) => account.currencyCode === event.currencyCode)
-                                .map((account) => (
-                                  <option key={account.id} value={account.id}>
-                                    {account.name}
-                                  </option>
-                                ))}
-                            </Select>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </Table>
-            </TableWrapper>
-            <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
-              <div className="text-sm text-ink-2">
-                選択中 {selectedOverdueCount} / {visibleOverdueForecast.length} 件
-              </div>
-              <div className="flex flex-wrap justify-end gap-3">
-                <Button
-                  variant="ghost"
-                  onClick={() => setDismissedOverdueSignature(visibleOverdueSignature)}
-                  disabled={isBatchConfirming}
-                >
-                  あとで
-                </Button>
-                <Button onClick={handleBatchConfirm} disabled={isBatchConfirming || selectedOverdueCount === 0}>
-                  選択した {selectedOverdueCount} 件を確定
-                </Button>
-              </div>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
         open={Boolean(selectedEvent)}
         onOpenChange={(open) => {
           if (!open) {
@@ -989,7 +1092,7 @@ export function DashboardPage() {
           }
         }}
       >
-        <DialogContent>
+        <DialogContent className="inset-x-0 bottom-0 left-0 top-auto w-full max-w-none translate-x-0 translate-y-0 rounded-b-none rounded-t-[var(--radius-l)] pb-[max(1rem,env(safe-area-inset-bottom))] sm:inset-auto sm:bottom-auto sm:left-1/2 sm:top-1/2 sm:w-[min(94vw,32rem)] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-[var(--radius-l)]">
           <DialogTitle className="text-lg font-semibold">予測イベントを確定</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-ink-2">
             予定額と実績額が一致するとは限らないため、自動確定せず手動で確認します。必要なら金額を変更できます。
@@ -1045,11 +1148,15 @@ export function DashboardPage() {
                 </Select>
               )}
             </label>
-            <div className="flex justify-end gap-3">
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
               <DialogClose asChild>
-                <Button variant="ghost">閉じる</Button>
+                <Button variant="ghost" className="w-full sm:w-auto">
+                  閉じる
+                </Button>
               </DialogClose>
-              <Button onClick={handleConfirm}>確定する</Button>
+              <Button onClick={handleConfirm} className="w-full sm:w-auto">
+                確定する
+              </Button>
             </div>
           </div>
         </DialogContent>
@@ -1058,43 +1165,16 @@ export function DashboardPage() {
   );
 }
 
-function SummaryCard({
-  title,
-  value,
-  detail,
-  onClick,
-}: {
-  title: string;
-  value: string;
-  detail?: string;
-  onClick?: () => void;
-}) {
-  const content = (
-    <>
-      <div className="break-words text-sm font-medium text-ink-3">{title}</div>
-      <div className="font-data mt-3 min-w-0 overflow-x-auto whitespace-nowrap text-3xl font-semibold">{value}</div>
-      {detail ? <div className="mt-2 break-words text-sm text-ink-2">{detail}</div> : null}
-    </>
-  );
-
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        className={cn(
-          "min-w-0 rounded-[var(--radius-m)] border border-line bg-surface-1 p-4 text-left transition hover:border-brand/50 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg sm:p-5",
-        )}
-        onClick={onClick}
-      >
-        {content}
-      </button>
-    );
-  }
-
+function ChartSkeleton() {
   return (
-    <Card>
-      {content}
-    </Card>
+    <div className="grid h-full min-h-0 grid-rows-[1fr_auto] gap-2">
+      <div className="animate-pulse rounded-[var(--radius-m)] bg-surface-2" />
+      <div className="flex gap-4">
+        <div className="h-3 w-12 animate-pulse rounded-full bg-surface-2" />
+        <div className="h-3 w-12 animate-pulse rounded-full bg-surface-2" />
+        <div className="h-3 w-12 animate-pulse rounded-full bg-surface-2" />
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 概要

`20260702-frontend.md` レビュー C-8 ロードマップの **ステージ2（ダッシュボード再構成）**。#290 の続き。

- **水位ヘッダー（C-3 / P1 対応）**: SummaryCard 4 枚を 1 枚のヘッダーに置換。3 値判定（安全/警告/危険）を言い切り文で最上部に表示、危険時は「あと N 日」を 40px Mono ヒーローで表示。総資産・期間内最小・次の収入/支出は従属位置に格下げ。絵文字警告カード（🔴⚠️⏳）廃止 → StatusChip の色＋形＋ラベル
- **口座別水位リスト（B-3）**: 口座ごとの現在残高・期間内最小・最小日をバー付きで一覧。行クリックでチャート切替。AccountSelector のボタン列を吸収
- **確定キュー（P5 対応）**: ロード直後に自動で開く超過確定ダイアログを廃止し、件数バッジ付きのインボックス型セクションへ
- **チャート再設計（C-6 / B-10 対応)**: 注記の HTML オーバーレイ化（SVG テキスト被りの根治）、Y 軸 nice ticks ＋万単位短縮表記（軸幅 110→56px）、X 軸の年繰り返し廃止、水平グリッド、過去の減光（55%）/ 未来は破線全彩度＋イベントドット、危険水域塗り、切替時のクロスフェード（「読み込み中…」全面差し替え廃止）、rAF 間引き ResizeObserver
- **確定動線の修復（P2/P6/B-2/B-6 対応）**: handleConfirm の無音失敗を修正、確定/一括確定をトーストに配線、確定の楽観的更新（失敗時ロールバック）、モバイルは行タップ→ボトムシート確定
- **E2E 追随**: dashboard / confirm-flow / transfer-flow / forecast-flow / navigation / responsive の各 spec を新 UI に更新（検証しているユーザー価値は維持）

## テスト

- `make lint` / `make typecheck` / `make build` / `make test-unit` / `make test-e2e`（59 passed）すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)