### PR TITLE
feat: フロントエンド再設計 Stage 3 — フォームと管理ページの型化

### DIFF
--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -95,8 +95,8 @@ test("deletes an account", async ({ page }) => {
 
   await navigateTo(page, "/accounts");
 
-  page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("row", { name: /Delete Target/ }).first().getByRole("button", { name: "削除" }).click();
+  await page.getByRole("button", { name: "削除する" }).click();
   await waitForReload(page);
 
   await expect(page.getByText("Delete Target")).toHaveCount(0);

--- a/e2e/credit-cards.spec.ts
+++ b/e2e/credit-cards.spec.ts
@@ -56,11 +56,13 @@ test("creates a credit card", async ({ page }) => {
   await navigateTo(page, "/credit-cards");
 
   await page.getByRole("button", { name: "カードを追加" }).click();
-  await page.getByLabel("カード名 *").first().fill("Visa");
-  await page.getByLabel("引落日 (1-31)").first().fill("27");
-  await page.getByLabel("引き落とし口座 *").first().selectOption(account.id);
-  await page.getByLabel("月間仮定額 *").first().fill("50000");
-  await page.getByLabel("表示順").first().fill("1");
+  const createDialog = page.getByRole("dialog");
+  await createDialog.getByLabel("カード名 *").fill("Visa");
+  await createDialog.getByLabel("毎月の発生日").fill("27");
+  await createDialog.getByLabel("引き落とし口座 *").selectOption(account.id);
+  await createDialog.getByLabel("月間仮定額 *").fill("50000");
+  await createDialog.getByRole("button", { name: "詳細設定" }).click();
+  await createDialog.getByLabel("表示順").fill("1");
   await page.getByRole("button", { name: "追加" }).click();
   await waitForReload(page);
 
@@ -85,8 +87,8 @@ test("edits and deletes a credit card", async ({ page }) => {
   await waitForReload(page);
   await expect(cardListRow(page, "Master Gold")).toBeVisible();
 
-  page.once("dialog", (dialog) => dialog.accept());
   await cardListRow(page, "Master Gold").getByRole("button", { name: "削除" }).click();
+  await page.getByRole("button", { name: "削除する" }).click();
   await waitForReload(page);
   await expect(page.getByText("Master Gold")).toHaveCount(0);
 });
@@ -209,11 +211,9 @@ test("validates monthly billing changes and confirms before switching months", a
 
   const monthInput = page.locator('input[type="month"]');
   const currentMonth = await monthInput.inputValue();
-  page.once("dialog", (dialog) => {
-    expect(dialog.message()).toContain("未保存の月次請求");
-    dialog.dismiss();
-  });
   await monthInput.fill(toYearMonth(getJstDate(1)));
+  await expect(page.getByRole("heading", { name: "未保存の月次請求があります" })).toBeVisible();
+  await page.getByRole("button", { name: "キャンセル" }).click();
   await expect(monthInput).toHaveValue(currentMonth);
 });
 

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -197,6 +197,7 @@ test("confirms a forecast event from the dialog", async ({ page }) => {
   await navigateTo(page, "/");
 
   const salaryCells = page.locator("table").last().getByRole("cell", { name: "Salary" });
+  await expect(salaryCells.first()).toBeVisible();
   const beforeCount = await salaryCells.count();
   await page.getByRole("button", { name: "確定" }).first().click();
   await expect(page.getByRole("heading", { name: "予測イベントを確定" })).toBeVisible();

--- a/e2e/helpers/actions.ts
+++ b/e2e/helpers/actions.ts
@@ -19,15 +19,17 @@ export async function fillAndSubmitAccountForm(
   const currencyCode = values.currencyCode ?? "JPY";
 
   await page.getByRole("button", { name: "口座を追加" }).click();
-  await page.getByLabel("口座名 *").fill(values.name);
-  await page.getByLabel("通貨").selectOption(currencyCode);
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("口座名 *").fill(values.name);
+  await dialog.getByLabel("通貨").selectOption(currencyCode);
   if (currencyCode !== "JPY") {
-    await page.getByLabel("JPY換算レート").fill(String(values.exchangeRateToJpy ?? 1));
+    await dialog.getByLabel("JPY換算レート").fill(String(values.exchangeRateToJpy ?? 1));
   }
-  await page.getByLabel(`現在残高 (${currencyCode})`).fill(String(values.balance));
-  await page.getByLabel(`オフセット (${currencyCode})`).fill(String(values.balanceOffset ?? 0));
-  await page.getByLabel("表示順").fill(String(values.sortOrder));
-  await page.getByRole("button", { name: "追加" }).first().click();
+  await dialog.getByLabel(`現在残高 (${currencyCode})`).fill(String(values.balance));
+  await dialog.getByLabel(`オフセット (${currencyCode})`).fill(String(values.balanceOffset ?? 0));
+  await dialog.getByRole("button", { name: "詳細設定" }).click();
+  await dialog.getByLabel("表示順").fill(String(values.sortOrder));
+  await dialog.getByRole("button", { name: "追加" }).click();
 }
 
 export async function expectTableRowCount(scope: Locator, count: number) {

--- a/e2e/loans.spec.ts
+++ b/e2e/loans.spec.ts
@@ -28,7 +28,7 @@ test("creates a loan in normal mode", async ({ page }) => {
   await page.getByRole("button", { name: "追加" }).click();
   await waitForReload(page);
 
-  await expect(page.getByText("Laptop")).toBeVisible();
+  await expect(page.getByText("Laptop", { exact: true })).toBeVisible();
 });
 
 test("creates a loan in midway mode", async ({ page }) => {
@@ -46,7 +46,7 @@ test("creates a loan in midway mode", async ({ page }) => {
   await page.getByRole("button", { name: "追加" }).click();
   await waitForReload(page);
 
-  await expect(page.getByText("Camera")).toBeVisible();
+  await expect(page.getByText("Camera", { exact: true })).toBeVisible();
   await expect(page.getByText("残り 6 回")).toBeVisible();
 });
 
@@ -80,7 +80,7 @@ test("edits and deletes a loan", async ({ page }) => {
   await page.getByLabel("商品名 *").last().fill("Phone Updated");
   await page.getByRole("button", { name: "保存" }).click();
   await waitForReload(page);
-  await expect(page.getByText("Phone Updated")).toBeVisible();
+  await expect(page.getByText("Phone Updated", { exact: true })).toBeVisible();
 
   await page.locator("div.grid.gap-4.rounded-2xl").filter({ hasText: "Phone Updated" }).first().getByRole("button", { name: "削除" }).click();
   await page.getByRole("button", { name: "削除する" }).click();

--- a/e2e/loans.spec.ts
+++ b/e2e/loans.spec.ts
@@ -82,8 +82,8 @@ test("edits and deletes a loan", async ({ page }) => {
   await waitForReload(page);
   await expect(page.getByText("Phone Updated")).toBeVisible();
 
-  page.once("dialog", (dialog) => dialog.accept());
   await page.locator("div.grid.gap-4.rounded-2xl").filter({ hasText: "Phone Updated" }).first().getByRole("button", { name: "削除" }).click();
+  await page.getByRole("button", { name: "削除する" }).click();
   await waitForReload(page);
   await expect(page.getByText("Phone Updated")).toHaveCount(0);
 });

--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("serves the app shell after an offline reload", async ({ page, context }) => {
   await page.goto("/");
-  await expect(page.getByText("可処分資産予測")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "残高推移" })).toBeVisible();
 
   const manifestResponse = await page.request.get("/manifest.webmanifest");
   expect(manifestResponse.ok()).toBe(true);
@@ -24,12 +24,12 @@ test("serves the app shell after an offline reload", async ({ page, context }) =
 
   await expect.poll(() => page.evaluate(() => Boolean(navigator.serviceWorker.controller))).toBe(true);
   await page.reload({ waitUntil: "networkidle" });
-  await expect(page.getByText("可処分資産予測")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "残高推移" })).toBeVisible();
 
   await context.setOffline(true);
   try {
     await page.reload({ waitUntil: "domcontentloaded" });
-    await expect(page.getByText("可処分資産予測")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "残高推移" })).toBeVisible();
     await expect(page.getByText("ネットワークに接続できません。通信状態を確認してください。").first()).toBeVisible();
   } finally {
     await context.setOffline(false);

--- a/e2e/recurring.spec.ts
+++ b/e2e/recurring.spec.ts
@@ -21,7 +21,7 @@ test("creates an income recurring item", async ({ page }) => {
 
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("Salary");
-  await page.getByLabel("種別").first().selectOption("income");
+  await page.getByRole("radio", { name: "収入" }).first().click();
   await page.getByLabel("金額 (円)").first().fill("300000");
   await page.getByLabel("毎月の発生日").first().fill("25");
   await page.getByLabel("振り込み先口座 *").selectOption(account.id);
@@ -38,7 +38,7 @@ test("creates an expense recurring item with a period", async ({ page }) => {
 
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("Rent");
-  await page.getByLabel("種別").first().selectOption("expense");
+  await page.getByRole("radio", { name: "支出" }).first().click();
   await page.getByLabel("金額 (円)").first().fill("80000");
   await page.getByLabel("毎月の発生日").first().fill("27");
   await page.getByLabel("開始日").first().fill("2026-03-01");
@@ -80,7 +80,7 @@ test("keeps recurring item date shift policy through create and edit", async ({ 
 
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("Shifted Rent");
-  await page.getByLabel("種別").first().selectOption("expense");
+  await page.getByRole("radio", { name: "支出" }).first().click();
   await page.getByLabel("金額 (円)").first().fill("80000");
   await page.getByLabel("毎月の発生日").first().fill("31");
   await page.getByLabel("土日祝の扱い").first().selectOption("next");
@@ -114,8 +114,8 @@ test("deletes a recurring item", async ({ page }) => {
 
   await navigateTo(page, "/recurring");
 
-  page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("row", { name: /To Delete/ }).getByRole("button", { name: "削除" }).click();
+  await page.getByRole("button", { name: "削除する" }).click();
   await waitForReload(page);
 
   await expect(page.getByText("To Delete")).toHaveCount(0);

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -41,18 +41,21 @@ async function expectNoDocumentHorizontalScroll(page: Page) {
   expect(Math.max(metrics.bodyOverflow, metrics.documentOverflow), JSON.stringify(metrics)).toBeLessThanOrEqual(1);
 }
 
-async function expectFirstTableScrollsLocally(page: Page) {
-  const tableWrapper = page.locator("table").first().locator("..");
-  await expect(tableWrapper).toBeVisible();
+async function expectNoTableOverflow(page: Page) {
+  // ResponsiveTable はデスクトップ幅 (md 以上) でのみテーブルを表示し、
+  // それ未満ではリスト行レイアウトに切り替える。表示中のテーブルは横スクロールに依存しない。
+  const table = page.locator("table").first();
+  if ((await table.count()) === 0 || !(await table.isVisible())) {
+    return;
+  }
 
+  const tableWrapper = table.locator("..");
   const metrics = await tableWrapper.evaluate((element) => ({
     clientWidth: element.clientWidth,
-    overflowX: window.getComputedStyle(element).overflowX,
     scrollWidth: element.scrollWidth,
   }));
 
-  expect(metrics.overflowX).toBe("auto");
-  expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
 }
 
 async function captureResponsiveScreenshot(page: Page, testInfo: TestInfo, name: string) {
@@ -85,7 +88,7 @@ test("keeps primary screens inside the viewport at responsive sizes", async ({ p
     await expectNoDocumentHorizontalScroll(page);
 
     if (viewport.width < 1024) {
-      await expect(page.getByRole("button", { name: "メニュー" })).toBeVisible();
+      await expect(page.getByRole("navigation", { name: "モバイルナビゲーション" })).toBeVisible();
       const headerHeight = await page.locator("header").evaluate((element) => element.getBoundingClientRect().height);
       expect(headerHeight).toBeLessThan(96);
     }
@@ -95,24 +98,23 @@ test("keeps primary screens inside the viewport at responsive sizes", async ({ p
     await navigateTo(page, "/transactions");
     await expect(page.getByRole("heading", { name: "取引履歴" })).toBeVisible();
     await expectNoDocumentHorizontalScroll(page);
-
-    if (viewport.width < 1024) {
-      await expectFirstTableScrollsLocally(page);
-    }
+    await expectNoTableOverflow(page);
 
     await captureResponsiveScreenshot(page, testInfo, `${viewport.name}-transactions`);
   }
 });
 
-test("uses a compact mobile menu for navigation", async ({ page }) => {
+test("uses a bottom tab bar for mobile navigation", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await navigateTo(page, "/");
 
-  await page.getByRole("button", { name: "メニュー" }).click();
-  await expect(page.locator("#mobile-nav")).toBeVisible();
+  const mobileNav = page.getByRole("navigation", { name: "モバイルナビゲーション" });
+  await expect(mobileNav).toBeVisible();
+  await expect(mobileNav.getByRole("link", { name: "ダッシュボード" })).toBeVisible();
+  await expect(mobileNav.getByRole("link", { name: "取引" })).toBeVisible();
 
+  await mobileNav.getByRole("button", { name: "資産" }).click();
   await page.getByRole("link", { name: "クレカ管理" }).click();
   await expect(page.getByRole("heading", { name: "クレジットカード管理" })).toBeVisible();
-  await expect(page.locator("#mobile-nav")).toHaveCount(0);
   await expectNoDocumentHorizontalScroll(page);
 });

--- a/e2e/scenarios/forecast-flow.spec.ts
+++ b/e2e/scenarios/forecast-flow.spec.ts
@@ -24,7 +24,7 @@ test("reflects newly created accounts and recurring items on the dashboard forec
 
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("給料");
-  await page.getByLabel("種別").first().selectOption("income");
+  await page.getByRole("radio", { name: "収入" }).first().click();
   await page.getByLabel("金額 (円)").first().fill("250000");
   await page.getByLabel("毎月の発生日").first().fill(String(forecastDayOfMonth));
   await page.getByLabel("振り込み先口座 *").selectOption({ label: "メイン口座" });
@@ -35,7 +35,7 @@ test("reflects newly created accounts and recurring items on the dashboard forec
 
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("家賃");
-  await page.getByLabel("種別").first().selectOption("expense");
+  await page.getByRole("radio", { name: "支出" }).first().click();
   await page.getByLabel("金額 (円)").first().fill("80000");
   await page.getByLabel("毎月の発生日").first().fill(String(forecastDayOfMonth));
   await page.getByLabel("引き落とし口座 *").selectOption({ label: "メイン口座" });
@@ -77,7 +77,7 @@ test("reflects recurring transfers in account forecasts and confirms them as tra
   await navigateTo(page, "/recurring");
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("資金移動");
-  await page.getByLabel("種別").first().selectOption("transfer");
+  await page.getByRole("radio", { name: "振替" }).first().click();
   await page.getByLabel("金額 (円)").first().fill("100000");
   await page.getByLabel("毎月の発生日").first().fill(String(dayOfMonth));
   await page.getByLabel("開始日").first().fill(eventDate);

--- a/e2e/scenarios/loan-flow.spec.ts
+++ b/e2e/scenarios/loan-flow.spec.ts
@@ -23,7 +23,7 @@ test("creates a loan, reflects it on the dashboard, and updates the snapshot aft
 
   await page.getByRole("button", { name: "追加" }).click();
   await waitForReload(page);
-  await expect(page.getByText("PCローン")).toBeVisible();
+  await expect(page.getByText("PCローン", { exact: true })).toBeVisible();
 
   await navigateTo(page, "/");
 

--- a/e2e/scenarios/transfer-flow.spec.ts
+++ b/e2e/scenarios/transfer-flow.spec.ts
@@ -27,12 +27,12 @@ test("keeps the total balance unchanged while reflecting transfers across accoun
   await navigateTo(page, "/transactions");
 
   await page.getByRole("button", { name: "取引を追加" }).click();
-  await page.getByLabel("取引口座").selectOption({ label: "メイン口座" });
-  await page.getByLabel("取引種別").selectOption("transfer");
+  await page.getByLabel("内容").fill("口座移動");
+  await page.getByLabel("対象口座").selectOption({ label: "メイン口座" });
+  await page.getByRole("radio", { name: "振替" }).click();
+  await page.getByLabel("金額").fill("100000");
   await page.getByLabel("取引日").fill(getFutureDate(0));
   await page.getByLabel("振替先口座").selectOption({ label: "貯蓄口座" });
-  await page.getByPlaceholder("内容").fill("口座移動");
-  await page.getByPlaceholder("金額").fill("100000");
   await page.getByRole("button", { name: "取引を記録" }).click();
   await waitForReload(page);
 

--- a/e2e/subscriptions.spec.ts
+++ b/e2e/subscriptions.spec.ts
@@ -22,7 +22,7 @@ test("creates a subscription", async ({ page }) => {
   await page.getByLabel("金額 (円) *").fill("1490");
   await page.getByLabel("頻度").selectOption("1");
   await page.getByLabel("課金開始日 *").fill("2026-03-05");
-  await page.getByLabel("課金日 (1-31)").fill("5");
+  await page.getByLabel("毎月の発生日").fill("5");
   await page.getByLabel("支払い元").fill("Visa");
   await page.getByRole("button", { name: "追加" }).click();
   await waitForReload(page);
@@ -57,8 +57,8 @@ test("edits and deletes a subscription", async ({ page }) => {
   await expect(listCard.getByRole("row", { name: /Spotify/ })).toContainText(formatCurrency(1280));
   await expect(listCard.getByRole("row", { name: /Spotify/ })).toContainText("Master Gold");
 
-  page.once("dialog", (dialog) => dialog.accept());
   await listCard.getByRole("row", { name: /Spotify/ }).getByRole("button", { name: "削除" }).click();
+  await page.getByRole("button", { name: "削除する" }).click();
   await waitForReload(page);
 
   await expect(page.getByText("Spotify")).toHaveCount(0);

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -14,11 +14,11 @@ test("records a manual expense transaction", async ({ page }) => {
   await navigateTo(page, "/transactions");
 
   await page.getByRole("button", { name: "取引を追加" }).click();
-  await page.getByLabel("取引口座").selectOption(account.id);
-  await page.getByLabel("取引種別").selectOption("expense");
+  await page.getByLabel("内容").fill("Lunch");
+  await page.getByRole("radio", { name: "支出" }).click();
+  await page.getByLabel("金額").fill("1200");
   await page.getByLabel("取引日").fill(today);
-  await page.getByPlaceholder("内容").fill("Lunch");
-  await page.getByPlaceholder("金額").fill("1200");
+  await page.getByLabel("対象口座").selectOption(account.id);
   await page.getByRole("button", { name: "取引を記録" }).click();
   await waitForReload(page);
 
@@ -45,8 +45,8 @@ test("edits an existing transaction from the history table", async ({ page }) =>
   await row.getByRole("button", { name: "編集" }).click();
 
   const dialog = page.getByRole("dialog");
-  await dialog.getByPlaceholder("内容").fill("Dinner");
-  await dialog.getByPlaceholder("金額").fill("1800");
+  await dialog.getByLabel("内容").fill("Dinner");
+  await dialog.getByLabel("金額").fill("1800");
   await dialog.getByRole("button", { name: "保存" }).click();
   await waitForReload(page);
 
@@ -73,7 +73,7 @@ test("deletes a manual transaction and restores the account balance", async ({ p
 
   const dialog = page.getByRole("dialog");
   await expect(dialog).toContainText("残高が元に戻ります");
-  await dialog.getByRole("button", { name: "削除" }).click();
+  await dialog.getByRole("button", { name: "削除する" }).click();
   await waitForReload(page);
 
   await expect(page.getByText("Lunch")).toHaveCount(0);
@@ -108,12 +108,12 @@ test("records a transfer transaction and shows both account names", async ({ pag
   await navigateTo(page, "/transactions");
 
   await page.getByRole("button", { name: "取引を追加" }).click();
-  await page.getByLabel("取引口座").selectOption(source.id);
-  await page.getByLabel("取引種別").selectOption("transfer");
+  await page.getByLabel("内容").fill("Move");
+  await page.getByLabel("対象口座").selectOption(source.id);
+  await page.getByRole("radio", { name: "振替" }).click();
+  await page.getByLabel("金額").fill("3000");
   await page.getByLabel("取引日").fill(today);
   await page.getByLabel("振替先口座").selectOption(destination.id);
-  await page.getByPlaceholder("内容").fill("Move");
-  await page.getByPlaceholder("金額").fill("3000");
   await page.getByRole("button", { name: "取引を記録" }).click();
   await waitForReload(page);
 
@@ -128,20 +128,20 @@ test("records transfers with an empty source or destination account", async ({ p
   await navigateTo(page, "/transactions");
 
   await page.getByRole("button", { name: "取引を追加" }).click();
-  await page.getByLabel("取引種別").selectOption("transfer");
+  await page.getByLabel("内容").fill("Inbound");
+  await page.getByRole("radio", { name: "振替" }).click();
+  await page.getByLabel("金額").fill("1000");
   await page.getByLabel("取引日").fill(today);
   await page.getByLabel("振替先口座").selectOption(destination.id);
-  await page.getByPlaceholder("内容").fill("Inbound");
-  await page.getByPlaceholder("金額").fill("1000");
   await page.getByRole("button", { name: "取引を記録" }).click();
   await waitForReload(page);
 
   await page.getByRole("button", { name: "取引を追加" }).click();
-  await page.getByLabel("取引口座").selectOption(source.id);
-  await page.getByLabel("取引種別").selectOption("transfer");
+  await page.getByLabel("内容").fill("Outbound");
+  await page.getByLabel("対象口座").selectOption(source.id);
+  await page.getByRole("radio", { name: "振替" }).click();
+  await page.getByLabel("金額").fill("1500");
   await page.getByLabel("取引日").fill(today);
-  await page.getByPlaceholder("内容").fill("Outbound");
-  await page.getByPlaceholder("金額").fill("1500");
   await page.getByRole("button", { name: "取引を記録" }).click();
   await waitForReload(page);
 

--- a/packages/frontend/src/components/form-fields.tsx
+++ b/packages/frontend/src/components/form-fields.tsx
@@ -1,0 +1,154 @@
+import type { Account, DateShiftPolicy, SupportedCurrencyCode } from "@sui/shared";
+import { FormField } from "./ui/form-field";
+import { Input } from "./ui/input";
+import { Select } from "./ui/select";
+
+/**
+ * 毎月の日付入力。同一概念に 3 つのラベル（「毎月の発生日」「引落日 (1-31)」「課金日 (1-31)」）が
+ * あった揺れを解消し、「毎月の発生日」に統一する。制約は placeholder ではなくヘルプテキストで示す。
+ */
+export function DayOfMonthField({
+  id,
+  value,
+  onChange,
+  required = true,
+  error,
+}: {
+  id: string;
+  value: number | null;
+  onChange: (value: number | null) => void;
+  required?: boolean;
+  error?: string | null;
+}) {
+  return (
+    <FormField label="毎月の発生日" htmlFor={id} required={required} help="1〜31 の範囲で指定します。" error={error}>
+      <Input
+        id={id}
+        type="number"
+        inputMode="numeric"
+        min={1}
+        max={31}
+        value={value ?? ""}
+        onChange={(event) => onChange(event.target.value === "" ? null : Number(event.target.value))}
+      />
+    </FormField>
+  );
+}
+
+/**
+ * 開始日・終了日の対フィールド。「空欄で無期限」ヘルプを一体化する。
+ */
+export function PeriodFields({
+  idPrefix,
+  startDate,
+  endDate,
+  onChangeStartDate,
+  onChangeEndDate,
+  startRequired = false,
+  error,
+}: {
+  idPrefix: string;
+  startDate: string;
+  endDate: string;
+  onChangeStartDate: (value: string) => void;
+  onChangeEndDate: (value: string) => void;
+  startRequired?: boolean;
+  error?: string | null;
+}) {
+  return (
+    <div className="grid min-w-0 gap-2">
+      <div className="grid min-w-0 grid-cols-2 gap-3">
+        <FormField label="開始日" htmlFor={`${idPrefix}-start`} required={startRequired}>
+          <Input
+            id={`${idPrefix}-start`}
+            type="date"
+            value={startDate}
+            onChange={(event) => onChangeStartDate(event.target.value)}
+          />
+        </FormField>
+        <FormField label="終了日" htmlFor={`${idPrefix}-end`}>
+          <Input
+            id={`${idPrefix}-end`}
+            type="date"
+            value={endDate}
+            onChange={(event) => onChangeEndDate(event.target.value)}
+          />
+        </FormField>
+      </div>
+      <p className="text-xs text-ink-3">空欄で無期限になります。</p>
+      {error ? (
+        <p role="alert" className="text-xs font-medium text-critical">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * 口座選択。未選択プレースホルダと通貨フィルタを内蔵する。
+ */
+export function AccountSelect({
+  id,
+  label,
+  accounts,
+  value,
+  onChange,
+  currencyFilter,
+  excludeAccountId,
+  required = true,
+  disabled = false,
+  placeholder = "口座を選択",
+}: {
+  id: string;
+  label: string;
+  accounts: Account[];
+  value: string;
+  onChange: (accountId: string) => void;
+  currencyFilter?: SupportedCurrencyCode;
+  excludeAccountId?: string;
+  required?: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const options = accounts.filter(
+    (account) =>
+      (!currencyFilter || account.currencyCode === currencyFilter) && account.id !== excludeAccountId,
+  );
+
+  return (
+    <FormField label={label} htmlFor={id} required={required}>
+      <Select id={id} value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)}>
+        <option value="">{placeholder}</option>
+        {options.map((account) => (
+          <option key={account.id} value={account.id}>
+            {account.name}
+          </option>
+        ))}
+      </Select>
+    </FormField>
+  );
+}
+
+/**
+ * 土日祝の扱い。固定収支/ローン/クレカの 3 複製を解消する共有部品。
+ */
+export function DateShiftField({
+  id,
+  value,
+  onChange,
+}: {
+  id: string;
+  value: DateShiftPolicy;
+  onChange: (value: DateShiftPolicy) => void;
+}) {
+  return (
+    <FormField label="土日祝の扱い" htmlFor={id}>
+      <Select id={id} value={value} onChange={(event) => onChange(event.target.value as DateShiftPolicy)}>
+        <option value="none">シフトなし</option>
+        <option value="previous">前営業日</option>
+        <option value="next">後営業日</option>
+      </Select>
+    </FormField>
+  );
+}

--- a/packages/frontend/src/components/layout.tsx
+++ b/packages/frontend/src/components/layout.tsx
@@ -2,90 +2,181 @@ import type { PropsWithChildren } from "react";
 import { useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { cn } from "../lib/utils";
+import {
+  BarChart3,
+  Landmark,
+  LayoutGrid,
+  ListChecks,
+  Repeat,
+  Settings,
+  Wallet,
+} from "lucide-react";
 
-const navItems = [
-  // 総合
-  { to: "/", label: "ダッシュボード" },
-  { to: "/transactions", label: "取引履歴" },
-  // 資産
-  { to: "/accounts", label: "口座管理" },
-  // 負債
-  { to: "/credit-cards", label: "クレカ管理" },
-  { to: "/loans", label: "ローン管理" },
-  // 定期
-  { to: "/recurring", label: "固定収支" },
-  { to: "/subscriptions", label: "サブスク" },
-  { to: "/data", label: "データ管理" },
+type NavItem = { to: string; label: string; icon: typeof Wallet };
+type NavGroup = { heading: string; items: NavItem[]; muted?: boolean };
+
+const navGroups: NavGroup[] = [
+  { heading: "毎日見る", items: [{ to: "/", label: "ダッシュボード", icon: LayoutGrid }] },
+  { heading: "記録", items: [{ to: "/transactions", label: "取引履歴", icon: ListChecks }] },
+  {
+    heading: "資産と負債",
+    items: [
+      { to: "/accounts", label: "口座管理", icon: Wallet },
+      { to: "/credit-cards", label: "クレカ管理", icon: Landmark },
+      { to: "/loans", label: "ローン管理", icon: Landmark },
+    ],
+  },
+  {
+    heading: "定期",
+    items: [
+      { to: "/recurring", label: "固定収支", icon: Repeat },
+      { to: "/subscriptions", label: "サブスク", icon: Repeat },
+    ],
+  },
+  { heading: "システム", items: [{ to: "/data", label: "データ管理", icon: Settings }], muted: true },
+];
+
+const allNavItems = navGroups.flatMap((group) => group.items);
+
+// モバイル下部タブバー。ハンバーガー＋2 列グリッドの代わりに、週次ループに沿う 4 項目のみを常設する。
+const mobileTabs: Array<{ key: string; label: string; icon: typeof Wallet; to?: string; groupItems?: NavItem[] }> = [
+  { key: "dashboard", label: "ダッシュボード", icon: LayoutGrid, to: "/" },
+  { key: "transactions", label: "取引", icon: ListChecks, to: "/transactions" },
+  {
+    key: "assets",
+    label: "資産",
+    icon: Wallet,
+    groupItems: navGroups.find((group) => group.heading === "資産と負債")?.items,
+  },
+  {
+    key: "more",
+    label: "その他",
+    icon: BarChart3,
+    groupItems: [
+      ...(navGroups.find((group) => group.heading === "定期")?.items ?? []),
+      ...(navGroups.find((group) => group.heading === "システム")?.items ?? []),
+    ],
+  },
 ];
 
 export function AppLayout({ children }: PropsWithChildren) {
-  const [navOpen, setNavOpen] = useState(false);
+  const [openTabKey, setOpenTabKey] = useState<string | null>(null);
   const { pathname } = useLocation();
   const currentItem =
-    navItems.find((item) => (item.to === "/" ? pathname === "/" : pathname.startsWith(item.to))) ?? navItems[0];
+    allNavItems.find((item) => (item.to === "/" ? pathname === "/" : pathname.startsWith(item.to))) ?? allNavItems[0];
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-4 px-3 py-3 sm:px-4 sm:py-4 lg:flex-row lg:gap-6 lg:px-6 lg:py-6">
+    <div className="mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-4 px-3 py-3 pb-20 sm:px-4 sm:py-4 lg:flex-row lg:gap-6 lg:px-6 lg:py-6 lg:pb-6">
       <header className="rounded-[var(--radius-m)] border border-line bg-surface-1 p-3 lg:hidden">
-        <div className="flex items-center justify-between gap-3">
-          <div className="min-w-0">
-            <div className="text-xs tracking-[0.24em] text-brand">sui</div>
-            <div className="mt-1 truncate text-base font-semibold">{currentItem.label}</div>
-          </div>
-          <button
-            type="button"
-            aria-controls="mobile-nav"
-            aria-expanded={navOpen}
-            className="shrink-0 rounded-[var(--radius-s)] border border-line bg-surface-2 px-3 py-2 text-sm font-semibold text-ink transition hover:bg-surface-2/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-            onClick={() => setNavOpen((value) => !value)}
-          >
-            メニュー
-          </button>
-        </div>
-        {navOpen ? (
-          <nav id="mobile-nav" className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
-            {navItems.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                onClick={() => setNavOpen(false)}
-                className={({ isActive }) =>
-                  cn(
-                    "min-w-0 rounded-[var(--radius-s)] px-3 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-                    isActive ? "bg-brand text-[#0B0E13]" : "bg-surface-2 text-ink-2 hover:bg-surface-2/70 hover:text-ink",
-                  )
-                }
-              >
-                <span className="block truncate">{item.label}</span>
-              </NavLink>
-            ))}
-          </nav>
-        ) : null}
+        <div className="text-xs tracking-[0.24em] text-brand">sui</div>
+        <div className="mt-1 truncate text-base font-semibold">{currentItem.label}</div>
       </header>
-      <aside className="hidden w-72 shrink-0 rounded-[var(--radius-l)] border border-line bg-surface-1 p-5 lg:block">
-        <div className="mb-8">
-          <div className="text-xs tracking-[0.3em] text-brand">sui</div>
-          <h1 className="mt-3 text-3xl font-semibold">可処分資産予測</h1>
-          <p className="mt-2 text-sm text-ink-2">固定収支とクレカ請求を基準に残高推移を管理します。</p>
-        </div>
-        <nav className="grid gap-2">
-          {navItems.map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              className={({ isActive }) =>
-                cn(
-                  "block min-w-0 rounded-[var(--radius-m)] px-4 py-3 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-                  isActive ? "bg-brand text-[#0B0E13]" : "bg-surface-2 text-ink-2 hover:bg-surface-2/70 hover:text-ink",
-                )
-              }
-            >
-              <span className="block truncate">{item.label}</span>
-            </NavLink>
+
+      <aside className="hidden w-60 shrink-0 rounded-[var(--radius-l)] border border-line bg-surface-1 p-5 lg:block">
+        <div className="mb-6 text-xs tracking-[0.3em] text-brand">sui</div>
+        <nav className="grid gap-5">
+          {navGroups.map((group) => (
+            <div key={group.heading} className="grid gap-1.5">
+              <div className={cn("px-1 text-xs font-medium tracking-wide", group.muted ? "text-ink-3/70" : "text-ink-3")}>
+                {group.heading}
+              </div>
+              <div className="grid gap-1">
+                {group.items.map((item) => (
+                  <NavLink
+                    key={item.to}
+                    to={item.to}
+                    className={({ isActive }) =>
+                      cn(
+                        "flex min-w-0 items-center gap-2.5 rounded-[var(--radius-s)] px-3 py-2.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+                        isActive
+                          ? "bg-brand text-[#0B0E13]"
+                          : group.muted
+                            ? "text-ink-3 hover:bg-surface-2/70 hover:text-ink-2"
+                            : "text-ink-2 hover:bg-surface-2/70 hover:text-ink",
+                      )
+                    }
+                  >
+                    <item.icon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                    <span className="truncate">{item.label}</span>
+                  </NavLink>
+                ))}
+              </div>
+            </div>
           ))}
         </nav>
       </aside>
+
       <main className="min-w-0 flex-1">{children}</main>
+
+      <nav
+        aria-label="モバイルナビゲーション"
+        className="fixed inset-x-0 bottom-0 z-40 border-t border-line bg-surface-1 pb-[env(safe-area-inset-bottom)] lg:hidden"
+      >
+        <div className="grid grid-cols-4">
+          {mobileTabs.map((tab) => {
+            const isActive = tab.to
+              ? tab.to === "/"
+                ? pathname === "/"
+                : pathname.startsWith(tab.to)
+              : (tab.groupItems ?? []).some((item) => pathname.startsWith(item.to));
+
+            if (tab.to) {
+              return (
+                <NavLink
+                  key={tab.key}
+                  to={tab.to}
+                  onClick={() => setOpenTabKey(null)}
+                  className={cn(
+                    "flex min-h-14 flex-col items-center justify-center gap-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-inset",
+                    isActive ? "text-brand" : "text-ink-2",
+                  )}
+                >
+                  <tab.icon aria-hidden="true" className="h-5 w-5" />
+                  {tab.label}
+                </NavLink>
+              );
+            }
+
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                aria-expanded={openTabKey === tab.key}
+                onClick={() => setOpenTabKey((current) => (current === tab.key ? null : tab.key))}
+                className={cn(
+                  "flex min-h-14 flex-col items-center justify-center gap-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-inset",
+                  isActive || openTabKey === tab.key ? "text-brand" : "text-ink-2",
+                )}
+              >
+                <tab.icon aria-hidden="true" className="h-5 w-5" />
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+        {openTabKey ? (
+          <div className="absolute inset-x-3 bottom-[calc(100%+0.5rem)] grid gap-1 rounded-[var(--radius-m)] border border-line bg-surface-1 p-2 shadow-[var(--elev-1)]">
+            {mobileTabs
+              .find((tab) => tab.key === openTabKey)
+              ?.groupItems?.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  onClick={() => setOpenTabKey(null)}
+                  className={({ isActive }) =>
+                    cn(
+                      "flex items-center gap-2.5 rounded-[var(--radius-s)] px-3 py-2.5 text-sm font-medium transition",
+                      isActive ? "bg-brand text-[#0B0E13]" : "text-ink-2 hover:bg-surface-2",
+                    )
+                  }
+                >
+                  <item.icon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                  {item.label}
+                </NavLink>
+              ))}
+          </div>
+        ) : null}
+      </nav>
     </div>
   );
 }

--- a/packages/frontend/src/components/layout.tsx
+++ b/packages/frontend/src/components/layout.tsx
@@ -1,6 +1,8 @@
+import type { DashboardResponse } from "@sui/shared";
 import type { PropsWithChildren } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
+import { apiFetch } from "../lib/api";
 import { cn } from "../lib/utils";
 import {
   BarChart3,
@@ -59,9 +61,35 @@ const mobileTabs: Array<{ key: string; label: string; icon: typeof Wallet; to?: 
   },
 ];
 
+/** サイドバーのダッシュボード項目に出す未確定（予定日超過）件数。取得失敗時は静かに省略する。 */
+function useOverdueCount(pathname: string) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    apiFetch<DashboardResponse>("/api/dashboard?applyOffset=true")
+      .then((response) => {
+        if (active) {
+          setCount(response.overdueForecast.length);
+        }
+      })
+      .catch(() => {
+        // バッジは補助情報なので、失敗しても画面を邪魔しない。
+      });
+
+    return () => {
+      active = false;
+    };
+    // ページ遷移のたびに件数を追随させる（確定操作後の反映のため）。
+  }, [pathname]);
+
+  return count;
+}
+
 export function AppLayout({ children }: PropsWithChildren) {
   const [openTabKey, setOpenTabKey] = useState<string | null>(null);
   const { pathname } = useLocation();
+  const overdueCount = useOverdueCount(pathname);
   const currentItem =
     allNavItems.find((item) => (item.to === "/" ? pathname === "/" : pathname.startsWith(item.to))) ?? allNavItems[0];
 
@@ -98,6 +126,14 @@ export function AppLayout({ children }: PropsWithChildren) {
                   >
                     <item.icon aria-hidden="true" className="h-4 w-4 shrink-0" />
                     <span className="truncate">{item.label}</span>
+                    {item.to === "/" && overdueCount > 0 ? (
+                      <span
+                        aria-label={`未確定 ${overdueCount} 件`}
+                        className="font-data ml-auto inline-flex min-w-5 shrink-0 items-center justify-center rounded-full bg-warning/20 px-1.5 py-0.5 text-xs font-semibold text-warning"
+                      >
+                        {overdueCount}
+                      </span>
+                    ) : null}
                   </NavLink>
                 ))}
               </div>
@@ -131,7 +167,17 @@ export function AppLayout({ children }: PropsWithChildren) {
                     isActive ? "text-brand" : "text-ink-2",
                   )}
                 >
-                  <tab.icon aria-hidden="true" className="h-5 w-5" />
+                  <span className="relative">
+                    <tab.icon aria-hidden="true" className="h-5 w-5" />
+                    {tab.to === "/" && overdueCount > 0 ? (
+                      <span
+                        aria-label={`未確定 ${overdueCount} 件`}
+                        className="font-data absolute -right-2.5 -top-1.5 inline-flex min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-semibold leading-4 text-[#0B0E13]"
+                      >
+                        {overdueCount}
+                      </span>
+                    ) : null}
+                  </span>
                   {tab.label}
                 </NavLink>
               );

--- a/packages/frontend/src/components/offset-toggle.tsx
+++ b/packages/frontend/src/components/offset-toggle.tsx
@@ -1,3 +1,5 @@
+import { Switch } from "./ui/switch";
+
 export function OffsetToggle({
   checked,
   onChange,
@@ -6,14 +8,9 @@ export function OffsetToggle({
   onChange: (value: boolean) => void;
 }) {
   return (
-    <label className="flex max-w-full min-w-0 cursor-pointer items-center gap-3 rounded-[var(--radius-s)] border border-line bg-surface-2 px-4 py-2 text-sm">
-      <input
-        type="checkbox"
-        className="h-4 w-4 shrink-0 accent-[var(--color-brand)]"
-        checked={checked}
-        onChange={(event) => onChange(event.target.checked)}
-      />
+    <div className="flex max-w-full min-w-0 items-center gap-3 rounded-[var(--radius-s)] border border-line bg-surface-2 px-4 py-2 text-sm">
       <span className="min-w-0 truncate">残高オフセットを適用</span>
-    </label>
+      <Switch checked={checked} onChange={onChange} aria-label="残高オフセットを適用" />
+    </div>
   );
 }

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes } from "react";
+import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
 
 type Variant = "primary" | "secondary" | "ghost" | "danger";
@@ -6,13 +6,13 @@ type Variant = "primary" | "secondary" | "ghost" | "danger";
 const baseClass =
   "inline-flex max-w-full min-w-0 min-h-11 items-center justify-center gap-2 rounded-[var(--radius-m)] px-4 py-2 text-center text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
-export function Button({
-  className,
-  variant = "primary",
-  ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: Variant }) {
+export const Button = forwardRef<
+  HTMLButtonElement,
+  ButtonHTMLAttributes<HTMLButtonElement> & { variant?: Variant }
+>(function Button({ className, variant = "primary", ...props }, ref) {
   return (
     <button
+      ref={ref}
       className={cn(
         baseClass,
         variant === "primary" && "bg-brand text-[#0B0E13] hover:brightness-110",
@@ -25,16 +25,15 @@ export function Button({
       {...props}
     />
   );
-}
+});
 
-export function IconButton({
-  className,
-  variant = "ghost",
-  "aria-label": ariaLabel,
-  ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: Variant; "aria-label": string }) {
+export const IconButton = forwardRef<
+  HTMLButtonElement,
+  ButtonHTMLAttributes<HTMLButtonElement> & { variant?: Variant; "aria-label": string }
+>(function IconButton({ className, variant = "ghost", "aria-label": ariaLabel, ...props }, ref) {
   return (
     <button
+      ref={ref}
       aria-label={ariaLabel}
       className={cn(
         "inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-[var(--radius-s)] transition disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
@@ -48,4 +47,4 @@ export function IconButton({
       {...props}
     />
   );
-}
+});

--- a/packages/frontend/src/components/ui/conditional-field.tsx
+++ b/packages/frontend/src/components/ui/conditional-field.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+
+/**
+ * 条件フィールドは制御元の直下に全幅で出現する（C-5 規約 2）。
+ * 左端に 2px のインデント罫を付け、高さトランジション 150ms（motion-reduce で無効）で
+ * 出現・消滅する。他のフィールドの幅・水平位置は変えない。
+ */
+export function ConditionalField({ show, children }: { show: boolean; children: ReactNode }) {
+  return (
+    <div
+      aria-hidden={!show}
+      className={cn(
+        "grid transition-[grid-template-rows,opacity] duration-150 ease-out motion-reduce:transition-none",
+        show ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+      )}
+    >
+      <div className="overflow-hidden">
+        {show ? (
+          <div className="min-w-0 border-l-2 border-line-strong pl-3">{children}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/confirm-dialog.tsx
+++ b/packages/frontend/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,59 @@
+import { useRef } from "react";
+import { Button } from "./button";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "./dialog";
+
+/**
+ * 破壊的操作の確認を統一するダイアログ。window.confirm を全廃するための置き換え。
+ * 削除対象の名前と影響を description で示し、実行ボタンは danger、既定フォーカスはキャンセル側。
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "削除する",
+  cancelLabel = "キャンセル",
+  onConfirm,
+  danger = true,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  danger?: boolean;
+}) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        size="s"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          cancelRef.current?.focus();
+        }}
+      >
+        <DialogTitle className="text-lg font-semibold">{title}</DialogTitle>
+        {description ? (
+          <DialogDescription className="mt-2 text-sm text-ink-2">{description}</DialogDescription>
+        ) : null}
+        <div className="mt-6 flex justify-end gap-3">
+          <Button ref={cancelRef} variant="ghost" onClick={() => onOpenChange(false)}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={danger ? "danger" : "primary"}
+            onClick={() => {
+              onConfirm();
+            }}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -1,23 +1,40 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import type { PropsWithChildren } from "react";
+import type { ComponentProps, PropsWithChildren } from "react";
 import { cn } from "../../lib/utils";
 
 export const Dialog = DialogPrimitive.Root;
 export const DialogTrigger = DialogPrimitive.Trigger;
 export const DialogClose = DialogPrimitive.Close;
 
+/**
+ * ダイアログ幅トークンは 3 つのみ。
+ * S=28rem（確認）、M=36rem（フォーム）、L=min(96vw,72rem)（テーブル内包）。
+ */
+export type DialogSize = "s" | "m" | "l";
+
+const sizeClass: Record<DialogSize, string> = {
+  s: "w-[min(94vw,28rem)]",
+  m: "w-[min(94vw,36rem)]",
+  l: "w-[min(96vw,72rem)]",
+};
+
 export function DialogContent({
   children,
   className,
-}: PropsWithChildren<{ className?: string }>) {
+  size = "m",
+  ...props
+}: PropsWithChildren<{ className?: string; size?: DialogSize }> &
+  Omit<ComponentProps<typeof DialogPrimitive.Content>, "className">) {
   return (
     <DialogPrimitive.Portal>
-      <DialogPrimitive.Overlay className="fixed inset-0 bg-black/70 backdrop-blur-sm" />
+      <DialogPrimitive.Overlay className="fixed inset-0 bg-black/70" />
       <DialogPrimitive.Content
         className={cn(
-          "fixed left-1/2 top-1/2 max-h-[90dvh] w-[min(94vw,32rem)] min-w-0 -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-[var(--radius-l)] border border-line bg-surface-1 p-4 shadow-[var(--elev-1)] sm:p-6",
+          "fixed left-1/2 top-1/2 max-h-[90dvh] min-w-0 -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-[var(--radius-l)] border border-line bg-surface-1 p-4 shadow-[var(--elev-1)] sm:p-6",
+          sizeClass[size],
           className,
         )}
+        {...props}
       >
         {children}
       </DialogPrimitive.Content>

--- a/packages/frontend/src/components/ui/disclosure.tsx
+++ b/packages/frontend/src/components/ui/disclosure.tsx
@@ -1,0 +1,33 @@
+import { ChevronDown } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { cn } from "../../lib/utils";
+
+/**
+ * 「表示順」「有効」のような管理用フィールドを既定で閉じておくディスクロージャ（C-5 規約 4）。
+ */
+export function Disclosure({
+  summary,
+  children,
+  defaultOpen = false,
+}: {
+  summary: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="border-t border-line pt-4">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center justify-between gap-2 text-sm font-medium text-ink-2 transition hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+      >
+        {summary}
+        <ChevronDown aria-hidden="true" className={cn("h-4 w-4 shrink-0 transition-transform", open && "rotate-180")} />
+      </button>
+      {open ? <div className="mt-4 grid gap-4">{children}</div> : null}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/form-field.tsx
+++ b/packages/frontend/src/components/ui/form-field.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+
+/**
+ * 共有フィールド部品（C-5 規約 5）。ラベル、必須マーク、コントロール、ヘルプ、
+ * エラーの 5 スロットを持つ。placeholder をラベル代わりに使うことを禁止する。
+ */
+export function FormField({
+  label,
+  htmlFor,
+  required = false,
+  help,
+  error,
+  children,
+  className,
+}: {
+  label: string;
+  htmlFor?: string;
+  required?: boolean;
+  help?: ReactNode;
+  error?: string | null;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("grid min-w-0 gap-1.5 text-sm", className)}>
+      <label htmlFor={htmlFor} className="text-ink-2">
+        {label}
+        {required ? <span className="text-critical"> *</span> : null}
+      </label>
+      {children}
+      {help ? <p className="text-xs text-ink-3">{help}</p> : null}
+      {error ? (
+        <p role="alert" className="text-xs font-medium text-critical">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/input.tsx
+++ b/packages/frontend/src/components/ui/input.tsx
@@ -1,9 +1,13 @@
-import type { InputHTMLAttributes } from "react";
+import { forwardRef, type InputHTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
 
-export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(function Input(
+  { className, ...props },
+  ref,
+) {
   return (
     <input
+      ref={ref}
       className={cn(
         "h-11 max-w-full min-w-0 w-full rounded-[var(--radius-s)] border border-line bg-surface-2 px-3 text-sm text-ink outline-none transition focus:border-brand",
         className,
@@ -11,4 +15,4 @@ export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElem
       {...props}
     />
   );
-}
+});

--- a/packages/frontend/src/components/ui/money-input.tsx
+++ b/packages/frontend/src/components/ui/money-input.tsx
@@ -1,0 +1,81 @@
+import { DEFAULT_CURRENCY_CODE, getCurrencyMinorUnits, type SupportedCurrencyCode } from "@sui/shared";
+import { forwardRef, useId, useState, type InputHTMLAttributes } from "react";
+import { formatCurrencyInputValue, parseCurrencyInputValue } from "../../lib/format";
+import { cn } from "../../lib/utils";
+
+const currencySymbols: Partial<Record<SupportedCurrencyCode, string>> = {
+  JPY: "¥",
+  USD: "$",
+  EUR: "€",
+};
+
+function getCurrencySymbol(currencyCode: SupportedCurrencyCode) {
+  return currencySymbols[currencyCode] ?? currencyCode;
+}
+
+function buildDecimalPattern(minorUnits: number) {
+  return minorUnits === 0 ? /^-?\d*$/ : new RegExp(`^-?\\d*\\.?\\d{0,${minorUnits}}$`);
+}
+
+/**
+ * 通貨対応の金額入力（Issue #223 の根治）。
+ * フォーカス中はローカル文字列ドラフトを表示し、blur で整形し直す。
+ * 空欄や末尾ドットのような編集途中の状態を正当な入力として許可する。
+ * type="text" + inputMode="decimal" によって type="number" の先頭 0 残留やホイール誤操作を断つ。
+ */
+export const MoneyInput = forwardRef<
+  HTMLInputElement,
+  {
+    id?: string;
+    value: number;
+    currencyCode?: SupportedCurrencyCode;
+    onChange: (value: number) => void;
+    className?: string;
+  } & Omit<InputHTMLAttributes<HTMLInputElement>, "id" | "value" | "onChange" | "type" | "inputMode">
+>(function MoneyInput({ id, value, currencyCode = DEFAULT_CURRENCY_CODE, onChange, className, ...props }, ref) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const minorUnits = getCurrencyMinorUnits(currencyCode);
+  const pattern = buildDecimalPattern(minorUnits);
+  const [draft, setDraft] = useState<string | null>(null);
+  const displayValue = draft ?? formatCurrencyInputValue(value, currencyCode);
+
+  return (
+    <div className="relative min-w-0">
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-sm text-ink-3"
+      >
+        {getCurrencySymbol(currencyCode)}
+      </span>
+      <input
+        ref={ref}
+        id={inputId}
+        type="text"
+        inputMode="decimal"
+        className={cn(
+          "font-data h-11 w-full min-w-0 rounded-[var(--radius-s)] border border-line bg-surface-2 py-2 pr-3 pl-7 text-right text-sm text-ink outline-none transition focus:border-brand",
+          className,
+        )}
+        value={displayValue}
+        onFocus={(event) => {
+          setDraft(displayValue);
+          event.currentTarget.select();
+        }}
+        onChange={(event) => {
+          const next = event.target.value;
+          if (next !== "" && next !== "-" && !pattern.test(next)) {
+            return;
+          }
+
+          setDraft(next);
+          onChange(next === "" || next === "-" ? 0 : parseCurrencyInputValue(next, currencyCode));
+        }}
+        onBlur={() => {
+          setDraft(null);
+        }}
+        {...props}
+      />
+    </div>
+  );
+});

--- a/packages/frontend/src/components/ui/responsive-table.tsx
+++ b/packages/frontend/src/components/ui/responsive-table.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { cn } from "../../lib/utils";
+import { Table, TableWrapper } from "./table";
+
+const DESKTOP_QUERY = "(min-width: 768px)";
+
+function useIsDesktop() {
+  const [isDesktop, setIsDesktop] = useState(() =>
+    typeof window === "undefined" || typeof window.matchMedia !== "function"
+      ? true
+      : window.matchMedia(DESKTOP_QUERY).matches,
+  );
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(DESKTOP_QUERY);
+    const onChange = (event: MediaQueryListEvent) => setIsDesktop(event.matches);
+    mediaQuery.addEventListener("change", onChange);
+    return () => mediaQuery.removeEventListener("change", onChange);
+  }, []);
+
+  return isDesktop;
+}
+
+export type ResponsiveTableColumn<T> = {
+  key: string;
+  header: string;
+  render: (row: T) => ReactNode;
+  align?: "left" | "right";
+  mono?: boolean;
+};
+
+/**
+ * デスクトップは水平罫線のみのテーブル、モバイルは同一データソースからのリスト行レイアウト。
+ * min-w に依存した横スクロールテーブルの複製をここに集約する（C-4）。
+ * どちらか一方だけを描画し、hidden な複製 DOM を残さない。
+ */
+export function ResponsiveTable<T>({
+  columns,
+  rows,
+  rowKey,
+  emptyMessage = "データがありません。",
+  mobileRow,
+  footer,
+  className,
+}: {
+  columns: ReadonlyArray<ResponsiveTableColumn<T>>;
+  rows: ReadonlyArray<T>;
+  rowKey: (row: T) => string;
+  emptyMessage?: string;
+  mobileRow?: (row: T) => ReactNode;
+  footer?: ReactNode;
+  className?: string;
+}) {
+  const isDesktop = useIsDesktop();
+
+  if (!isDesktop && mobileRow) {
+    return (
+      <div className="grid gap-3">
+        {rows.length === 0 ? (
+          <div className="text-sm text-ink-3">{emptyMessage}</div>
+        ) : (
+          rows.map((row) => (
+            <div key={rowKey(row)} className="grid min-w-0 gap-2 rounded-2xl border border-line p-4 text-sm">
+              {mobileRow(row)}
+            </div>
+          ))
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <TableWrapper>
+      <Table className={cn("w-full", className)}>
+        <thead>
+          <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                scope="col"
+                className={cn("px-3 py-3", column.align === "right" && "text-right")}
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr>
+              <td className="px-3 py-6 text-sm text-ink-3" colSpan={columns.length}>
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr key={rowKey(row)} className="border-b border-line align-top">
+                {columns.map((column) => (
+                  <td
+                    key={column.key}
+                    className={cn(
+                      "px-3 py-3",
+                      column.align === "right" && "text-right",
+                      column.mono && "font-data",
+                    )}
+                  >
+                    {column.render(row)}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+        {footer}
+      </Table>
+    </TableWrapper>
+  );
+}
+
+/** 主金額＋下に小さく JPY 換算を置く 2 行組のセル。 */
+export function MoneyCell({ primary, secondary }: { primary: string; secondary?: string | null }) {
+  return (
+    <div className="text-right">
+      <div className="font-data">{primary}</div>
+      {secondary ? <div className="font-data text-xs text-ink-3">{secondary}</div> : null}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/segmented-control.tsx
+++ b/packages/frontend/src/components/ui/segmented-control.tsx
@@ -1,0 +1,43 @@
+import { cn } from "../../lib/utils";
+
+/**
+ * フォームの形を変える選択（種別、支払方法、入力起点など）はここに集約する（C-5 規約 3）。
+ * select でグリッド中程に埋めず、フォーム最上部に置いて「これを選ぶと下が変わる」ことを位置で伝える。
+ */
+export function SegmentedControl<TValue extends string>({
+  options,
+  value,
+  onChange,
+  "aria-label": ariaLabel,
+  className,
+}: {
+  options: ReadonlyArray<{ value: TValue; label: string }>;
+  value: TValue;
+  onChange: (value: TValue) => void;
+  "aria-label": string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={cn("inline-flex w-full min-w-0 rounded-[var(--radius-m)] border border-line bg-surface-2 p-1", className)}
+    >
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          role="radio"
+          aria-checked={value === option.value}
+          onClick={() => onChange(option.value)}
+          className={cn(
+            "min-h-9 min-w-0 flex-1 truncate rounded-[var(--radius-s)] px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+            value === option.value ? "bg-brand text-[#0B0E13]" : "text-ink-2 hover:text-ink",
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/switch.tsx
+++ b/packages/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+
+/**
+ * チェック系 UI を 1 種類に統一する Switch。オフセットトグル、固定収支の「有効」、
+ * 超過確定/データ管理のチェックボックスなど、4 種類の見た目をこれに置き換える。
+ */
+export function Switch({
+  checked,
+  onChange,
+  id,
+  "aria-label": ariaLabel,
+  disabled = false,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  id?: string;
+  "aria-label"?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      id={id}
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-brand" : "border border-line-strong bg-surface-2",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "inline-block h-4 w-4 transform rounded-full bg-ink transition-transform",
+          checked ? "translate-x-6 bg-[#0B0E13]" : "translate-x-1 bg-ink-3",
+        )}
+      />
+    </button>
+  );
+}
+
+/**
+ * ラベルと Switch を並べる行。設定系フォームで多用する構成をまとめる。
+ */
+export function SwitchField({
+  label,
+  help,
+  checked,
+  onChange,
+  id,
+  className,
+}: {
+  label: ReactNode;
+  help?: ReactNode;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  id?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-3 rounded-[var(--radius-s)] border border-line bg-surface-2 px-4 py-3 text-sm",
+        className,
+      )}
+    >
+      <div className="min-w-0 cursor-pointer select-none" onClick={() => onChange(!checked)}>
+        <div className="text-ink">{label}</div>
+        {help ? <div className="mt-0.5 text-xs text-ink-3">{help}</div> : null}
+      </div>
+      <Switch id={id} checked={checked} onChange={onChange} aria-label={typeof label === "string" ? label : undefined} />
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/format.test.ts
+++ b/packages/frontend/src/lib/format.test.ts
@@ -26,7 +26,7 @@ describe("formatCurrency", () => {
   it("formats foreign currencies from minor units", () => {
     expect(formatCurrency(123456, "USD")).toBe("$1,234.56");
     expect(formatCurrency(987, "EUR")).toBe("€9.87");
-    expect(formatCurrencyWithJpy(123456, "USD", 185184)).toMatch(/\$1,234\.56 \/ [¥￥]185,184/);
+    expect(formatCurrencyWithJpy(123456, "USD", 185184)).toMatch(/\$1,234\.56（[¥￥]185,184）/);
   });
 });
 

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -30,7 +30,26 @@ export function formatCurrencyWithJpy(
     return formattedValue;
   }
 
-  return `${formattedValue} / ${formatCurrency(valueJpy, "JPY")}`;
+  return `${formattedValue}（${formatCurrency(valueJpy, "JPY")}）`;
+}
+
+/**
+ * テーブルの金額セル用。主金額と JPY 換算額を分けて返し、呼び出し側で
+ * 主金額の下に小さく換算額を置く 2 行組として描画する（スラッシュ連結の廃止）。
+ */
+export function formatCurrencyParts(
+  value: number,
+  currencyCode: SupportedCurrencyCode,
+  valueJpy: number,
+): { primary: string; secondary: string | null } {
+  if (currencyCode === "JPY") {
+    return { primary: formatCurrency(value, currencyCode), secondary: null };
+  }
+
+  return {
+    primary: formatCurrency(value, currencyCode),
+    secondary: formatCurrency(valueJpy, "JPY"),
+  };
 }
 
 export function formatCurrencyInputValue(value: number, currencyCode: SupportedCurrencyCode) {

--- a/packages/frontend/src/routes/accounts.tsx
+++ b/packages/frontend/src/routes/accounts.tsx
@@ -5,22 +5,28 @@ import {
   type ReconcileAccountResponse,
   type SupportedCurrencyCode,
 } from "@sui/shared";
-import { useState, startTransition } from "react";
-import { Button } from "../components/ui/button";
+import { useEffect, useId, useRef, useState, startTransition } from "react";
+import { ConditionalField } from "../components/ui/conditional-field";
+import { ConfirmDialog } from "../components/ui/confirm-dialog";
+import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../components/ui/dialog";
+import { Disclosure } from "../components/ui/disclosure";
+import { FormField } from "../components/ui/form-field";
 import { Input } from "../components/ui/input";
+import { MoneyInput } from "../components/ui/money-input";
+import { ResponsiveTable, MoneyCell, type ResponsiveTableColumn } from "../components/ui/responsive-table";
 import { Select } from "../components/ui/select";
-import { Table, TableWrapper } from "../components/ui/table";
 import { useResource } from "../hooks/use-resource";
+import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import {
   convertCurrencyInputToJpy,
-  formatCurrencyInputValue,
+  formatCurrencyParts,
   formatCurrencyWithJpy,
-  parseCurrencyInputValue,
 } from "../lib/format";
 import { cn } from "../lib/utils";
+import { Pencil, RefreshCcw, Trash2 } from "lucide-react";
 
 type AccountForm = {
   name: string;
@@ -48,20 +54,27 @@ export function AccountsPage() {
   const [editForm, setEditForm] = useState<AccountForm>(emptyForm);
   const [reconcilingAccount, setReconcilingAccount] = useState<Account | null>(null);
   const [reconcileBalance, setReconcileBalance] = useState(0);
+  const [deletingAccount, setDeletingAccount] = useState<Account | null>(null);
   const { data, loading, error } = useResource(() => apiFetch<Account[]>("/api/accounts"), [reloadKey]);
+  const { toast } = useToast();
   const canCreate = form.name.trim().length > 0 && isValidExchangeRate(form);
   const canSaveEdit = editForm.name.trim().length > 0 && isValidExchangeRate(editForm);
 
   const reload = () => startTransition(() => setReloadKey((value) => value + 1));
 
   const createAccount = async () => {
-    await apiFetch("/api/accounts", {
-      method: "POST",
-      body: JSON.stringify(form),
-    });
-    setForm(emptyForm);
-    setCreateOpen(false);
-    reload();
+    try {
+      await apiFetch("/api/accounts", {
+        method: "POST",
+        body: JSON.stringify(form),
+      });
+      setForm(emptyForm);
+      setCreateOpen(false);
+      reload();
+      toast({ title: `${form.name} を追加しました` });
+    } catch (createError) {
+      toast({ title: "口座の追加に失敗しました", description: describeError(createError), variant: "error" });
+    }
   };
 
   const updateAccount = async (account: Account) => {
@@ -79,12 +92,21 @@ export function AccountsPage() {
     reload();
   };
 
-  const deleteAccount = async (id: string) => {
-    if (!window.confirm("この口座を削除します。よろしいですか？")) {
+  const requestDelete = (account: Account) => setDeletingAccount(account);
+
+  const confirmDelete = async () => {
+    if (!deletingAccount) {
       return;
     }
-    await apiFetch(`/api/accounts/${id}`, { method: "DELETE" });
-    reload();
+
+    try {
+      await apiFetch(`/api/accounts/${deletingAccount.id}`, { method: "DELETE" });
+      toast({ title: `${deletingAccount.name} を削除しました` });
+      setDeletingAccount(null);
+      reload();
+    } catch (deleteError) {
+      toast({ title: "口座の削除に失敗しました", description: describeError(deleteError), variant: "error" });
+    }
   };
 
   const openEdit = (account: Account) => {
@@ -119,11 +141,13 @@ export function AccountsPage() {
       return;
     }
 
-    await updateAccount({
-      ...editingAccount,
-      ...editForm,
-    });
-    closeEdit();
+    try {
+      await updateAccount({ ...editingAccount, ...editForm });
+      closeEdit();
+      toast({ title: `${editForm.name} を更新しました` });
+    } catch (updateError) {
+      toast({ title: "口座の更新に失敗しました", description: describeError(updateError), variant: "error" });
+    }
   };
 
   const saveReconcile = async () => {
@@ -131,19 +155,87 @@ export function AccountsPage() {
       return;
     }
 
-    const payload: ReconcileAccountPayload = { actualBalance: reconcileBalance };
-    await apiFetch<ReconcileAccountResponse>(`/api/accounts/${reconcilingAccount.id}/reconcile`, {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    closeReconcile();
-    reload();
+    try {
+      const payload: ReconcileAccountPayload = { actualBalance: reconcileBalance };
+      await apiFetch<ReconcileAccountResponse>(`/api/accounts/${reconcilingAccount.id}/reconcile`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      closeReconcile();
+      reload();
+      toast({ title: `${reconcilingAccount.name} を照合しました` });
+    } catch (reconcileError) {
+      toast({ title: "照合に失敗しました", description: describeError(reconcileError), variant: "error" });
+    }
   };
 
   const closeCreate = () => {
     setCreateOpen(false);
     setForm(emptyForm);
   };
+
+  const columns: ResponsiveTableColumn<Account>[] = [
+    { key: "name", header: "口座名", render: (account) => account.name },
+    { key: "currency", header: "通貨", render: (account) => account.currencyCode },
+    {
+      key: "balance",
+      header: "残高",
+      align: "right",
+      render: (account) => {
+        const parts = formatCurrencyParts(
+          account.balance,
+          account.currencyCode,
+          convertCurrencyInputToJpy(account.balance, account.currencyCode, account.exchangeRateToJpy),
+        );
+        return <MoneyCell primary={parts.primary} secondary={parts.secondary} />;
+      },
+    },
+    {
+      key: "disposable",
+      header: "可処分残高",
+      align: "right",
+      render: (account) => {
+        const disposable = account.balance - account.balanceOffset;
+        const parts = formatCurrencyParts(
+          disposable,
+          account.currencyCode,
+          convertCurrencyInputToJpy(disposable, account.currencyCode, account.exchangeRateToJpy),
+        );
+        return <MoneyCell primary={parts.primary} secondary={parts.secondary} />;
+      },
+    },
+    {
+      key: "reconciled",
+      header: "最終照合",
+      mono: true,
+      render: (account) => <span className="text-ink-2">{formatLastReconciledAt(account.lastReconciledAt)}</span>,
+    },
+    {
+      key: "rate",
+      header: "換算レート",
+      mono: true,
+      render: (account) =>
+        account.currencyCode === "JPY" ? "1" : `${account.exchangeRateToJpy.toLocaleString("ja-JP", { maximumFractionDigits: 4 })} JPY`,
+    },
+    { key: "sortOrder", header: "表示順", mono: true, render: (account) => account.sortOrder },
+    {
+      key: "actions",
+      header: "",
+      render: (account) => (
+        <div className="flex justify-end gap-1">
+          <IconButton aria-label="編集" onClick={() => openEdit(account)}>
+            <Pencil aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+          <IconButton aria-label="照合" onClick={() => openReconcile(account)}>
+            <RefreshCcw aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+          <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(account)}>
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+        </div>
+      ),
+    },
+  ];
 
   return (
     <div className="grid gap-6">
@@ -161,43 +253,57 @@ export function AccountsPage() {
       <Card>
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-xl font-semibold">口座一覧</h2>
-          <div className="text-sm text-ink-2">{loading ? "読み込み中..." : error ?? `${data?.length ?? 0} 件`}</div>
+          <div className="text-sm text-ink-2">{loading ? "読み込み中..." : `${data?.length ?? 0} 件`}</div>
         </div>
-        <TableWrapper>
-          <Table className="min-w-[72rem]">
-            <thead>
-              <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                <th className="px-3 py-3">口座名</th>
-                <th className="px-3 py-3">通貨</th>
-                <th className="px-3 py-3">残高</th>
-                <th className="px-3 py-3">可処分残高</th>
-                <th className="px-3 py-3">最終照合</th>
-                <th className="px-3 py-3">換算レート</th>
-                <th className="px-3 py-3">表示順</th>
-                <th className="px-3 py-3" />
-              </tr>
-            </thead>
-            <tbody>
-              {(data ?? []).map((account) => (
-                <AccountRow
-                  key={account.id}
-                  account={account}
-                  onEdit={openEdit}
-                  onReconcile={openReconcile}
-                  onDelete={deleteAccount}
-                />
-              ))}
-            </tbody>
-          </Table>
-        </TableWrapper>
+        {error ? (
+          <ErrorBlock message={error} onRetry={reload} />
+        ) : (
+          <ResponsiveTable
+            columns={columns}
+            rows={data ?? []}
+            rowKey={(account) => account.id}
+            emptyMessage="口座が登録されていません。"
+            mobileRow={(account) => (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{account.name}</div>
+                    <div className="text-xs text-ink-3">{account.currencyCode}</div>
+                  </div>
+                  <div className="text-right">
+                    <div className="font-data text-base font-semibold">
+                      {formatCurrencyWithJpy(
+                        account.balance,
+                        account.currencyCode,
+                        convertCurrencyInputToJpy(account.balance, account.currencyCode, account.exchangeRateToJpy),
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
+                  <span>最終照合 {formatLastReconciledAt(account.lastReconciledAt)}</span>
+                  <div className="flex gap-1">
+                    <IconButton aria-label="編集" onClick={() => openEdit(account)}>
+                      <Pencil aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                    <IconButton aria-label="照合" onClick={() => openReconcile(account)}>
+                      <RefreshCcw aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                    <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(account)}>
+                      <Trash2 aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                  </div>
+                </div>
+              </>
+            )}
+          />
+        )}
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(94vw,36rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">口座を追加</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            口座情報を登録します。
-          </DialogDescription>
+          <DialogDescription className="mt-2 text-sm text-ink-2">口座情報を登録します。</DialogDescription>
           <AccountEditModal
             form={form}
             onChange={setForm}
@@ -210,11 +316,9 @@ export function AccountsPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingAccount)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(94vw,36rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">口座を編集</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            口座情報を更新します。
-          </DialogDescription>
+          <DialogDescription className="mt-2 text-sm text-ink-2">口座情報を更新します。</DialogDescription>
           <AccountEditModal
             form={editForm}
             onChange={setEditForm}
@@ -227,7 +331,7 @@ export function AccountsPage() {
       </Dialog>
 
       <Dialog open={Boolean(reconcilingAccount)} onOpenChange={(open) => !open && closeReconcile()}>
-        <DialogContent className="w-[min(94vw,34rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">残高を照合</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-ink-2">
             実残高との差分を調整取引として記録します。
@@ -243,6 +347,14 @@ export function AccountsPage() {
           ) : null}
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(deletingAccount)}
+        onOpenChange={(open) => !open && setDeletingAccount(null)}
+        title="口座を削除しますか？"
+        description={deletingAccount ? `「${deletingAccount.name}」を削除します。この操作は取り消せません。` : undefined}
+        onConfirm={confirmDelete}
+      />
     </div>
   );
 }
@@ -264,40 +376,18 @@ function AccountEditModal({
   actionLabel?: string;
   showBalanceAdjustmentNote?: boolean;
 }) {
-  return (
-    <div className="mt-6 grid gap-5">
-      <section className="grid gap-4">
-        <div className="text-xs font-medium text-ink-3">基本情報</div>
-        <div className="grid gap-4 md:grid-cols-2">
-          <AccountFormFields
-            form={form}
-            onChange={onChange}
-            showBalanceAdjustmentNote={showBalanceAdjustmentNote}
-          />
-        </div>
-      </section>
-      <div className="flex justify-end gap-3 border-t border-line pt-4">
-        <Button variant="ghost" onClick={onCancel}>
-          キャンセル
-        </Button>
-        <Button disabled={!canSave} onClick={onSave}>
-          {actionLabel}
-        </Button>
-      </div>
-    </div>
-  );
-}
+  const nameId = useId();
+  const currencyId = useId();
+  const rateId = useId();
+  const balanceId = useId();
+  const offsetId = useId();
+  const sortOrderId = useId();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
 
-function AccountFormFields({
-  form,
-  onChange,
-  showBalanceAdjustmentNote,
-}: {
-  form: AccountForm;
-  onChange: (next: AccountForm) => void;
-  showBalanceAdjustmentNote: boolean;
-}) {
-  const amountStep = form.currencyCode === "JPY" ? 1 : 0.01;
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
+
   const setCurrencyCode = (currencyCode: SupportedCurrencyCode) => {
     onChange({
       ...form,
@@ -306,29 +396,38 @@ function AccountFormFields({
     });
   };
 
+  const missing: string[] = [];
+  if (form.name.trim().length === 0) missing.push("口座名");
+  if (!isValidExchangeRate(form)) missing.push("JPY換算レート");
+
   return (
-    <>
-      <label className="grid gap-2 text-sm">
-        <span>口座名 *</span>
-        <Input required value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>通貨</span>
-        <Select
-          value={form.currencyCode}
-          onChange={(event) => setCurrencyCode(event.target.value as SupportedCurrencyCode)}
-        >
+    <form
+      className="mt-6 grid gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (canSave) {
+          onSave();
+        }
+      }}
+    >
+      <FormField label="口座名" htmlFor={nameId} required>
+        <Input id={nameId} ref={firstFieldRef} required value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
+      </FormField>
+
+      <FormField label="通貨" htmlFor={currencyId}>
+        <Select id={currencyId} value={form.currencyCode} onChange={(event) => setCurrencyCode(event.target.value as SupportedCurrencyCode)}>
           {SUPPORTED_CURRENCY_CODES.map((currencyCode) => (
             <option key={currencyCode} value={currencyCode}>
               {currencyCode}
             </option>
           ))}
         </Select>
-      </label>
-      {form.currencyCode !== "JPY" ? (
-        <label className="grid gap-2 text-sm">
-          <span>JPY換算レート</span>
+      </FormField>
+
+      <ConditionalField show={form.currencyCode !== "JPY"}>
+        <FormField label="JPY換算レート" htmlFor={rateId}>
           <Input
+            id={rateId}
             type="number"
             inputMode="decimal"
             min="0"
@@ -336,92 +435,55 @@ function AccountFormFields({
             value={form.exchangeRateToJpy}
             onChange={(event) => onChange({ ...form, exchangeRateToJpy: Number(event.target.value) })}
           />
-        </label>
-      ) : null}
-      <label className="grid gap-2 text-sm">
-        <span>現在残高 ({form.currencyCode})</span>
-        <Input
-          type="number"
-          inputMode="decimal"
-          step={amountStep}
-          value={formatCurrencyInputValue(form.balance, form.currencyCode)}
-          onChange={(event) => onChange({
-            ...form,
-            balance: parseCurrencyInputValue(event.target.value, form.currencyCode),
-          })}
-        />
-        {showBalanceAdjustmentNote ? (
-          <span className="text-xs text-ink-3">変更分は調整取引として記録されます。</span>
-        ) : null}
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>オフセット ({form.currencyCode})</span>
-        <Input
-          type="number"
-          inputMode="decimal"
-          step={amountStep}
-          value={formatCurrencyInputValue(form.balanceOffset, form.currencyCode)}
-          onChange={(event) => onChange({
-            ...form,
-            balanceOffset: parseCurrencyInputValue(event.target.value, form.currencyCode),
-          })}
-        />
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>表示順</span>
-        <Input
-          type="number"
-          inputMode="numeric"
-          value={form.sortOrder}
-          onChange={(event) => onChange({ ...form, sortOrder: Number(event.target.value) })}
-        />
-      </label>
-    </>
-  );
-}
+        </FormField>
+      </ConditionalField>
 
-function AccountRow({
-  account,
-  onEdit,
-  onReconcile,
-  onDelete,
-}: {
-  account: Account;
-  onEdit: (account: Account) => void;
-  onReconcile: (account: Account) => void;
-  onDelete: (id: string) => Promise<void>;
-}) {
-  return (
-    <tr className="border-b border-line">
-      <td className="px-3 py-3">{account.name}</td>
-      <td className="px-3 py-3">{account.currencyCode}</td>
-      <td className="px-3 py-3">
-        <MoneyValue account={account} amount={account.balance} />
-      </td>
-      <td className="px-3 py-3">
-        <MoneyValue account={account} amount={account.balance - account.balanceOffset} />
-      </td>
-      <td className="font-data px-3 py-3 text-ink-2">{formatLastReconciledAt(account.lastReconciledAt)}</td>
-      <td className="font-data px-3 py-3">
-        {account.currencyCode === "JPY"
-          ? "1"
-          : `${account.exchangeRateToJpy.toLocaleString("ja-JP", { maximumFractionDigits: 4 })} JPY`}
-      </td>
-      <td className="font-data px-3 py-3">{account.sortOrder}</td>
-      <td className="px-3 py-3">
-        <div className="flex justify-end gap-2">
-          <Button variant="ghost" onClick={() => onEdit(account)}>
-            編集
+      <FormField
+        label={`現在残高 (${form.currencyCode})`}
+        htmlFor={balanceId}
+        help={showBalanceAdjustmentNote ? "変更分は調整取引として記録されます。" : undefined}
+      >
+        <MoneyInput
+          id={balanceId}
+          currencyCode={form.currencyCode}
+          value={form.balance}
+          onChange={(value) => onChange({ ...form, balance: value })}
+        />
+      </FormField>
+
+      <FormField label={`オフセット (${form.currencyCode})`} htmlFor={offsetId}>
+        <MoneyInput
+          id={offsetId}
+          currencyCode={form.currencyCode}
+          value={form.balanceOffset}
+          onChange={(value) => onChange({ ...form, balanceOffset: value })}
+        />
+      </FormField>
+
+      <Disclosure summary="詳細設定">
+        <FormField label="表示順" htmlFor={sortOrderId}>
+          <Input
+            id={sortOrderId}
+            type="number"
+            inputMode="numeric"
+            value={form.sortOrder}
+            onChange={(event) => onChange({ ...form, sortOrder: Number(event.target.value) })}
+          />
+        </FormField>
+      </Disclosure>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-4">
+        <div className="text-xs text-ink-3">{!canSave && missing.length > 0 ? `必須: ${missing.join("、")}` : ""}</div>
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            キャンセル
           </Button>
-          <Button variant="ghost" onClick={() => onReconcile(account)}>
-            照合
-          </Button>
-          <Button variant="danger" onClick={() => onDelete(account.id)}>
-            削除
+          <Button type="submit" disabled={!canSave}>
+            {actionLabel}
           </Button>
         </div>
-      </td>
-    </tr>
+      </div>
+    </form>
   );
 }
 
@@ -438,21 +500,31 @@ function ReconcileModal({
   onCancel: () => void;
   onSave: () => void;
 }) {
-  const amountStep = account.currencyCode === "JPY" ? 1 : 0.01;
   const diff = actualBalance - account.balance;
+  const inputId = useId();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
 
   return (
-    <div className="mt-6 grid gap-5">
-      <label className="grid gap-2 text-sm">
-        <span>実残高 ({account.currencyCode})</span>
-        <Input
-          type="number"
-          inputMode="decimal"
-          step={amountStep}
-          value={formatCurrencyInputValue(actualBalance, account.currencyCode)}
-          onChange={(event) => onChange(parseCurrencyInputValue(event.target.value, account.currencyCode))}
+    <form
+      className="mt-6 grid gap-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSave();
+      }}
+    >
+      <FormField label={`実残高 (${account.currencyCode})`} htmlFor={inputId} required>
+        <MoneyInput
+          id={inputId}
+          ref={firstFieldRef}
+          currencyCode={account.currencyCode}
+          value={actualBalance}
+          onChange={onChange}
         />
-      </label>
+      </FormField>
       <div className="grid gap-3 rounded-xl border border-line bg-surface-2 p-4 text-sm">
         <div className="flex items-center justify-between gap-3">
           <span className="text-ink-2">現在残高</span>
@@ -470,33 +542,28 @@ function ReconcileModal({
         </div>
       </div>
       <div className="flex justify-end gap-3 border-t border-line pt-4">
-        <Button variant="ghost" onClick={onCancel}>
+        <Button type="button" variant="ghost" onClick={onCancel}>
           キャンセル
         </Button>
-        <Button onClick={onSave}>
-          照合を実行
-        </Button>
+        <Button type="submit">照合を実行</Button>
       </div>
-    </div>
+    </form>
   );
 }
 
-function MoneyValue({ account, amount }: { account: Account; amount: number }) {
+function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
-    <div>
-      <div className="font-data">{formatAccountMoney(account, amount)}</div>
+    <div className="grid gap-3 rounded-xl border border-critical/40 bg-critical/10 p-4 text-sm text-ink">
+      <p role="alert">{message}</p>
+      <Button className="justify-self-start" variant="secondary" onClick={onRetry}>
+        再試行
+      </Button>
     </div>
   );
 }
 
-function formatAccountMoney(account: Account, amount: number) {
-  const amountJpy = convertCurrencyInputToJpy(amount, account.currencyCode, account.exchangeRateToJpy);
-  return formatCurrencyWithJpy(amount, account.currencyCode, amountJpy);
-}
-
-function formatSignedAccountMoney(account: Account, amount: number) {
-  const formatted = formatAccountMoney(account, amount);
-  return amount > 0 ? `+${formatted}` : formatted;
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : "不明なエラーが発生しました。";
 }
 
 const lastReconciledAtFormatter = new Intl.DateTimeFormat("ja-JP", {
@@ -512,6 +579,16 @@ function formatLastReconciledAt(value: string | null) {
   }
 
   return lastReconciledAtFormatter.format(new Date(value));
+}
+
+function formatAccountMoney(account: Account, amount: number) {
+  const amountJpy = convertCurrencyInputToJpy(amount, account.currencyCode, account.exchangeRateToJpy);
+  return formatCurrencyWithJpy(amount, account.currencyCode, amountJpy);
+}
+
+function formatSignedAccountMoney(account: Account, amount: number) {
+  const formatted = formatAccountMoney(account, amount);
+  return amount > 0 ? `+${formatted}` : formatted;
 }
 
 function isValidExchangeRate(form: AccountForm) {

--- a/packages/frontend/src/routes/credit-cards.tsx
+++ b/packages/frontend/src/routes/credit-cards.tsx
@@ -6,18 +6,25 @@ import {
   type CreditCardAssumptionSuggestionResponse,
   type DateShiftPolicy,
 } from "@sui/shared";
-import { useMemo, useState, startTransition } from "react";
+import { useEffect, useId, useMemo, useRef, useState, startTransition } from "react";
+import { AccountSelect, DateShiftField, DayOfMonthField } from "../components/form-fields";
 import { Badge } from "../components/ui/badge";
-import { Button } from "../components/ui/button";
+import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
+import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../components/ui/dialog";
+import { Disclosure } from "../components/ui/disclosure";
+import { FormField } from "../components/ui/form-field";
 import { Input } from "../components/ui/input";
-import { Select } from "../components/ui/select";
+import { MoneyInput } from "../components/ui/money-input";
+import { ResponsiveTable, type ResponsiveTableColumn } from "../components/ui/responsive-table";
 import { Table, TableWrapper } from "../components/ui/table";
 import { useResource } from "../hooks/use-resource";
+import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import { formatCurrency } from "../lib/format";
 import { getCurrentYearMonth } from "../lib/utils";
+import { Pencil, Trash2 } from "lucide-react";
 
 type CreditCardForm = {
   name: string;
@@ -118,6 +125,10 @@ function resolveAppliedCardAmount({
   };
 }
 
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : "不明なエラーが発生しました。";
+}
+
 export function CreditCardsPage() {
   const [reloadKey, setReloadKey] = useState(0);
   const [yearMonth, setYearMonth] = useState(getCurrentYearMonth());
@@ -125,11 +136,13 @@ export function CreditCardsPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editingCard, setEditingCard] = useState<CreditCard | null>(null);
   const [editForm, setEditForm] = useState<CreditCardForm>(emptyCard);
+  const [deletingCard, setDeletingCard] = useState<CreditCard | null>(null);
   const [assumptionSuggestion, setAssumptionSuggestion] = useState<CreditCardAssumptionSuggestionResponse | null>(null);
   const [assumptionSuggestionLoading, setAssumptionSuggestionLoading] = useState(false);
   const [assumptionSuggestionError, setAssumptionSuggestionError] = useState<string | null>(null);
   const [editedAmounts, setEditedAmounts] = useState<Record<string, number>>({});
   const [editedYearMonth, setEditedYearMonth] = useState<string | null>(null);
+  const { toast } = useToast();
 
   const { data, loading, error } = useResource(
     () =>
@@ -218,13 +231,19 @@ export function CreditCardsPage() {
     (editForm.settlementDay === null || (editForm.settlementDay >= 1 && editForm.settlementDay <= 31));
 
   const createCard = async () => {
-    await apiFetch("/api/credit-cards", {
-      method: "POST",
-      body: JSON.stringify(cardForm),
-    });
-    setCardForm({ ...emptyCard, accountId: accounts[0]?.id ?? "" });
-    setCreateOpen(false);
-    reload();
+    try {
+      await apiFetch("/api/credit-cards", {
+        method: "POST",
+        body: JSON.stringify(cardForm),
+      });
+      const name = cardForm.name;
+      setCardForm({ ...emptyCard, accountId: accounts[0]?.id ?? "" });
+      setCreateOpen(false);
+      reload();
+      toast({ title: `${name} を追加しました` });
+    } catch (createError) {
+      toast({ title: "カードの追加に失敗しました", description: describeError(createError), variant: "error" });
+    }
   };
 
   const updateCard = async (card: CreditCard) => {
@@ -242,13 +261,21 @@ export function CreditCardsPage() {
     reload();
   };
 
-  const deleteCard = async (id: string) => {
-    if (!window.confirm("このカードを削除します。よろしいですか？")) {
+  const requestDelete = (card: CreditCard) => setDeletingCard(card);
+
+  const confirmDelete = async () => {
+    if (!deletingCard) {
       return;
     }
 
-    await apiFetch(`/api/credit-cards/${id}`, { method: "DELETE" });
-    reload();
+    try {
+      await apiFetch(`/api/credit-cards/${deletingCard.id}`, { method: "DELETE" });
+      toast({ title: `${deletingCard.name} を削除しました` });
+      setDeletingCard(null);
+      reload();
+    } catch (deleteError) {
+      toast({ title: "削除に失敗しました", description: describeError(deleteError), variant: "error" });
+    }
   };
 
   const saveBilling = async () => {
@@ -256,16 +283,21 @@ export function CreditCardsPage() {
       return;
     }
 
-    await apiFetch(`/api/billings/${yearMonth}`, {
-      method: "PUT",
-      body: JSON.stringify({
-        items: (data?.cards ?? []).map((card) => ({
-          creditCardId: card.id,
-          amount: amounts[card.id] ?? 0,
-        })),
-      }),
-    });
-    reload();
+    try {
+      await apiFetch(`/api/billings/${yearMonth}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          items: (data?.cards ?? []).map((card) => ({
+            creditCardId: card.id,
+            amount: amounts[card.id] ?? 0,
+          })),
+        }),
+      });
+      reload();
+      toast({ title: "月次請求を保存しました" });
+    } catch (billingError) {
+      toast({ title: "月次請求の保存に失敗しました", description: describeError(billingError), variant: "error" });
+    }
   };
 
   const updateBillingAmount = (cardId: string, amount: number) => {
@@ -276,14 +308,28 @@ export function CreditCardsPage() {
     }));
   };
 
+  const [pendingYearMonth, setPendingYearMonth] = useState<string | null>(null);
+
   const changeYearMonth = (nextYearMonth: string) => {
-    if (isBillingDirty && !window.confirm("未保存の月次請求があります。月を切り替えますか？")) {
+    if (isBillingDirty) {
+      setPendingYearMonth(nextYearMonth);
       return;
     }
 
     setYearMonth(nextYearMonth);
     setEditedAmounts({});
     setEditedYearMonth(null);
+  };
+
+  const confirmChangeYearMonth = () => {
+    if (!pendingYearMonth) {
+      return;
+    }
+
+    setYearMonth(pendingYearMonth);
+    setEditedAmounts({});
+    setEditedYearMonth(null);
+    setPendingYearMonth(null);
   };
 
   const openEdit = (card: CreditCard) => {
@@ -308,9 +354,9 @@ export function CreditCardsPage() {
         `/api/credit-cards/${cardId}/assumption-suggestion?months=6`,
       );
       setAssumptionSuggestion(suggestion);
-    } catch (error) {
+    } catch (suggestionError) {
       setAssumptionSuggestion(null);
-      setAssumptionSuggestionError(error instanceof Error ? error.message : "提案を取得できませんでした");
+      setAssumptionSuggestionError(suggestionError instanceof Error ? suggestionError.message : "提案を取得できませんでした");
     } finally {
       setAssumptionSuggestionLoading(false);
     }
@@ -328,19 +374,46 @@ export function CreditCardsPage() {
       return;
     }
 
-    await updateCard({
-      ...editingCard,
-      ...editForm,
-      accountId: editForm.accountId,
-      account: accounts.find((account) => account.id === editForm.accountId) ?? null,
-    });
-    closeEdit();
+    try {
+      await updateCard({
+        ...editingCard,
+        ...editForm,
+        accountId: editForm.accountId,
+        account: accounts.find((account) => account.id === editForm.accountId) ?? null,
+      });
+      closeEdit();
+      toast({ title: `${editForm.name} を更新しました` });
+    } catch (updateError) {
+      toast({ title: "更新に失敗しました", description: describeError(updateError), variant: "error" });
+    }
   };
 
   const closeCreate = () => {
     setCreateOpen(false);
     setCardForm({ ...emptyCard, accountId: accounts[0]?.id ?? "" });
   };
+
+  const cardColumns: ResponsiveTableColumn<CreditCard>[] = [
+    { key: "name", header: "カード名", render: (card) => card.name },
+    { key: "day", header: "引落日", render: (card) => card.settlementDay ?? "-" },
+    { key: "account", header: "引き落とし口座", render: (card) => card.account?.name ?? "未設定" },
+    { key: "assumption", header: "月間仮定額", align: "right", mono: true, render: (card) => formatCurrency(card.assumptionAmount) },
+    { key: "sortOrder", header: "表示順", mono: true, render: (card) => card.sortOrder },
+    {
+      key: "actions",
+      header: "",
+      render: (card) => (
+        <div className="flex justify-end gap-1">
+          <IconButton aria-label="編集" onClick={() => openEdit(card)}>
+            <Pencil aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+          <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(card)}>
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+        </div>
+      ),
+    },
+  ];
 
   return (
     <div className="grid gap-6">
@@ -361,7 +434,7 @@ export function CreditCardsPage() {
             <h2 className="text-xl font-semibold">月別請求入力</h2>
             <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-ink-2">
               <span>{isBillingDirty ? "未保存の変更あり" : "保存済み"}</span>
-              {hasBillingErrors ? <span className="text-pink-300">入力エラーがあります</span> : null}
+              {hasBillingErrors ? <span className="text-critical">入力エラーがあります</span> : null}
             </div>
           </div>
           <Button disabled={!canSaveBilling} onClick={saveBilling}>
@@ -374,25 +447,21 @@ export function CreditCardsPage() {
         <div className="grid min-w-0 gap-4 self-start">
           <div className="hidden min-w-0 md:block">
             <TableWrapper>
-              <Table className="min-w-[60rem]">
+              <Table className="w-full">
                 <thead>
                   <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                    <th className="px-3 py-3">カード名</th>
-                    <th className="px-3 py-3">引き落とし口座</th>
-                    <th className="px-3 py-3">引落日</th>
-                    <th className="px-3 py-3">仮定額</th>
-                    <th className="px-3 py-3">実額入力</th>
-                    <th className="px-3 py-3">適用額</th>
-                    <th className="px-3 py-3">状態</th>
+                    <th scope="col" className="px-3 py-3">カード名</th>
+                    <th scope="col" className="px-3 py-3">引き落とし口座</th>
+                    <th scope="col" className="px-3 py-3">引落日</th>
+                    <th scope="col" className="px-3 py-3">仮定額</th>
+                    <th scope="col" className="px-3 py-3">実額入力</th>
+                    <th scope="col" className="px-3 py-3">適用額</th>
+                    <th scope="col" className="px-3 py-3">状態</th>
                   </tr>
                 </thead>
                 <tbody>
                   {billingRows.map((row) => (
-                    <BillingTableRow
-                      key={row.card.id}
-                      row={row}
-                      onAmountChange={updateBillingAmount}
-                    />
+                    <BillingTableRow key={row.card.id} row={row} onAmountChange={updateBillingAmount} />
                   ))}
                 </tbody>
                 <tfoot>
@@ -413,35 +482,46 @@ export function CreditCardsPage() {
       <Card className="grid gap-3">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-xl font-semibold">カード一覧</h2>
-          <div className="text-sm text-ink-2">{loading ? "読み込み中..." : error ?? `${data?.cards.length ?? 0} 件`}</div>
+          <div className="text-sm text-ink-2">{loading ? "読み込み中..." : `${data?.cards.length ?? 0} 件`}</div>
         </div>
-        <TableWrapper>
-          <Table className="min-w-[56rem]">
-            <thead>
-              <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                <th className="px-3 py-3">カード名</th>
-                <th className="px-3 py-3">引落日</th>
-                <th className="px-3 py-3">引き落とし口座</th>
-                <th className="px-3 py-3">月間仮定額</th>
-                <th className="px-3 py-3">表示順</th>
-                <th className="px-3 py-3" />
-              </tr>
-            </thead>
-            <tbody>
-              {(data?.cards ?? []).map((card) => (
-                <CardRow key={card.id} card={card} onEdit={openEdit} onDelete={deleteCard} />
-              ))}
-            </tbody>
-          </Table>
-        </TableWrapper>
+        {error ? (
+          <ErrorBlock message={error} onRetry={reload} />
+        ) : (
+          <ResponsiveTable
+            columns={cardColumns}
+            rows={data?.cards ?? []}
+            rowKey={(card) => card.id}
+            emptyMessage="カードが登録されていません。"
+            mobileRow={(card) => (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{card.name}</div>
+                    <div className="text-xs text-ink-3">毎月 {card.settlementDay ?? 27} 日・{card.account?.name ?? "未設定"}</div>
+                  </div>
+                  <div className="font-data text-base font-semibold">{formatCurrency(card.assumptionAmount)}</div>
+                </div>
+                <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
+                  <span>表示順 {card.sortOrder}</span>
+                  <div className="flex gap-1">
+                    <IconButton aria-label="編集" onClick={() => openEdit(card)}>
+                      <Pencil aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                    <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(card)}>
+                      <Trash2 aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                  </div>
+                </div>
+              </>
+            )}
+          />
+        )}
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(94vw,36rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">カードを追加</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            カード情報を登録します。
-          </DialogDescription>
+          <DialogDescription className="mt-2 text-sm text-ink-2">カード情報を登録します。</DialogDescription>
           <CreditCardEditModal
             accounts={accounts}
             form={cardForm}
@@ -455,11 +535,9 @@ export function CreditCardsPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingCard)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(94vw,36rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">カードを編集</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            カード情報を更新します。
-          </DialogDescription>
+          <DialogDescription className="mt-2 text-sm text-ink-2">カード情報を更新します。</DialogDescription>
           <CreditCardEditModal
             accounts={accounts}
             form={editForm}
@@ -475,6 +553,24 @@ export function CreditCardsPage() {
           />
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(deletingCard)}
+        onOpenChange={(open) => !open && setDeletingCard(null)}
+        title="カードを削除しますか？"
+        description={deletingCard ? `「${deletingCard.name}」を削除します。この操作は取り消せません。` : undefined}
+        onConfirm={confirmDelete}
+      />
+
+      <ConfirmDialog
+        open={Boolean(pendingYearMonth)}
+        onOpenChange={(open) => !open && setPendingYearMonth(null)}
+        title="未保存の月次請求があります"
+        description="月を切り替えると入力中の請求額は破棄されます。切り替えますか？"
+        confirmLabel="切り替える"
+        danger={false}
+        onConfirm={confirmChangeYearMonth}
+      />
     </div>
   );
 }
@@ -506,7 +602,11 @@ function BillingAmountInput({
         }}
         onChange={(event) => onAmountChange(row.card.id, Number(event.target.value))}
       />
-      {row.error ? <div className="text-xs text-pink-300">{row.error}</div> : null}
+      {row.error ? (
+        <div role="alert" className="text-xs font-medium text-critical">
+          {row.error}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -645,165 +745,117 @@ function CreditCardEditModal({
   onSave: () => void;
   actionLabel?: string;
 }) {
-  return (
-    <div className="mt-6 grid gap-5">
-      <section className="grid gap-4">
-        <div className="text-xs font-medium text-ink-3">基本情報</div>
-        <div className="grid gap-4 md:grid-cols-2">
-          <CreditCardFormFields
-            accounts={accounts}
-            form={form}
-            onChange={onChange}
-            suggestion={suggestion}
-            suggestionLoading={suggestionLoading}
-            suggestionError={suggestionError}
-            onRequestSuggestion={onRequestSuggestion}
-            onApplySuggestion={onApplySuggestion}
-          />
-        </div>
-      </section>
-      <div className="flex justify-end gap-3 border-t border-line pt-4">
-        <Button variant="ghost" onClick={onCancel}>
-          キャンセル
-        </Button>
-        <Button disabled={!canSave} onClick={onSave}>
-          {actionLabel}
-        </Button>
-      </div>
-    </div>
-  );
-}
+  const nameId = useId();
+  const amountId = useId();
+  const sortOrderId = useId();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const missing: string[] = [];
+  if (form.name.trim().length === 0) missing.push("カード名");
+  if (form.accountId === "") missing.push("引き落とし口座");
 
-function CreditCardFormFields({
-  accounts,
-  form,
-  onChange,
-  suggestion,
-  suggestionLoading = false,
-  suggestionError,
-  onRequestSuggestion,
-  onApplySuggestion,
-}: {
-  accounts: Account[];
-  form: CreditCardForm;
-  onChange: (next: CreditCardForm) => void;
-  suggestion?: CreditCardAssumptionSuggestionResponse | null;
-  suggestionLoading?: boolean;
-  suggestionError?: string | null;
-  onRequestSuggestion?: () => void;
-  onApplySuggestion?: (amount: number) => void;
-}) {
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
+
   return (
-    <>
-      <label className="grid gap-2 text-sm">
-        <span>カード名 *</span>
-        <Input required value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>引落日 (1-31)</span>
-        <Input type="number" min={1} max={31} value={form.settlementDay ?? ""} onChange={(event) => onChange({ ...form, settlementDay: event.target.value === "" ? null : Number(event.target.value) })} />
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>引き落とし口座 *</span>
-        <Select value={form.accountId} onChange={(event) => onChange({ ...form, accountId: event.target.value })}>
-          <option value="">口座を選択</option>
-          {accounts.map((account) => (
-            <option key={account.id} value={account.id}>
-              {account.name}
-            </option>
-          ))}
-        </Select>
-      </label>
-      <label className="grid gap-2 text-sm">
-        <span>土日祝の扱い</span>
-        <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
-      </label>
-      <div className="grid gap-2 text-sm">
-        <label className="grid gap-2">
-          <span>月間仮定額 *</span>
-          <Input type="number" min={0} max={INT4_MAX} value={form.assumptionAmount} onChange={(event) => onChange({ ...form, assumptionAmount: Number(event.target.value) })} />
-        </label>
-        {onRequestSuggestion ? (
-          <div className="grid gap-2 rounded-xl border border-line bg-surface-2 p-3 text-xs text-ink-2">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <span className="font-medium text-ink-2">過去実績の提案</span>
-              <Button type="button" variant="ghost" className="min-h-9 px-3 py-1.5 text-xs" disabled={suggestionLoading} onClick={onRequestSuggestion}>
-                {suggestionLoading ? "取得中..." : "過去実績から提案"}
-              </Button>
-            </div>
-            {suggestionError ? <div className="break-words text-pink-300">{suggestionError}</div> : null}
-            {suggestion ? (
-              suggestion.suggestedAmount === null ? (
-                <div className="break-words">提案できる過去実額がありません。</div>
-              ) : (
-                <div className="grid gap-2">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge tone="success">中央値</Badge>
-                    <span className="font-data font-medium text-ink">提案額 {formatCurrency(suggestion.suggestedAmount)}</span>
-                    <span>{suggestion.sampleCount} 件</span>
-                  </div>
-                  <div className="break-words">対象月: {suggestion.sourceYearMonths.join(", ")}</div>
-                  <div className="flex justify-end">
-                    <Button type="button" variant="ghost" className="min-h-9 px-3 py-1.5 text-xs" onClick={() => onApplySuggestion?.(suggestion.suggestedAmount ?? 0)}>
-                      反映
-                    </Button>
-                  </div>
-                </div>
-              )
-            ) : null}
+    <form
+      className="mt-6 grid gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (canSave) {
+          onSave();
+        }
+      }}
+    >
+      <FormField label="カード名" htmlFor={nameId} required>
+        <Input id={nameId} ref={firstFieldRef} value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
+      </FormField>
+
+      <FormField label="月間仮定額" htmlFor={amountId} required>
+        <MoneyInput id={amountId} currencyCode="JPY" value={form.assumptionAmount} onChange={(value) => onChange({ ...form, assumptionAmount: value })} />
+      </FormField>
+
+      {onRequestSuggestion ? (
+        <div className="grid gap-2 rounded-xl border border-line bg-surface-2 p-3 text-xs text-ink-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="font-medium text-ink-2">過去実績の提案</span>
+            <Button type="button" variant="ghost" className="min-h-9 px-3 py-1.5 text-xs" disabled={suggestionLoading} onClick={onRequestSuggestion}>
+              {suggestionLoading ? "取得中..." : "過去実績から提案"}
+            </Button>
           </div>
-        ) : null}
-      </div>
-      <label className="grid gap-2 text-sm md:col-span-2">
-        <span>表示順</span>
-        <Input type="number" value={form.sortOrder} onChange={(event) => onChange({ ...form, sortOrder: Number(event.target.value) })} />
-      </label>
-    </>
-  );
-}
+          {suggestionLoading ? <div>読み込み中...</div> : null}
+          {suggestionError ? (
+            <div role="alert" className="break-words font-medium text-critical">
+              {suggestionError}
+            </div>
+          ) : null}
+          {suggestion ? (
+            suggestion.suggestedAmount === null ? (
+              <div className="break-words">提案できる過去実額がありません。</div>
+            ) : (
+              <div className="grid gap-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge tone="success">中央値</Badge>
+                  <span className="font-data font-medium text-ink">提案額 {formatCurrency(suggestion.suggestedAmount)}</span>
+                  <span>{suggestion.sampleCount} 件</span>
+                </div>
+                <div className="break-words">対象月: {suggestion.sourceYearMonths.join(", ")}</div>
+                <div className="flex justify-end">
+                  <Button type="button" variant="ghost" className="min-h-9 px-3 py-1.5 text-xs" onClick={() => onApplySuggestion?.(suggestion.suggestedAmount ?? 0)}>
+                    反映
+                  </Button>
+                </div>
+              </div>
+            )
+          ) : null}
+        </div>
+      ) : null}
 
-function DateShiftSelect({
-  value,
-  onChange,
-}: {
-  value: DateShiftPolicy;
-  onChange: (value: DateShiftPolicy) => void;
-}) {
-  return (
-    <Select value={value} onChange={(event) => onChange(event.target.value as DateShiftPolicy)}>
-      <option value="none">シフトなし</option>
-      <option value="previous">前営業日</option>
-      <option value="next">後営業日</option>
-    </Select>
-  );
-}
+      <DayOfMonthField
+        id="credit-card-day"
+        required={false}
+        value={form.settlementDay}
+        onChange={(value) => onChange({ ...form, settlementDay: value })}
+      />
 
-function CardRow({
-  card,
-  onEdit,
-  onDelete,
-}: {
-  card: CreditCard;
-  onEdit: (card: CreditCard) => void;
-  onDelete: (id: string) => Promise<void>;
-}) {
-  return (
-    <tr className="border-b border-line">
-      <td className="px-3 py-3">{card.name}</td>
-      <td className="px-3 py-3">{card.settlementDay ?? "-"}</td>
-      <td className="px-3 py-3">{card.account?.name ?? "未設定"}</td>
-      <td className="px-3 py-3">{formatCurrency(card.assumptionAmount)}</td>
-      <td className="px-3 py-3">{card.sortOrder}</td>
-      <td className="px-3 py-3">
-        <div className="flex justify-end gap-2">
-          <Button variant="ghost" onClick={() => onEdit(card)}>
-            編集
+      <AccountSelect
+        id="credit-card-account"
+        label="引き落とし口座"
+        accounts={accounts}
+        value={form.accountId}
+        onChange={(accountId) => onChange({ ...form, accountId })}
+      />
+
+      <DateShiftField id="credit-card-date-shift" value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
+
+      <Disclosure summary="詳細設定">
+        <FormField label="表示順" htmlFor={sortOrderId}>
+          <Input id={sortOrderId} type="number" value={form.sortOrder} onChange={(event) => onChange({ ...form, sortOrder: Number(event.target.value) })} />
+        </FormField>
+      </Disclosure>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-4">
+        <div className="text-xs text-ink-3">{!canSave && missing.length > 0 ? `必須: ${missing.join("、")}` : ""}</div>
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            キャンセル
           </Button>
-          <Button variant="danger" onClick={() => onDelete(card.id)}>
-            削除
+          <Button type="submit" disabled={!canSave}>
+            {actionLabel}
           </Button>
         </div>
-      </td>
-    </tr>
+      </div>
+    </form>
+  );
+}
+
+function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="grid gap-3 rounded-xl border border-critical/40 bg-critical/10 p-4 text-sm text-ink">
+      <p role="alert">{message}</p>
+      <Button className="justify-self-start" variant="secondary" onClick={onRetry}>
+        再試行
+      </Button>
+    </div>
   );
 }

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -25,6 +25,7 @@ import {
 } from "../components/ui/dialog";
 import { Input } from "../components/ui/input";
 import { Select } from "../components/ui/select";
+import { Switch } from "../components/ui/switch";
 import { Table, TableWrapper } from "../components/ui/table";
 import { useResource } from "../hooks/use-resource";
 import { useToast } from "../hooks/use-toast";
@@ -783,15 +784,10 @@ export function DashboardPage() {
                           onClick={() => openConfirm(event)}
                         >
                           <td className="px-3 py-3" onClick={(clickEvent) => clickEvent.stopPropagation()}>
-                            <input
-                              type="checkbox"
+                            <Switch
                               aria-label={`${event.description} を確定対象にする`}
                               checked={draft.selected}
-                              onChange={(changeEvent) =>
-                                updateOverdueDraft(event, {
-                                  selected: changeEvent.target.checked,
-                                })}
-                              className="h-4 w-4 rounded border-line-strong bg-surface-2"
+                              onChange={(selected) => updateOverdueDraft(event, { selected })}
                               disabled={isBatchConfirming || isConfirmed}
                             />
                           </td>

--- a/packages/frontend/src/routes/data-management.tsx
+++ b/packages/frontend/src/routes/data-management.tsx
@@ -7,6 +7,8 @@ import { useState } from "react";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { Input } from "../components/ui/input";
+import { SwitchField } from "../components/ui/switch";
+import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 
 type DataKey =
@@ -136,6 +138,7 @@ export function DataManagementPage() {
   const [importResult, setImportResult] = useState<DataImportCounts | null>(null);
   const [confirmed, setConfirmed] = useState(false);
   const [importing, setImporting] = useState(false);
+  const { toast } = useToast();
 
   const handleExport = async () => {
     setExporting(true);
@@ -150,8 +153,11 @@ export function DataManagementPage() {
       const blob = await response.blob();
       downloadBlob(blob, parseFilename(response.headers.get("Content-Disposition")));
       setExportMessage("エクスポートファイルをダウンロードしました。");
+      toast({ title: "エクスポートファイルをダウンロードしました" });
     } catch (error) {
-      setExportMessage(error instanceof Error ? error.message : "エクスポートに失敗しました。");
+      const message = error instanceof Error ? error.message : "エクスポートに失敗しました。";
+      setExportMessage(message);
+      toast({ title: "エクスポートに失敗しました", description: message, variant: "error" });
     } finally {
       setExporting(false);
     }
@@ -196,8 +202,11 @@ export function DataManagementPage() {
       setPreview(null);
       setConfirmed(false);
       setFileInputKey((value) => value + 1);
+      toast({ title: "インポートが完了しました" });
     } catch (error) {
-      setImportMessage(error instanceof Error ? error.message : "インポートに失敗しました。");
+      const message = error instanceof Error ? error.message : "インポートに失敗しました。";
+      setImportMessage(message);
+      toast({ title: "インポートに失敗しました", description: message, variant: "error" });
     } finally {
       setImporting(false);
     }
@@ -253,15 +262,11 @@ export function DataManagementPage() {
                   </div>
                 ))}
               </dl>
-              <label className="flex items-start gap-3 text-sm text-ink">
-                <input
-                  checked={confirmed}
-                  className="mt-1 h-4 w-4 accent-primary"
-                  type="checkbox"
-                  onChange={(event) => setConfirmed(event.target.checked)}
-                />
-                <span>既存の全データが置き換えられることを確認しました。</span>
-              </label>
+              <SwitchField
+                label="既存の全データが置き換えられることを確認しました。"
+                checked={confirmed}
+                onChange={setConfirmed}
+              />
               <Button
                 className="min-h-11 justify-self-start"
                 disabled={!confirmed || importing}

--- a/packages/frontend/src/routes/loans.tsx
+++ b/packages/frontend/src/routes/loans.tsx
@@ -1,13 +1,20 @@
 import type { Account, DateShiftPolicy, Loan, LoanPaymentMethod } from "@sui/shared";
-import { startTransition, useState } from "react";
-import { Button } from "../components/ui/button";
+import { useEffect, useId, useRef, useState, startTransition } from "react";
+import { AccountSelect, DateShiftField } from "../components/form-fields";
+import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
+import { ConditionalField } from "../components/ui/conditional-field";
+import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../components/ui/dialog";
+import { FormField } from "../components/ui/form-field";
 import { Input } from "../components/ui/input";
-import { Select } from "../components/ui/select";
+import { MoneyInput } from "../components/ui/money-input";
+import { SegmentedControl } from "../components/ui/segmented-control";
 import { useResource } from "../hooks/use-resource";
+import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import { formatCurrency, formatDateWithYear } from "../lib/format";
+import { Pencil, Trash2 } from "lucide-react";
 
 type LoanForm = {
   name: string;
@@ -29,6 +36,16 @@ const emptyForm: LoanForm = {
   accountId: "",
 };
 
+const paymentMethodOptions = [
+  { value: "account_withdrawal", label: "口座引落し" },
+  { value: "credit_card", label: "クレカ分割" },
+] as const;
+
+const entryModeOptions = [
+  { value: "normal", label: "最初から入力する" },
+  { value: "midway", label: "途中から入力する" },
+] as const;
+
 function parseNumber(value: string) {
   return Number(value === "" ? 0 : value);
 }
@@ -49,6 +66,14 @@ function buildLoanPayload(form: LoanForm, totalAmount: number) {
   };
 }
 
+function getEffectiveTotalAmount(totalAmount: number, remainingBalance: number, midwayMode: boolean) {
+  return midwayMode ? remainingBalance : totalAmount;
+}
+
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : "不明なエラーが発生しました。";
+}
+
 export function LoansPage() {
   const [reloadKey, setReloadKey] = useState(0);
   const [form, setForm] = useState<LoanForm>(emptyForm);
@@ -59,6 +84,8 @@ export function LoansPage() {
   const [editForm, setEditForm] = useState<LoanForm>(emptyForm);
   const [editMidwayMode, setEditMidwayMode] = useState(false);
   const [editRemainingBalance, setEditRemainingBalance] = useState(0);
+  const [deletingLoan, setDeletingLoan] = useState<Loan | null>(null);
+  const { toast } = useToast();
 
   const { data, loading, error } = useResource(
     () =>
@@ -87,16 +114,21 @@ export function LoansPage() {
   const reload = () => startTransition(() => setReloadKey((value) => value + 1));
 
   const createLoan = async () => {
-    await apiFetch("/api/loans", {
-      method: "POST",
-      body: JSON.stringify(buildLoanPayload(form, getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode))),
-    });
-
-    setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
-    setMidwayMode(false);
-    setRemainingBalance(0);
-    setCreateOpen(false);
-    reload();
+    try {
+      await apiFetch("/api/loans", {
+        method: "POST",
+        body: JSON.stringify(buildLoanPayload(form, getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode))),
+      });
+      const name = form.name;
+      setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
+      setMidwayMode(false);
+      setRemainingBalance(0);
+      setCreateOpen(false);
+      reload();
+      toast({ title: `${name} を追加しました` });
+    } catch (createError) {
+      toast({ title: "ローンの追加に失敗しました", description: describeError(createError), variant: "error" });
+    }
   };
 
   const updateLoan = async (loanId: string, nextForm: LoanForm, nextRemainingBalance: number, nextMidwayMode: boolean) => {
@@ -109,13 +141,21 @@ export function LoansPage() {
     reload();
   };
 
-  const deleteLoan = async (loanId: string) => {
-    if (!window.confirm("このローンを削除します。よろしいですか？")) {
+  const requestDelete = (loan: Loan) => setDeletingLoan(loan);
+
+  const confirmDelete = async () => {
+    if (!deletingLoan) {
       return;
     }
 
-    await apiFetch(`/api/loans/${loanId}`, { method: "DELETE" });
-    reload();
+    try {
+      await apiFetch(`/api/loans/${deletingLoan.id}`, { method: "DELETE" });
+      toast({ title: `${deletingLoan.name} を削除しました` });
+      setDeletingLoan(null);
+      reload();
+    } catch (deleteError) {
+      toast({ title: "削除に失敗しました", description: describeError(deleteError), variant: "error" });
+    }
   };
 
   const openEdit = (loan: Loan) => {
@@ -145,8 +185,13 @@ export function LoansPage() {
       return;
     }
 
-    await updateLoan(editingLoan.id, editForm, editRemainingBalance, editMidwayMode);
-    closeEdit();
+    try {
+      await updateLoan(editingLoan.id, editForm, editRemainingBalance, editMidwayMode);
+      closeEdit();
+      toast({ title: `${editForm.name} を更新しました` });
+    } catch (updateError) {
+      toast({ title: "更新に失敗しました", description: describeError(updateError), variant: "error" });
+    }
   };
 
   const closeCreate = () => {
@@ -174,13 +219,19 @@ export function LoansPage() {
           <h2 className="text-xl font-semibold">ローン一覧</h2>
           <div className="text-sm text-ink-2">{loading ? "読み込み中..." : `${loans.length} 件`}</div>
         </div>
-        {loans.map((loan) => (
-          <LoanRow key={loan.id} loan={loan} accounts={accounts} onEdit={openEdit} onDelete={deleteLoan} />
-        ))}
+        {error ? (
+          <ErrorBlock message={error} onRetry={reload} />
+        ) : loans.length === 0 ? (
+          <p className="text-sm text-ink-3">ローンが登録されていません。</p>
+        ) : (
+          loans.map((loan) => (
+            <LoanRow key={loan.id} loan={loan} accounts={accounts} onEdit={openEdit} onDelete={requestDelete} />
+          ))
+        )}
       </Card>
 
       <Dialog open={Boolean(editingLoan)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(94vw,40rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">ローンを編集</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-ink-2">
             途中参入モードを含めてローン情報を更新します。
@@ -200,83 +251,37 @@ export function LoansPage() {
         </DialogContent>
       </Dialog>
 
-      <LoanCreateModal
-        open={createOpen}
-        accounts={accounts}
-        form={form}
-        midwayMode={midwayMode}
-        remainingBalance={remainingBalance}
-        canCreate={canCreate}
-        loading={loading}
-        error={error}
-        onOpenChange={(open) => {
-          if (open) {
-            setCreateOpen(true);
-          } else {
-            closeCreate();
-          }
-        }}
-        onFormChange={setForm}
-        onRemainingBalanceChange={setRemainingBalance}
-        onMidwayModeChange={setMidwayMode}
-        onCreate={createLoan}
+      <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
+        <DialogContent size="m">
+          <DialogTitle className="text-lg font-semibold">ローンを追加</DialogTitle>
+          <DialogDescription className="mt-2 text-sm text-ink-2">
+            途中参入モードを含めてローン情報を登録します。
+          </DialogDescription>
+          <LoanEditModal
+            accounts={accounts}
+            form={form}
+            midwayMode={midwayMode}
+            remainingBalance={remainingBalance}
+            canSave={canCreate}
+            actionLabel="追加"
+            helperText="クレカ分割は取引予測には反映されません。"
+            onFormChange={setForm}
+            onRemainingBalanceChange={setRemainingBalance}
+            onMidwayModeChange={setMidwayMode}
+            onCancel={closeCreate}
+            onSave={createLoan}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(deletingLoan)}
+        onOpenChange={(open) => !open && setDeletingLoan(null)}
+        title="ローンを削除しますか？"
+        description={deletingLoan ? `「${deletingLoan.name}」を削除します。この操作は取り消せません。` : undefined}
+        onConfirm={confirmDelete}
       />
     </div>
-  );
-}
-
-function LoanCreateModal({
-  open,
-  accounts,
-  form,
-  midwayMode,
-  remainingBalance,
-  canCreate,
-  loading,
-  error,
-  onOpenChange,
-  onFormChange,
-  onRemainingBalanceChange,
-  onMidwayModeChange,
-  onCreate,
-}: {
-  open: boolean;
-  accounts: Account[];
-  form: LoanForm;
-  midwayMode: boolean;
-  remainingBalance: number;
-  canCreate: boolean;
-  loading: boolean;
-  error: string | null;
-  onOpenChange: (open: boolean) => void;
-  onFormChange: (next: LoanForm) => void;
-  onRemainingBalanceChange: (value: number) => void;
-  onMidwayModeChange: (value: boolean) => void;
-  onCreate: () => Promise<void>;
-}) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[min(94vw,40rem)]">
-        <DialogTitle className="text-lg font-semibold">ローンを追加</DialogTitle>
-        <DialogDescription className="mt-2 text-sm text-ink-2">
-          途中参入モードを含めてローン情報を登録します。
-        </DialogDescription>
-        <LoanEditModal
-          accounts={accounts}
-          form={form}
-          midwayMode={midwayMode}
-          remainingBalance={remainingBalance}
-          canSave={canCreate}
-          actionLabel="追加"
-          helperText={loading ? "読み込み中..." : error ?? "クレカ分割は取引予測には反映されません。"}
-          onFormChange={onFormChange}
-          onRemainingBalanceChange={onRemainingBalanceChange}
-          onMidwayModeChange={onMidwayModeChange}
-          onCancel={() => onOpenChange(false)}
-          onSave={onCreate}
-        />
-      </DialogContent>
-    </Dialog>
   );
 }
 
@@ -289,7 +294,7 @@ function LoanRow({
   loan: Loan;
   accounts: Account[];
   onEdit: (loan: Loan) => void;
-  onDelete: (loanId: string) => Promise<void>;
+  onDelete: (loan: Loan) => void;
 }) {
   return (
     <div className="grid min-w-0 gap-4 rounded-2xl border border-line p-4">
@@ -306,13 +311,13 @@ function LoanRow({
             / 初回引落日 {formatDateWithYear(loan.startDate.slice(0, 10))}
           </div>
         </div>
-        <div className="flex justify-end gap-2">
-          <Button variant="ghost" onClick={() => onEdit(loan)}>
-            編集
-          </Button>
-          <Button variant="danger" onClick={() => onDelete(loan.id)}>
-            削除
-          </Button>
+        <div className="flex justify-end gap-1">
+          <IconButton aria-label="編集" onClick={() => onEdit(loan)}>
+            <Pencil aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+          <IconButton aria-label="削除" variant="danger" onClick={() => onDelete(loan)}>
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
         </div>
       </div>
       <div className="break-words text-sm text-ink-2">
@@ -351,186 +356,120 @@ function LoanEditModal({
   actionLabel?: string;
   helperText?: string;
 }) {
+  const nameId = useId();
+  const amountId = useId();
+  const dateId = useId();
+  const countId = useId();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const effectiveAmount = getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode);
+  const missing: string[] = [];
+  if (form.name.trim().length === 0) missing.push("商品名");
+  if (form.startDate === "") missing.push(midwayMode ? "次回引落日" : "初回引落日");
+  if (form.paymentMethod !== "credit_card" && form.accountId === "") missing.push("引き落とし口座");
+  if (effectiveAmount <= 0) missing.push(midwayMode ? "残り残高" : "総支払額");
+
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
+
   return (
-    <div className="mt-6 grid gap-5">
-      <section className="grid gap-4">
-        <div className="text-xs font-medium text-ink-3">基本情報</div>
-        <label className="grid gap-2 text-sm">
-          <span>商品名 *</span>
-          <Input value={form.name} onChange={(event) => onFormChange({ ...form, name: event.target.value })} />
-        </label>
-        <div className="grid gap-4 md:grid-cols-2">
-          <label className="grid gap-2 text-sm">
-            <span>総支払額 *</span>
-            <Input
-              type="number"
-              min={0}
-              inputMode="numeric"
-              disabled={midwayMode}
-              className={midwayMode ? "bg-surface-2 text-ink-3" : undefined}
-              value={form.totalAmount}
-              onChange={(event) => onFormChange({ ...form, totalAmount: parseNumber(event.target.value) })}
-            />
-          </label>
-          <label className="grid gap-2 text-sm">
-            <span>支払方法 *</span>
-            <Select
-              value={form.paymentMethod}
-              onChange={(event) => {
-                const paymentMethod = event.target.value as LoanPaymentMethod;
-                onFormChange({ ...form, paymentMethod, accountId: paymentMethod === "credit_card" ? "" : form.accountId });
-              }}
-            >
-              <option value="account_withdrawal">口座引落し</option>
-              <option value="credit_card">クレカ分割</option>
-            </Select>
-          </label>
-          {form.paymentMethod === "account_withdrawal" ? (
-            <label className="grid gap-2 text-sm">
-              <span>引き落とし口座 *</span>
-              <Select value={form.accountId} onChange={(event) => onFormChange({ ...form, accountId: event.target.value })}>
-                <option value="">口座を選択</option>
-                {accounts.map((account) => (
-                  <option key={account.id} value={account.id}>
-                    {account.name}
-                  </option>
-                ))}
-              </Select>
-            </label>
-          ) : null}
-          <label className="grid gap-2 text-sm">
-            <span>土日祝の扱い</span>
-            <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onFormChange({ ...form, dateShiftPolicy })} />
-          </label>
-          {!midwayMode ? (
-            <>
-              <label className="grid gap-2 text-sm">
-                <span>初回引落日 *</span>
-                <Input
-                  type="date"
-                  value={form.startDate}
-                  onChange={(event) => onFormChange({ ...form, startDate: event.target.value })}
-                />
-              </label>
-              <label className="grid gap-2 text-sm">
-                <span>支払回数 *</span>
-                <Input
-                  type="number"
-                  min={1}
-                  inputMode="numeric"
-                  value={form.paymentCount}
-                  onChange={(event) => onFormChange({ ...form, paymentCount: parseNumber(event.target.value) })}
-                />
-              </label>
-            </>
-          ) : null}
-        </div>
-      </section>
+    <form
+      className="mt-6 grid gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (canSave) {
+          onSave();
+        }
+      }}
+    >
+      <FormField label="商品名" htmlFor={nameId} required>
+        <Input id={nameId} ref={firstFieldRef} value={form.name} onChange={(event) => onFormChange({ ...form, name: event.target.value })} />
+      </FormField>
 
-      <section className="grid gap-4 border-t border-line pt-4">
-        <div className="text-xs font-medium text-ink-3">途中参入</div>
-        <MidwayToggle enabled={midwayMode} onChange={onMidwayModeChange} />
-        {midwayMode ? (
-          <div className="grid gap-4 md:grid-cols-3">
-            <label className="grid gap-2 text-sm">
-              <span>残り残高 *</span>
-              <Input
-                type="number"
-                min={0}
-                inputMode="numeric"
-                value={remainingBalance}
-                onChange={(event) => onRemainingBalanceChange(parseNumber(event.target.value))}
-              />
-            </label>
-            <label className="grid gap-2 text-sm">
-              <span>次回引落日 *</span>
-              <Input
-                type="date"
-                value={form.startDate}
-                onChange={(event) => onFormChange({ ...form, startDate: event.target.value })}
-              />
-            </label>
-            <label className="grid gap-2 text-sm">
-              <span>残り回数 *</span>
-              <Input
-                type="number"
-                min={1}
-                inputMode="numeric"
-                value={form.paymentCount}
-                onChange={(event) => onFormChange({ ...form, paymentCount: parseNumber(event.target.value) })}
-              />
-            </label>
-          </div>
-        ) : null}
-      </section>
-
-      <section className="grid gap-3 border-t border-line pt-4">
-        <div className="text-xs font-medium text-ink-3">プレビュー</div>
-        <LoanPreview
-          totalAmount={getEffectiveTotalAmount(form.totalAmount, remainingBalance, midwayMode)}
-          paymentCount={form.paymentCount}
+      <FormField label="支払方法" htmlFor="loan-payment-method">
+        <SegmentedControl
+          aria-label="支払方法"
+          value={form.paymentMethod}
+          options={paymentMethodOptions}
+          onChange={(paymentMethod) => onFormChange({ ...form, paymentMethod, accountId: paymentMethod === "credit_card" ? "" : form.accountId })}
         />
-        {helperText ? <div className="text-sm text-ink-2">{helperText}</div> : null}
-      </section>
+      </FormField>
 
-      <div className="flex justify-end gap-3 border-t border-line pt-4">
-        <Button variant="ghost" onClick={onCancel}>
-          キャンセル
-        </Button>
-        <Button disabled={!canSave} onClick={onSave}>
-          {actionLabel}
-        </Button>
+      <FormField label="入力起点" htmlFor="loan-entry-mode">
+        <SegmentedControl
+          aria-label="入力起点"
+          value={midwayMode ? "midway" : "normal"}
+          options={entryModeOptions}
+          onChange={(mode) => onMidwayModeChange(mode === "midway")}
+        />
+      </FormField>
+
+      <FormField label={midwayMode ? "残り残高" : "総支払額"} htmlFor={amountId} required>
+        <MoneyInput
+          id={amountId}
+          currencyCode="JPY"
+          value={midwayMode ? remainingBalance : form.totalAmount}
+          onChange={(value) => (midwayMode ? onRemainingBalanceChange(value) : onFormChange({ ...form, totalAmount: value }))}
+        />
+      </FormField>
+
+      <FormField label={midwayMode ? "次回引落日" : "初回引落日"} htmlFor={dateId} required>
+        <Input id={dateId} type="date" value={form.startDate} onChange={(event) => onFormChange({ ...form, startDate: event.target.value })} />
+      </FormField>
+
+      <FormField label={midwayMode ? "残り回数" : "支払回数"} htmlFor={countId} required>
+        <Input
+          id={countId}
+          type="number"
+          min={1}
+          inputMode="numeric"
+          value={form.paymentCount}
+          onChange={(event) => onFormChange({ ...form, paymentCount: parseNumber(event.target.value) })}
+        />
+      </FormField>
+
+      <ConditionalField show={form.paymentMethod === "account_withdrawal"}>
+        <AccountSelect
+          id="loan-account"
+          label="引き落とし口座"
+          accounts={accounts}
+          value={form.accountId}
+          onChange={(accountId) => onFormChange({ ...form, accountId })}
+        />
+      </ConditionalField>
+
+      <DateShiftField id="loan-date-shift" value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onFormChange({ ...form, dateShiftPolicy })} />
+
+      <div className="grid gap-2 border-l-2 border-line-strong pl-3 text-sm text-ink-2">
+        <div className="text-xs font-medium text-ink-3">プレビュー</div>
+        <div>
+          月々の支払額プレビュー: <span className="font-data font-semibold text-ink">{formatCurrency(getPreviewAmount(effectiveAmount, form.paymentCount))}</span>
+        </div>
+        {helperText ? <div className="text-xs text-ink-3">{helperText}</div> : null}
       </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-4">
+        <div className="text-xs text-ink-3">{!canSave && missing.length > 0 ? `必須: ${missing.join("、")}` : ""}</div>
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={!canSave}>
+            {actionLabel}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="grid gap-3 rounded-xl border border-critical/40 bg-critical/10 p-4 text-sm text-ink">
+      <p role="alert">{message}</p>
+      <Button className="justify-self-start" variant="secondary" onClick={onRetry}>
+        再試行
+      </Button>
     </div>
   );
-}
-
-function DateShiftSelect({
-  value,
-  onChange,
-}: {
-  value: DateShiftPolicy;
-  onChange: (value: DateShiftPolicy) => void;
-}) {
-  return (
-    <Select value={value} onChange={(event) => onChange(event.target.value as DateShiftPolicy)}>
-      <option value="none">シフトなし</option>
-      <option value="previous">前営業日</option>
-      <option value="next">後営業日</option>
-    </Select>
-  );
-}
-
-function MidwayToggle({
-  enabled,
-  onChange,
-}: {
-  enabled: boolean;
-  onChange: (value: boolean) => void;
-}) {
-  return (
-    <label className="flex max-w-full min-w-0 cursor-pointer items-center gap-3 rounded-xl border border-line bg-surface-2 px-4 py-2 text-sm">
-      <input type="checkbox" className="h-4 w-4 shrink-0 accent-[var(--color-primary)]" checked={enabled} onChange={(event) => onChange(event.target.checked)} />
-      <span className="min-w-0 truncate">途中から入力する</span>
-    </label>
-  );
-}
-
-function LoanPreview({
-  totalAmount,
-  paymentCount,
-}: {
-  totalAmount: number;
-  paymentCount: number;
-}) {
-  return (
-    <div className="break-words rounded-r-2xl border-l-2 border-primary bg-surface-2 p-4 text-sm text-ink-2">
-      月々の支払額プレビュー:{" "}
-      <span className="font-semibold text-ink">{formatCurrency(getPreviewAmount(totalAmount, paymentCount))}</span>
-    </div>
-  );
-}
-
-function getEffectiveTotalAmount(totalAmount: number, remainingBalance: number, midwayMode: boolean) {
-  return midwayMode ? remainingBalance : totalAmount;
 }

--- a/packages/frontend/src/routes/recurring.tsx
+++ b/packages/frontend/src/routes/recurring.tsx
@@ -1,14 +1,22 @@
 import type { Account, DateShiftPolicy, RecurringItem, RecurringItemType } from "@sui/shared";
-import { useState, startTransition } from "react";
-import { Button } from "../components/ui/button";
+import { useEffect, useId, useRef, useState, startTransition } from "react";
+import { AccountSelect, DateShiftField, DayOfMonthField, PeriodFields } from "../components/form-fields";
+import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
+import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../components/ui/dialog";
+import { Disclosure } from "../components/ui/disclosure";
+import { FormField } from "../components/ui/form-field";
 import { Input } from "../components/ui/input";
-import { Select } from "../components/ui/select";
-import { Table, TableWrapper } from "../components/ui/table";
+import { MoneyInput } from "../components/ui/money-input";
+import { ResponsiveTable, type ResponsiveTableColumn } from "../components/ui/responsive-table";
+import { SegmentedControl } from "../components/ui/segmented-control";
+import { SwitchField } from "../components/ui/switch";
 import { useResource } from "../hooks/use-resource";
+import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import { formatCurrency, formatDateWithYear } from "../lib/format";
+import { Pencil, Trash2 } from "lucide-react";
 
 type RecurringForm = {
   name: string;
@@ -37,6 +45,12 @@ const emptyForm: RecurringForm = {
   enabled: true,
   sortOrder: 0,
 };
+
+const typeOptions = [
+  { value: "income", label: "収入" },
+  { value: "expense", label: "支出" },
+  { value: "transfer", label: "振替" },
+] as const;
 
 function isPeriodValid(startDate: string | null, endDate: string | null) {
   return !startDate || !endDate || startDate <= endDate;
@@ -76,14 +90,14 @@ function getRecurringTypeLabel(type: RecurringItemType) {
 
 function getAccountLabel(type: RecurringItemType) {
   if (type === "income") {
-    return "振り込み先口座 *";
+    return "振り込み先口座";
   }
 
   if (type === "transfer") {
-    return "振替元口座 *";
+    return "振替元口座";
   }
 
-  return "引き落とし口座 *";
+  return "引き落とし口座";
 }
 
 function getTransferDestinationAccounts(accounts: Account[], sourceAccountId: string) {
@@ -126,6 +140,15 @@ function canSaveRecurringForm(form: RecurringForm, accounts: Account[]) {
   );
 }
 
+function getMissingFields(form: RecurringForm, accounts: Account[]) {
+  const missing: string[] = [];
+  if (form.name.trim().length === 0) missing.push("カテゴリ名");
+  if (form.accountId === "") missing.push("口座");
+  if (form.type === "transfer" && !isTransferDestinationValid(form, accounts)) missing.push("振替先口座");
+  if (!isPeriodValid(form.startDate, form.endDate)) missing.push("期間");
+  return missing;
+}
+
 function toRecurringPayload(form: RecurringForm) {
   return {
     ...form,
@@ -142,12 +165,17 @@ function formatRecurringAccounts(item: RecurringItem) {
   return `${sourceName} → ${item.transferToAccount?.name ?? "未設定"}`;
 }
 
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : "不明なエラーが発生しました。";
+}
+
 export function RecurringPage() {
   const [reloadKey, setReloadKey] = useState(0);
   const [form, setForm] = useState(emptyForm);
   const [createOpen, setCreateOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<RecurringItem | null>(null);
   const [editForm, setEditForm] = useState<RecurringForm>(emptyForm);
+  const [deletingItem, setDeletingItem] = useState<RecurringItem | null>(null);
   const { data, loading, error } = useResource(
     () =>
       Promise.all([
@@ -156,6 +184,7 @@ export function RecurringPage() {
       ]).then(([items, accounts]) => ({ items, accounts })),
     [reloadKey],
   );
+  const { toast } = useToast();
 
   const reload = () => startTransition(() => setReloadKey((value) => value + 1));
   const accounts = data?.accounts ?? [];
@@ -163,13 +192,19 @@ export function RecurringPage() {
   const canSaveEdit = canSaveRecurringForm(editForm, accounts);
 
   const createItem = async () => {
-    await apiFetch("/api/recurring-items", {
-      method: "POST",
-      body: JSON.stringify(toRecurringPayload(form)),
-    });
-    setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
-    setCreateOpen(false);
-    reload();
+    try {
+      await apiFetch("/api/recurring-items", {
+        method: "POST",
+        body: JSON.stringify(toRecurringPayload(form)),
+      });
+      const name = form.name;
+      setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
+      setCreateOpen(false);
+      reload();
+      toast({ title: `${name} を追加しました` });
+    } catch (createError) {
+      toast({ title: "固定収支の追加に失敗しました", description: describeError(createError), variant: "error" });
+    }
   };
 
   const updateItem = async (item: RecurringItem, nextForm: RecurringForm) => {
@@ -180,12 +215,21 @@ export function RecurringPage() {
     reload();
   };
 
-  const deleteItem = async (id: string) => {
-    if (!window.confirm("この固定収支を削除します。よろしいですか？")) {
+  const requestDelete = (item: RecurringItem) => setDeletingItem(item);
+
+  const confirmDelete = async () => {
+    if (!deletingItem) {
       return;
     }
-    await apiFetch(`/api/recurring-items/${id}`, { method: "DELETE" });
-    reload();
+
+    try {
+      await apiFetch(`/api/recurring-items/${deletingItem.id}`, { method: "DELETE" });
+      toast({ title: `${deletingItem.name} を削除しました` });
+      setDeletingItem(null);
+      reload();
+    } catch (deleteError) {
+      toast({ title: "削除に失敗しました", description: describeError(deleteError), variant: "error" });
+    }
   };
 
   const openEdit = (item: RecurringItem) => {
@@ -215,14 +259,44 @@ export function RecurringPage() {
       return;
     }
 
-    await updateItem(editingItem, editForm);
-    closeEdit();
+    try {
+      await updateItem(editingItem, editForm);
+      closeEdit();
+      toast({ title: `${editForm.name} を更新しました` });
+    } catch (updateError) {
+      toast({ title: "更新に失敗しました", description: describeError(updateError), variant: "error" });
+    }
   };
 
   const closeCreate = () => {
     setCreateOpen(false);
     setForm({ ...emptyForm, accountId: accounts[0]?.id ?? "" });
   };
+
+  const columns: ResponsiveTableColumn<RecurringItem>[] = [
+    { key: "name", header: "カテゴリ", render: (item) => item.name },
+    { key: "type", header: "種別", render: (item) => getRecurringTypeLabel(item.type) },
+    { key: "amount", header: "金額", align: "right", mono: true, render: (item) => formatCurrency(item.amount) },
+    { key: "day", header: "日", mono: true, render: (item) => item.dayOfMonth },
+    { key: "period", header: "期間", render: (item) => formatPeriod(item.startDate, item.endDate) },
+    { key: "account", header: "対象口座", render: (item) => formatRecurringAccounts(item) },
+    { key: "sortOrder", header: "順序", mono: true, render: (item) => item.sortOrder },
+    { key: "enabled", header: "有効", render: (item) => (item.enabled ? "有効" : "無効") },
+    {
+      key: "actions",
+      header: "",
+      render: (item) => (
+        <div className="flex justify-end gap-1">
+          <IconButton aria-label="編集" onClick={() => openEdit(item)}>
+            <Pencil aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+          <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(item)}>
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+        </div>
+      ),
+    },
+  ];
 
   return (
     <div className="grid gap-6">
@@ -240,43 +314,46 @@ export function RecurringPage() {
       <Card>
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-xl font-semibold">固定収支一覧</h2>
-          <div className="text-sm text-ink-2">{loading ? "読み込み中..." : error ?? `${data?.items.length ?? 0} 件`}</div>
+          <div className="text-sm text-ink-2">{loading ? "読み込み中..." : `${data?.items.length ?? 0} 件`}</div>
         </div>
-        <TableWrapper>
-          <Table className="min-w-[64rem]">
-            <thead>
-              <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                <th className="px-3 py-3">カテゴリ</th>
-                <th className="px-3 py-3">種別</th>
-                <th className="px-3 py-3">金額</th>
-                <th className="px-3 py-3">日</th>
-                <th className="px-3 py-3">期間</th>
-                <th className="px-3 py-3">対象口座</th>
-                <th className="px-3 py-3">順序</th>
-                <th className="px-3 py-3">有効</th>
-                <th className="px-3 py-3" />
-              </tr>
-            </thead>
-            <tbody>
-              {(data?.items ?? []).map((item) => (
-                <RecurringRow
-                  key={item.id}
-                  item={item}
-                  onEdit={openEdit}
-                  onDelete={deleteItem}
-                />
-              ))}
-            </tbody>
-          </Table>
-        </TableWrapper>
+        {error ? (
+          <ErrorBlock message={error} onRetry={reload} />
+        ) : (
+          <ResponsiveTable
+            columns={columns}
+            rows={data?.items ?? []}
+            rowKey={(item) => item.id}
+            emptyMessage="固定収支が登録されていません。"
+            mobileRow={(item) => (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{item.name}</div>
+                    <div className="text-xs text-ink-3">{getRecurringTypeLabel(item.type)}・毎月 {item.dayOfMonth} 日</div>
+                  </div>
+                  <div className="font-data text-base font-semibold">{formatCurrency(item.amount)}</div>
+                </div>
+                <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
+                  <span>{formatRecurringAccounts(item)}・{item.enabled ? "有効" : "無効"}</span>
+                  <div className="flex gap-1">
+                    <IconButton aria-label="編集" onClick={() => openEdit(item)}>
+                      <Pencil aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                    <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(item)}>
+                      <Trash2 aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                  </div>
+                </div>
+              </>
+            )}
+          />
+        )}
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(94vw,36rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">固定収支を追加</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            固定収支の内容を登録します。
-          </DialogDescription>
+          <DialogDescription className="mt-2 text-sm text-ink-2">固定収支の内容を登録します。</DialogDescription>
           <RecurringEditModal
             accounts={accounts}
             form={form}
@@ -290,11 +367,9 @@ export function RecurringPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingItem)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(94vw,36rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">固定収支を編集</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            固定収支の内容を更新します。
-          </DialogDescription>
+          <DialogDescription className="mt-2 text-sm text-ink-2">固定収支の内容を更新します。</DialogDescription>
           <RecurringEditModal
             accounts={accounts}
             form={editForm}
@@ -305,6 +380,14 @@ export function RecurringPage() {
           />
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(deletingItem)}
+        onOpenChange={(open) => !open && setDeletingItem(null)}
+        title="固定収支を削除しますか？"
+        description={deletingItem ? `「${deletingItem.name}」を削除します。この操作は取り消せません。` : undefined}
+        onConfirm={confirmDelete}
+      />
     </div>
   );
 }
@@ -327,177 +410,111 @@ function RecurringEditModal({
   actionLabel?: string;
 }) {
   const transferDestinationAccounts = getTransferDestinationAccounts(accounts, form.accountId);
+  const nameId = useId();
+  const amountId = useId();
+  const dateShiftId = useId();
+  const sortOrderId = useId();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const missing = getMissingFields(form, accounts);
+
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
 
   return (
-    <div className="mt-6 grid gap-5">
-      <section className="grid gap-4">
-        <div className="text-xs font-medium text-ink-3">基本情報</div>
-        <label className="grid gap-2 text-sm">
-          <span>カテゴリ名 *</span>
-          <Input required value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
-        </label>
-        <div className="grid gap-4 md:grid-cols-3">
-          <label className="grid gap-2 text-sm">
-            <span>種別</span>
-            <Select
-              value={form.type}
-              onChange={(event) => {
-                const nextForm = {
-                  ...form,
-                  type: event.target.value as RecurringItemType,
-                };
-                onChange({
-                  ...nextForm,
-                  transferToAccountId: normalizeTransferToAccountId(nextForm, accounts),
-                });
-              }}
-            >
-              <option value="income">収入</option>
-              <option value="expense">支出</option>
-              <option value="transfer">振替</option>
-            </Select>
-          </label>
-          <label className="grid gap-2 text-sm">
-            <span>金額 (円)</span>
-            <Input type="number" value={form.amount} onChange={(event) => onChange({ ...form, amount: Number(event.target.value) })} />
-          </label>
-          <label className="grid gap-2 text-sm">
-            <span>毎月の発生日</span>
-            <Input type="number" min={1} max={31} value={form.dayOfMonth} onChange={(event) => onChange({ ...form, dayOfMonth: Number(event.target.value) })} />
-          </label>
-        </div>
-      </section>
+    <form
+      className="mt-6 grid gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (canSave) {
+          onSave();
+        }
+      }}
+    >
+      <FormField label="カテゴリ名" htmlFor={nameId} required>
+        <Input id={nameId} ref={firstFieldRef} required value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
+      </FormField>
 
-      <section className="grid gap-3 border-t border-line pt-4">
-        <div className="text-xs font-medium text-ink-3">期間</div>
-        <div className="grid gap-4 md:grid-cols-2">
-          <label className="grid gap-2 text-sm">
-            <span>開始日</span>
-            <Input type="date" value={form.startDate ?? ""} onChange={(event) => onChange({ ...form, startDate: parseOptionalDate(event.target.value) })} />
-          </label>
-          <label className="grid gap-2 text-sm">
-            <span>終了日</span>
-            <Input type="date" value={form.endDate ?? ""} onChange={(event) => onChange({ ...form, endDate: parseOptionalDate(event.target.value) })} />
-          </label>
-        </div>
-        <div className="text-xs text-ink-3">(空欄で無期限)</div>
-        {!isPeriodValid(form.startDate, form.endDate) ? (
-          <div className="text-sm text-sky-200">開始日は終了日以前にしてください。</div>
-        ) : null}
-      </section>
+      <FormField label="種別" htmlFor="recurring-type">
+        <SegmentedControl
+          aria-label="種別"
+          value={form.type}
+          options={typeOptions}
+          onChange={(type) => {
+            const nextForm = { ...form, type };
+            onChange({ ...nextForm, transferToAccountId: normalizeTransferToAccountId(nextForm, accounts) });
+          }}
+        />
+      </FormField>
 
-      <section className="grid gap-4 border-t border-line pt-4">
-        <div className="text-xs font-medium text-ink-3">口座・その他</div>
-        <label className="grid gap-2 text-sm">
-          <span>{getAccountLabel(form.type)}</span>
-          <Select
-            value={form.accountId}
-            onChange={(event) => {
-              const nextForm = { ...form, accountId: event.target.value };
-              onChange({
-                ...nextForm,
-                transferToAccountId: normalizeTransferToAccountId(nextForm, accounts),
-              });
-            }}
-          >
-            <option value="">口座を選択</option>
-            {accounts.map((account) => (
-              <option key={account.id} value={account.id}>
-                {account.name}
-              </option>
-            ))}
-          </Select>
-        </label>
-        {form.type === "transfer" ? (
-          <label className="grid gap-2 text-sm">
-            <span>振替先口座 *</span>
-            <Select
-              value={form.transferToAccountId}
-              onChange={(event) => onChange({ ...form, transferToAccountId: event.target.value })}
-              disabled={form.accountId === ""}
-            >
-              <option value="">口座を選択</option>
-              {transferDestinationAccounts.map((account) => (
-                <option key={account.id} value={account.id}>
-                  {account.name}
-                </option>
-              ))}
-            </Select>
-          </label>
-        ) : null}
-        <label className="grid gap-2 text-sm">
-          <span>土日祝の扱い</span>
-          <DateShiftSelect value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
-        </label>
-        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_8rem] md:items-end">
-          <label className="grid gap-2 text-sm">
-            <span>表示順</span>
-            <Input type="number" value={form.sortOrder} onChange={(event) => onChange({ ...form, sortOrder: Number(event.target.value) })} />
-          </label>
-          <label className="flex h-11 items-center justify-center gap-3 rounded-xl border border-line px-4 text-sm">
-            <input aria-label="有効/無効" type="checkbox" checked={form.enabled} onChange={(event) => onChange({ ...form, enabled: event.target.checked })} />
-            <span>有効</span>
-          </label>
-        </div>
-      </section>
+      <FormField label="金額 (円)" htmlFor={amountId} required>
+        <MoneyInput id={amountId} currencyCode="JPY" value={form.amount} onChange={(value) => onChange({ ...form, amount: value })} />
+      </FormField>
 
-      <div className="flex justify-end gap-3 border-t border-line pt-4">
-        <Button variant="ghost" onClick={onCancel}>
-          キャンセル
-        </Button>
-        <Button disabled={!canSave} onClick={onSave}>
-          {actionLabel}
-        </Button>
+      <DayOfMonthField id="recurring-day" value={form.dayOfMonth} onChange={(value) => onChange({ ...form, dayOfMonth: value ?? 1 })} />
+
+      <PeriodFields
+        idPrefix="recurring-period"
+        startDate={form.startDate ?? ""}
+        endDate={form.endDate ?? ""}
+        onChangeStartDate={(value) => onChange({ ...form, startDate: parseOptionalDate(value) })}
+        onChangeEndDate={(value) => onChange({ ...form, endDate: parseOptionalDate(value) })}
+        error={!isPeriodValid(form.startDate, form.endDate) ? "開始日は終了日以前にしてください。" : null}
+      />
+
+      <AccountSelect
+        id="recurring-account"
+        label={getAccountLabel(form.type)}
+        accounts={accounts}
+        value={form.accountId}
+        onChange={(accountId) => {
+          const nextForm = { ...form, accountId };
+          onChange({ ...nextForm, transferToAccountId: normalizeTransferToAccountId(nextForm, accounts) });
+        }}
+      />
+
+      {form.type === "transfer" ? (
+        <AccountSelect
+          id="recurring-transfer-account"
+          label="振替先口座"
+          accounts={transferDestinationAccounts}
+          value={form.transferToAccountId}
+          onChange={(accountId) => onChange({ ...form, transferToAccountId: accountId })}
+          disabled={form.accountId === ""}
+        />
+      ) : null}
+
+      <DateShiftField id={dateShiftId} value={form.dateShiftPolicy} onChange={(dateShiftPolicy) => onChange({ ...form, dateShiftPolicy })} />
+
+      <Disclosure summary="詳細設定">
+        <FormField label="表示順" htmlFor={sortOrderId}>
+          <Input id={sortOrderId} type="number" inputMode="numeric" value={form.sortOrder} onChange={(event) => onChange({ ...form, sortOrder: Number(event.target.value) })} />
+        </FormField>
+        <SwitchField label="有効" checked={form.enabled} onChange={(enabled) => onChange({ ...form, enabled })} />
+      </Disclosure>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-4">
+        <div className="text-xs text-ink-3">{!canSave && missing.length > 0 ? `必須: ${missing.join("、")}` : ""}</div>
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={!canSave}>
+            {actionLabel}
+          </Button>
+        </div>
       </div>
+    </form>
+  );
+}
+
+function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="grid gap-3 rounded-xl border border-critical/40 bg-critical/10 p-4 text-sm text-ink">
+      <p role="alert">{message}</p>
+      <Button className="justify-self-start" variant="secondary" onClick={onRetry}>
+        再試行
+      </Button>
     </div>
-  );
-}
-
-function DateShiftSelect({
-  value,
-  onChange,
-}: {
-  value: DateShiftPolicy;
-  onChange: (value: DateShiftPolicy) => void;
-}) {
-  return (
-    <Select value={value} onChange={(event) => onChange(event.target.value as DateShiftPolicy)}>
-      <option value="none">シフトなし</option>
-      <option value="previous">前営業日</option>
-      <option value="next">後営業日</option>
-    </Select>
-  );
-}
-
-function RecurringRow({
-  item,
-  onEdit,
-  onDelete,
-}: {
-  item: RecurringItem;
-  onEdit: (item: RecurringItem) => void;
-  onDelete: (id: string) => Promise<void>;
-}) {
-  return (
-    <tr className="border-b border-line">
-      <td className="px-3 py-3">{item.name}</td>
-      <td className="px-3 py-3">{getRecurringTypeLabel(item.type)}</td>
-      <td className="font-data px-3 py-3">{formatCurrency(item.amount)}</td>
-      <td className="px-3 py-3">{item.dayOfMonth}</td>
-      <td className="px-3 py-3">{formatPeriod(item.startDate, item.endDate)}</td>
-      <td className="px-3 py-3">{formatRecurringAccounts(item)}</td>
-      <td className="px-3 py-3">{item.sortOrder}</td>
-      <td className="px-3 py-3 text-center">{item.enabled ? "有効" : "無効"}</td>
-      <td className="px-3 py-3">
-        <div className="flex justify-end gap-2">
-          <Button variant="ghost" onClick={() => onEdit(item)}>
-            編集
-          </Button>
-          <Button variant="danger" onClick={() => onDelete(item.id)}>
-            削除
-          </Button>
-        </div>
-      </td>
-    </tr>
   );
 }

--- a/packages/frontend/src/routes/subscriptions.tsx
+++ b/packages/frontend/src/routes/subscriptions.tsx
@@ -4,18 +4,24 @@ import type {
   CreditCard,
   Subscription,
 } from "@sui/shared";
-import { startTransition, useState } from "react";
-import { Button } from "../components/ui/button";
+import { useEffect, useId, useRef, useState, startTransition } from "react";
+import { DayOfMonthField } from "../components/form-fields";
+import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
+import { ConditionalField } from "../components/ui/conditional-field";
+import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../components/ui/dialog";
+import { FormField } from "../components/ui/form-field";
 import { Input } from "../components/ui/input";
+import { MoneyInput } from "../components/ui/money-input";
+import { ResponsiveTable, type ResponsiveTableColumn } from "../components/ui/responsive-table";
 import { Select } from "../components/ui/select";
-import { Table, TableWrapper } from "../components/ui/table";
 import { useResource } from "../hooks/use-resource";
+import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import { formatCurrency, formatDateWithYear } from "../lib/format";
-import { cn } from "../lib/utils";
 import { getCurrentYearMonth, getTodayDate } from "../lib/utils";
+import { Pencil, Trash2 } from "lucide-react";
 
 type SubscriptionForm = CreateSubscriptionPayload;
 
@@ -140,6 +146,10 @@ function getPaymentSourceOptions(accounts: Account[], cards: CreditCard[]) {
   ).sort((left, right) => left.localeCompare(right, "ja-JP"));
 }
 
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : "不明なエラーが発生しました。";
+}
+
 export function SubscriptionsPage() {
   const [reloadKey, setReloadKey] = useState(0);
   const [yearMonth, setYearMonth] = useState(getCurrentYearMonth());
@@ -147,6 +157,8 @@ export function SubscriptionsPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editingSubscription, setEditingSubscription] = useState<Subscription | null>(null);
   const [editForm, setEditForm] = useState<SubscriptionForm>(emptyForm);
+  const [deletingSubscription, setDeletingSubscription] = useState<Subscription | null>(null);
+  const { toast } = useToast();
 
   const { data, loading, error } = useResource(
     () =>
@@ -182,13 +194,19 @@ export function SubscriptionsPage() {
     isPeriodValid(editForm.startDate, editForm.endDate);
 
   const createSubscription = async () => {
-    await apiFetch("/api/subscriptions", {
-      method: "POST",
-      body: JSON.stringify(form),
-    });
-    setForm(emptyForm);
-    setCreateOpen(false);
-    reload();
+    try {
+      await apiFetch("/api/subscriptions", {
+        method: "POST",
+        body: JSON.stringify(form),
+      });
+      const name = form.name;
+      setForm(emptyForm);
+      setCreateOpen(false);
+      reload();
+      toast({ title: `${name} を追加しました` });
+    } catch (createError) {
+      toast({ title: "サブスクの追加に失敗しました", description: describeError(createError), variant: "error" });
+    }
   };
 
   const updateSubscription = async (subscription: Subscription) => {
@@ -207,13 +225,21 @@ export function SubscriptionsPage() {
     reload();
   };
 
-  const deleteSubscription = async (id: string) => {
-    if (!window.confirm("このサブスクを削除します。よろしいですか？")) {
+  const requestDelete = (subscription: Subscription) => setDeletingSubscription(subscription);
+
+  const confirmDelete = async () => {
+    if (!deletingSubscription) {
       return;
     }
 
-    await apiFetch(`/api/subscriptions/${id}`, { method: "DELETE" });
-    reload();
+    try {
+      await apiFetch(`/api/subscriptions/${deletingSubscription.id}`, { method: "DELETE" });
+      toast({ title: `${deletingSubscription.name} を削除しました` });
+      setDeletingSubscription(null);
+      reload();
+    } catch (deleteError) {
+      toast({ title: "削除に失敗しました", description: describeError(deleteError), variant: "error" });
+    }
   };
 
   const openEdit = (subscription: Subscription) => {
@@ -239,17 +265,43 @@ export function SubscriptionsPage() {
       return;
     }
 
-    await updateSubscription({
-      ...editingSubscription,
-      ...editForm,
-    });
-    closeEdit();
+    try {
+      await updateSubscription({ ...editingSubscription, ...editForm });
+      closeEdit();
+      toast({ title: `${editForm.name} を更新しました` });
+    } catch (updateError) {
+      toast({ title: "更新に失敗しました", description: describeError(updateError), variant: "error" });
+    }
   };
 
   const closeCreate = () => {
     setCreateOpen(false);
     setForm(emptyForm);
   };
+
+  const columns: ResponsiveTableColumn<Subscription>[] = [
+    { key: "name", header: "サービス", render: (subscription) => subscription.name },
+    { key: "amount", header: "金額", align: "right", mono: true, render: (subscription) => formatCurrency(subscription.amount) },
+    { key: "interval", header: "頻度", render: (subscription) => formatInterval(subscription.intervalMonths) },
+    { key: "day", header: "課金日", render: (subscription) => `毎月 ${subscription.dayOfMonth} 日` },
+    { key: "start", header: "開始日", render: (subscription) => formatDateWithYear(subscription.startDate) },
+    { key: "period", header: "期間", render: (subscription) => formatPeriod(subscription.startDate, subscription.endDate) },
+    { key: "source", header: "支払い元", render: (subscription) => subscription.paymentSource ?? "未設定" },
+    {
+      key: "actions",
+      header: "",
+      render: (subscription) => (
+        <div className="flex justify-end gap-1">
+          <IconButton aria-label="編集" onClick={() => openEdit(subscription)}>
+            <Pencil aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+          <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(subscription)}>
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+        </div>
+      ),
+    },
+  ];
 
   return (
     <div className="grid gap-6">
@@ -288,7 +340,7 @@ export function SubscriptionsPage() {
         <div className="min-w-0 rounded-lg border border-line bg-surface-2 p-4">
           <div className="text-sm font-medium text-ink-3">件数</div>
           <div className="mt-3 break-words text-2xl font-semibold sm:text-3xl">
-            {loading ? "読み込み中..." : error ?? `${subscriptions.length}件`}
+            {loading ? "読み込み中..." : `${subscriptions.length}件`}
           </div>
           <div className="mt-2 text-sm text-ink-2">登録済みサブスク</div>
         </div>
@@ -314,75 +366,70 @@ export function SubscriptionsPage() {
           </div>
           <div className="text-sm text-ink-2">{monthlySummary.items.length} 件</div>
         </div>
-        <TableWrapper>
-          <Table className="min-w-[56rem]">
-            <thead>
-              <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                <th className="px-3 py-3">サービス</th>
-                <th className="px-3 py-3">課金日</th>
-                <th className="px-3 py-3">頻度</th>
-                <th className="px-3 py-3">金額</th>
-                <th className="px-3 py-3">支払い元</th>
-              </tr>
-            </thead>
-            <tbody>
-              {monthlySummary.items.length === 0 ? (
-                <tr>
-                  <td className="px-3 py-6 text-sm text-ink-3" colSpan={5}>
-                    この月に課金されるサブスクはありません。
-                  </td>
-                </tr>
-              ) : (
-                monthlySummary.items.map((subscription) => (
-                  <tr key={`${subscription.id}-${yearMonth}`} className="border-b border-line">
-                    <td className="px-3 py-3">{subscription.name}</td>
-                    <td className="px-3 py-3">毎月 {subscription.dayOfMonth} 日</td>
-                    <td className="px-3 py-3">{formatInterval(subscription.intervalMonths)}</td>
-                    <td className="font-data px-3 py-3">{formatCurrency(subscription.amount)}</td>
-                    <td className="px-3 py-3">{subscription.paymentSource ?? "未設定"}</td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </Table>
-        </TableWrapper>
+        <ResponsiveTable
+          columns={[
+            { key: "name", header: "サービス", render: (subscription: Subscription) => subscription.name },
+            { key: "day", header: "課金日", render: (subscription: Subscription) => `毎月 ${subscription.dayOfMonth} 日` },
+            { key: "interval", header: "頻度", render: (subscription: Subscription) => formatInterval(subscription.intervalMonths) },
+            { key: "amount", header: "金額", align: "right", mono: true, render: (subscription: Subscription) => formatCurrency(subscription.amount) },
+            { key: "source", header: "支払い元", render: (subscription: Subscription) => subscription.paymentSource ?? "未設定" },
+          ]}
+          rows={monthlySummary.items}
+          rowKey={(subscription) => `${subscription.id}-${yearMonth}`}
+          emptyMessage="この月に課金されるサブスクはありません。"
+          mobileRow={(subscription) => (
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate font-medium">{subscription.name}</div>
+                <div className="text-xs text-ink-3">毎月 {subscription.dayOfMonth} 日・{formatInterval(subscription.intervalMonths)}</div>
+              </div>
+              <div className="font-data">{formatCurrency(subscription.amount)}</div>
+            </div>
+          )}
+        />
       </Card>
 
       <Card>
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-xl font-semibold">サブスク一覧</h2>
-          <div className="text-sm text-ink-2">{loading ? "読み込み中..." : error ?? `${subscriptions.length} 件`}</div>
+          <div className="text-sm text-ink-2">{loading ? "読み込み中..." : `${subscriptions.length} 件`}</div>
         </div>
-        <TableWrapper>
-          <Table className="min-w-[72rem]">
-            <thead>
-              <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                <th className="px-3 py-3">サービス</th>
-                <th className="px-3 py-3">金額</th>
-                <th className="px-3 py-3">頻度</th>
-                <th className="px-3 py-3">課金日</th>
-                <th className="px-3 py-3">開始日</th>
-                <th className="px-3 py-3">期間</th>
-                <th className="px-3 py-3">支払い元</th>
-                <th className="px-3 py-3" />
-              </tr>
-            </thead>
-            <tbody>
-              {subscriptions.map((subscription) => (
-                <SubscriptionRow
-                  key={subscription.id}
-                  subscription={subscription}
-                  onEdit={openEdit}
-                  onDelete={deleteSubscription}
-                />
-              ))}
-            </tbody>
-          </Table>
-        </TableWrapper>
+        {error ? (
+          <ErrorBlock message={error} onRetry={reload} />
+        ) : (
+          <ResponsiveTable
+            columns={columns}
+            rows={subscriptions}
+            rowKey={(subscription) => subscription.id}
+            emptyMessage="サブスクが登録されていません。"
+            mobileRow={(subscription) => (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{subscription.name}</div>
+                    <div className="text-xs text-ink-3">{formatInterval(subscription.intervalMonths)}・毎月 {subscription.dayOfMonth} 日</div>
+                  </div>
+                  <div className="font-data text-base font-semibold">{formatCurrency(subscription.amount)}</div>
+                </div>
+                <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
+                  <span>{subscription.paymentSource ?? "未設定"}</span>
+                  <div className="flex gap-1">
+                    <IconButton aria-label="編集" onClick={() => openEdit(subscription)}>
+                      <Pencil aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                    <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(subscription)}>
+                      <Trash2 aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                  </div>
+                </div>
+              </>
+            )}
+          />
+        )}
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(94vw,40rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">サブスクを追加</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-ink-2">
             サブスク台帳として登録します。残高予測へは直接追加されません。
@@ -400,7 +447,7 @@ export function SubscriptionsPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingSubscription)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(94vw,40rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">サブスクを編集</DialogTitle>
           <DialogDescription className="mt-2 text-sm text-ink-2">
             登録済みのサブスク台帳を更新します。残高予測へは直接追加されません。
@@ -415,6 +462,14 @@ export function SubscriptionsPage() {
           />
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(deletingSubscription)}
+        onOpenChange={(open) => !open && setDeletingSubscription(null)}
+        title="サブスクを削除しますか？"
+        description={deletingSubscription ? `「${deletingSubscription.name}」を削除します。この操作は取り消せません。` : undefined}
+        onConfirm={confirmDelete}
+      />
     </div>
   );
 }
@@ -436,143 +491,126 @@ function SubscriptionEditModal({
   onSave: () => void;
   actionLabel?: string;
 }) {
-  return (
-    <div className="mt-6 grid gap-5">
-      <section className="grid gap-4">
-        <div className="text-xs font-medium text-ink-3">基本情報</div>
-        <SubscriptionFormFields form={form} paymentSources={paymentSources} onChange={onChange} />
-      </section>
-      {!isPeriodValid(form.startDate, form.endDate) ? (
-        <div className="text-sm text-sky-200">開始日は終了日以前にしてください。</div>
-      ) : null}
-      <div className="flex justify-end gap-3 border-t border-line pt-4">
-        <Button variant="ghost" onClick={onCancel}>
-          キャンセル
-        </Button>
-        <Button disabled={!canSave} onClick={onSave}>
-          {actionLabel}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function SubscriptionFormFields({
-  form,
-  paymentSources,
-  onChange,
-}: {
-  form: SubscriptionForm;
-  paymentSources: string[];
-  onChange: (next: SubscriptionForm) => void;
-}) {
   const intervalValue = getIntervalOptionValue(form.intervalMonths);
   const isCustomInterval = intervalValue === "custom";
+  const nameId = useId();
+  const amountId = useId();
+  const intervalId = useId();
+  const customIntervalId = useId();
+  const sourceId = useId();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
+
+  const missing: string[] = [];
+  if (form.name.trim().length === 0) missing.push("サービス名");
+  if (form.amount <= 0) missing.push("金額");
+  if (!isPeriodValid(form.startDate, form.endDate)) missing.push("期間");
 
   return (
-    <div className="grid gap-4">
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-12">
-        <label className="grid min-w-0 gap-2 text-sm md:col-span-2 xl:col-span-4">
-          <span>サービス名 *</span>
-          <Input value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
-        </label>
-        <label className="grid min-w-0 gap-2 text-sm xl:col-span-2">
-          <span>金額 (円) *</span>
-          <Input type="number" min={1} value={form.amount} onChange={(event) => onChange({ ...form, amount: Number(event.target.value) })} />
-        </label>
-        <label className="grid min-w-0 gap-2 text-sm xl:col-span-2">
-          <span>頻度</span>
-          <Select
-            value={intervalValue}
-            onChange={(event) =>
-              onChange({
-                ...form,
-                intervalMonths:
-                  event.target.value === "custom"
-                    ? resolveCustomInterval(form.intervalMonths)
-                    : Number(event.target.value),
-              })}
-          >
-            {intervalOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </Select>
-        </label>
-        {isCustomInterval ? (
-          <label className="grid min-w-0 gap-2 text-sm xl:col-span-2">
-            <span>周期 (ヶ月) *</span>
-            <Input
-              type="number"
-              min={1}
-              value={form.intervalMonths}
-              onChange={(event) => onChange({ ...form, intervalMonths: Number(event.target.value) })}
-            />
-          </label>
-        ) : null}
-        <label
-          className={cn(
-            "grid min-w-0 gap-2 text-sm",
-            isCustomInterval ? "xl:col-span-2" : "xl:col-span-4",
-          )}
-        >
-          <span>課金開始日 *</span>
-          <Input type="date" value={form.startDate} onChange={(event) => onChange({ ...form, startDate: event.target.value })} />
-        </label>
-      </div>
+    <form
+      className="mt-6 grid gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (canSave) {
+          onSave();
+        }
+      }}
+    >
+      <FormField label="サービス名" htmlFor={nameId} required>
+        <Input id={nameId} ref={firstFieldRef} value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
+      </FormField>
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-12">
-        <label className="grid min-w-0 gap-2 text-sm xl:col-span-3">
-          <span>課金日 (1-31)</span>
-          <Input type="number" min={1} max={31} value={form.dayOfMonth} onChange={(event) => onChange({ ...form, dayOfMonth: Number(event.target.value) })} />
-        </label>
-        <label className="grid min-w-0 gap-2 text-sm xl:col-span-3">
-          <span>終了日</span>
-          <Input type="date" value={form.endDate ?? ""} onChange={(event) => onChange({ ...form, endDate: parseOptionalDate(event.target.value) })} />
-        </label>
-        <label className="grid min-w-0 gap-2 text-sm md:col-span-2 xl:col-span-6">
-          <span>支払い元</span>
+      <FormField label="金額 (円)" htmlFor={amountId} required>
+        <MoneyInput id={amountId} currencyCode="JPY" value={form.amount} onChange={(value) => onChange({ ...form, amount: value })} />
+      </FormField>
+
+      <FormField label="頻度" htmlFor={intervalId}>
+        <Select
+          id={intervalId}
+          value={intervalValue}
+          onChange={(event) =>
+            onChange({
+              ...form,
+              intervalMonths:
+                event.target.value === "custom" ? resolveCustomInterval(form.intervalMonths) : Number(event.target.value),
+            })}
+        >
+          {intervalOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </FormField>
+
+      <ConditionalField show={isCustomInterval}>
+        <FormField label="周期 (ヶ月)" htmlFor={customIntervalId} required>
           <Input
-            list="subscription-payment-sources"
-            placeholder={paymentSources.length === 0 ? "任意入力" : "カード名・口座名から選択または入力"}
-            value={form.paymentSource ?? ""}
-            onChange={(event) => onChange({ ...form, paymentSource: parseOptionalText(event.target.value) })}
+            id={customIntervalId}
+            type="number"
+            inputMode="numeric"
+            min={1}
+            value={form.intervalMonths}
+            onChange={(event) => onChange({ ...form, intervalMonths: Number(event.target.value) })}
           />
-        </label>
+        </FormField>
+      </ConditionalField>
+
+      <FormField label="課金開始日" htmlFor="subscription-start" required>
+        <Input id="subscription-start" type="date" value={form.startDate} onChange={(event) => onChange({ ...form, startDate: event.target.value })} />
+      </FormField>
+
+      <DayOfMonthField id="subscription-day" value={form.dayOfMonth} onChange={(value) => onChange({ ...form, dayOfMonth: value ?? 1 })} />
+
+      <FormField
+        label="終了日"
+        htmlFor="subscription-end"
+        help="空欄で無期限になります。"
+        error={!isPeriodValid(form.startDate, form.endDate) ? "開始日は終了日以前にしてください。" : null}
+      >
+        <Input
+          id="subscription-end"
+          type="date"
+          value={form.endDate ?? ""}
+          onChange={(event) => onChange({ ...form, endDate: parseOptionalDate(event.target.value) })}
+        />
+      </FormField>
+
+      <FormField label="支払い元" htmlFor={sourceId}>
+        <Input
+          id={sourceId}
+          list="subscription-payment-sources"
+          placeholder={paymentSources.length === 0 ? "任意入力" : "カード名・口座名から選択または入力"}
+          value={form.paymentSource ?? ""}
+          onChange={(event) => onChange({ ...form, paymentSource: parseOptionalText(event.target.value) })}
+        />
+      </FormField>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-4">
+        <div className="text-xs text-ink-3">{!canSave && missing.length > 0 ? `必須: ${missing.join("、")}` : ""}</div>
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={!canSave}>
+            {actionLabel}
+          </Button>
+        </div>
       </div>
-    </div>
+    </form>
   );
 }
 
-function SubscriptionRow({
-  subscription,
-  onEdit,
-  onDelete,
-}: {
-  subscription: Subscription;
-  onEdit: (subscription: Subscription) => void;
-  onDelete: (id: string) => Promise<void>;
-}) {
+function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
-    <tr className="border-b border-line">
-      <td className="px-3 py-3">{subscription.name}</td>
-      <td className="font-data px-3 py-3">{formatCurrency(subscription.amount)}</td>
-      <td className="px-3 py-3">{formatInterval(subscription.intervalMonths)}</td>
-      <td className="px-3 py-3">毎月 {subscription.dayOfMonth} 日</td>
-      <td className="px-3 py-3">{formatDateWithYear(subscription.startDate)}</td>
-      <td className="px-3 py-3">{formatPeriod(subscription.startDate, subscription.endDate)}</td>
-      <td className="px-3 py-3">{subscription.paymentSource ?? "未設定"}</td>
-      <td className="px-3 py-3">
-        <div className="flex justify-end gap-2">
-          <Button variant="ghost" onClick={() => onEdit(subscription)}>
-            編集
-          </Button>
-          <Button variant="danger" onClick={() => onDelete(subscription.id)}>
-            削除
-          </Button>
-        </div>
-      </td>
-    </tr>
+    <div className="grid gap-3 rounded-xl border border-critical/40 bg-critical/10 p-4 text-sm text-ink">
+      <p role="alert">{message}</p>
+      <Button className="justify-self-start" variant="secondary" onClick={onRetry}>
+        再試行
+      </Button>
+    </div>
   );
 }

--- a/packages/frontend/src/routes/transactions.tsx
+++ b/packages/frontend/src/routes/transactions.tsx
@@ -5,28 +5,35 @@ import type {
   Transaction,
   TransactionsResponse,
 } from "@sui/shared";
-import { useState, startTransition } from "react";
+import { useEffect, useId, useRef, useState, startTransition } from "react";
+import { AccountSelect } from "../components/form-fields";
 import { AccountSelector } from "../components/account-selector";
 import { BalanceChart } from "../components/balance-chart";
 import { OffsetToggle } from "../components/offset-toggle";
 import { PeriodSelector } from "../components/period-selector";
-import { Button } from "../components/ui/button";
+import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
+import { ConditionalField } from "../components/ui/conditional-field";
+import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../components/ui/dialog";
+import { FormField } from "../components/ui/form-field";
 import { Input } from "../components/ui/input";
+import { MoneyInput } from "../components/ui/money-input";
+import { ResponsiveTable, MoneyCell, type ResponsiveTableColumn } from "../components/ui/responsive-table";
+import { SegmentedControl } from "../components/ui/segmented-control";
 import { Select } from "../components/ui/select";
-import { Table, TableWrapper } from "../components/ui/table";
 import { useResource } from "../hooks/use-resource";
+import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import {
   convertCurrencyInputToJpy,
   formatCurrency,
-  formatCurrencyInputValue,
+  formatCurrencyParts,
   formatCurrencyWithJpy,
   formatDateWithYear,
-  parseCurrencyInputValue,
 } from "../lib/format";
 import { getTodayDate } from "../lib/utils";
+import { Pencil, Trash2 } from "lucide-react";
 
 const transactionTypeLabels = {
   income: "収入",
@@ -34,6 +41,12 @@ const transactionTypeLabels = {
   transfer: "振替",
   adjustment: "調整",
 } as const;
+
+const transactionTypeOptions = [
+  { value: "income", label: "収入" },
+  { value: "expense", label: "支出" },
+  { value: "transfer", label: "振替" },
+] as const;
 
 const unspecifiedAccountLabel = "未指定";
 
@@ -198,6 +211,16 @@ function canSubmitTransaction(form: TransactionForm) {
   );
 }
 
+function getMissingFields(form: TransactionForm) {
+  const missing: string[] = [];
+  if (form.description.trim() === "") missing.push("内容");
+  if (form.amount <= 0) missing.push("金額");
+  if (form.date === "") missing.push("取引日");
+  if (form.type !== "transfer" && form.accountId === "") missing.push("口座");
+  if (form.type === "transfer" && form.accountId === "" && form.transferToAccountId === "") missing.push("口座");
+  return missing;
+}
+
 function toTransactionPayload(form: TransactionForm) {
   return {
     accountId: form.accountId || undefined,
@@ -254,12 +277,31 @@ function formatTransactionAmount(transaction: Transaction) {
   ].join(" / ");
 }
 
+function getTransactionAmountParts(transaction: Transaction) {
+  if (transaction.type !== "adjustment") {
+    return formatCurrencyParts(transaction.amount, transaction.currencyCode, transaction.amountJpy);
+  }
+
+  if (transaction.currencyCode === "JPY") {
+    return { primary: formatSignedCurrency(transaction.amount, transaction.currencyCode), secondary: null };
+  }
+
+  return {
+    primary: formatSignedCurrency(transaction.amount, transaction.currencyCode),
+    secondary: formatSignedCurrency(transaction.amountJpy, "JPY"),
+  };
+}
+
 function getAccountBalanceJpy(account: Account, applyOffset: boolean) {
   return convertCurrencyInputToJpy(
     account.balance - (applyOffset ? account.balanceOffset : 0),
     account.currencyCode,
     account.exchangeRateToJpy,
   );
+}
+
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : "不明なエラーが発生しました。";
 }
 
 export function TransactionsPage() {
@@ -278,6 +320,7 @@ export function TransactionsPage() {
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [editForm, setEditForm] = useState<TransactionForm>(emptyForm);
   const [deletingTransaction, setDeletingTransaction] = useState<Transaction | null>(null);
+  const { toast } = useToast();
   const range =
     periodPreset === "custom"
       ? { startDate: customStartDate, endDate: customEndDate }
@@ -337,13 +380,18 @@ export function TransactionsPage() {
   const canSaveEdit = canSubmitTransaction(editForm);
 
   const submitTransaction = async () => {
-    await apiFetch("/api/transactions", {
-      method: "POST",
-      body: JSON.stringify(toTransactionPayload(form)),
-    });
-    setForm(emptyForm);
-    setCreateOpen(false);
-    reload();
+    try {
+      await apiFetch("/api/transactions", {
+        method: "POST",
+        body: JSON.stringify(toTransactionPayload(form)),
+      });
+      setForm(emptyForm);
+      setCreateOpen(false);
+      reload();
+      toast({ title: "取引を記録しました" });
+    } catch (createError) {
+      toast({ title: "取引の記録に失敗しました", description: describeError(createError), variant: "error" });
+    }
   };
 
   const openEdit = (transaction: Transaction) => {
@@ -377,12 +425,17 @@ export function TransactionsPage() {
       return;
     }
 
-    await apiFetch(`/api/transactions/${editingTransaction.id}`, {
-      method: "PUT",
-      body: JSON.stringify(toTransactionPayload(editForm)),
-    });
-    closeEdit();
-    reload();
+    try {
+      await apiFetch(`/api/transactions/${editingTransaction.id}`, {
+        method: "PUT",
+        body: JSON.stringify(toTransactionPayload(editForm)),
+      });
+      closeEdit();
+      reload();
+      toast({ title: "取引を更新しました" });
+    } catch (updateError) {
+      toast({ title: "更新に失敗しました", description: describeError(updateError), variant: "error" });
+    }
   };
 
   const openDelete = (transaction: Transaction) => {
@@ -398,15 +451,63 @@ export function TransactionsPage() {
       return;
     }
 
-    await apiFetch(`/api/transactions/${deletingTransaction.id}`, {
-      method: "DELETE",
-    });
-    closeDelete();
-    if (transactionItems.length === 1 && page > 1) {
-      setPage((value) => value - 1);
+    try {
+      await apiFetch(`/api/transactions/${deletingTransaction.id}`, {
+        method: "DELETE",
+      });
+      closeDelete();
+      if (transactionItems.length === 1 && page > 1) {
+        setPage((value) => value - 1);
+      }
+      reload();
+      toast({ title: "取引を削除しました" });
+    } catch (deleteError) {
+      toast({ title: "削除に失敗しました", description: describeError(deleteError), variant: "error" });
     }
-    reload();
   };
+
+  const columns: ResponsiveTableColumn<Transaction>[] = [
+    { key: "date", header: "日付", mono: true, render: (transaction) => <span className="text-ink-2">{formatDateWithYear(transaction.date)}</span> },
+    {
+      key: "type",
+      header: "種別",
+      render: (transaction) => (
+        <span className={getTransactionTypeClassName(transaction.type)}>{transactionTypeLabels[transaction.type]}</span>
+      ),
+    },
+    { key: "description", header: "内容", render: (transaction) => transaction.description },
+    {
+      key: "amount",
+      header: "金額",
+      align: "right",
+      render: (transaction) => {
+        const parts = getTransactionAmountParts(transaction);
+        return <MoneyCell primary={parts.primary} secondary={parts.secondary} />;
+      },
+    },
+    { key: "account", header: "対象口座", render: (transaction) => formatTransactionAccounts(transaction) },
+    {
+      key: "actions",
+      header: "",
+      render: (transaction) => (
+        <div className="flex justify-end gap-1">
+          {transaction.type !== "adjustment" ? (
+            <IconButton aria-label="編集" onClick={() => openEdit(transaction)}>
+              <Pencil aria-hidden="true" className="h-4 w-4" />
+            </IconButton>
+          ) : null}
+          <IconButton
+            aria-label="削除"
+            variant="danger"
+            disabled={transaction.forecastEventId !== null}
+            onClick={() => openDelete(transaction)}
+          >
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+        </div>
+      ),
+    },
+  ];
 
   return (
     <div className="grid gap-6">
@@ -474,9 +575,7 @@ export function TransactionsPage() {
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
           <div>
             <h2 className="text-xl font-semibold">取引履歴</h2>
-            <p className="mt-1 text-sm text-ink-2">
-              {loading ? "読み込み中..." : error ?? `${transactions?.total ?? 0} 件`}
-            </p>
+            <p className="mt-1 text-sm text-ink-2">{loading ? "読み込み中..." : `${transactions?.total ?? 0} 件`}</p>
           </div>
           <div className="flex flex-wrap items-center gap-3">
             <PeriodSelector
@@ -530,33 +629,47 @@ export function TransactionsPage() {
             </>
           ) : null}
         </div>
-        <TableWrapper>
-          <Table className="min-w-[56rem]">
-            <thead>
-              <tr className="border-b border-line text-left text-xs font-medium text-ink-3">
-                <th className="px-3 py-3">日付</th>
-                <th className="px-3 py-3">種別</th>
-                <th className="px-3 py-3">内容</th>
-                <th className="px-3 py-3">金額</th>
-                <th className="px-3 py-3">対象口座</th>
-                <th className="px-3 py-3 text-right" />
-              </tr>
-            </thead>
-            <tbody>
-              {transactionItems.map((transaction) => (
-                <TransactionRow
-                  key={transaction.id}
-                  transaction={transaction}
-                  onEdit={openEdit}
-                  onDelete={openDelete}
-                />
-              ))}
-            </tbody>
-          </Table>
-        </TableWrapper>
-        {!loading && !error && transactionItems.length === 0 ? (
-          <div className="mt-4 text-ink-2">該当する取引はありません。</div>
-        ) : null}
+        {error ? (
+          <ErrorBlock message={error} onRetry={reload} />
+        ) : (
+          <ResponsiveTable
+            columns={columns}
+            rows={transactionItems}
+            rowKey={(transaction) => transaction.id}
+            emptyMessage="該当する取引はありません。"
+            mobileRow={(transaction) => (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{transaction.description}</div>
+                    <div className="text-xs text-ink-3">
+                      <span className={getTransactionTypeClassName(transaction.type)}>{transactionTypeLabels[transaction.type]}</span>
+                    </div>
+                  </div>
+                  <div className="font-data text-base font-semibold">{formatTransactionAmount(transaction)}</div>
+                </div>
+                <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
+                  <span>{formatDateWithYear(transaction.date)}・{formatTransactionAccounts(transaction)}</span>
+                  <div className="flex gap-1">
+                    {transaction.type !== "adjustment" ? (
+                      <IconButton aria-label="編集" onClick={() => openEdit(transaction)}>
+                        <Pencil aria-hidden="true" className="h-4 w-4" />
+                      </IconButton>
+                    ) : null}
+                    <IconButton
+                      aria-label="削除"
+                      variant="danger"
+                      disabled={transaction.forecastEventId !== null}
+                      onClick={() => openDelete(transaction)}
+                    >
+                      <Trash2 aria-hidden="true" className="h-4 w-4" />
+                    </IconButton>
+                  </div>
+                </div>
+              </>
+            )}
+          />
+        )}
         <div className="mt-4 flex justify-end gap-2">
           <Button className="border border-line" variant="ghost" disabled={page <= 1} onClick={() => setPage((value) => value - 1)}>
             前へ
@@ -573,11 +686,9 @@ export function TransactionsPage() {
       </Card>
 
       <Dialog open={createOpen} onOpenChange={(open) => (open ? setCreateOpen(true) : closeCreate())}>
-        <DialogContent className="w-[min(94vw,36rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">取引を追加</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            手動取引を記録します。
-          </DialogDescription>
+          <DialogDescription className="mt-2 text-sm text-ink-2">手動取引を記録します。</DialogDescription>
           <TransactionEditModal
             accounts={accounts}
             form={form}
@@ -591,11 +702,9 @@ export function TransactionsPage() {
       </Dialog>
 
       <Dialog open={Boolean(editingTransaction)} onOpenChange={(open) => !open && closeEdit()}>
-        <DialogContent className="w-[min(94vw,36rem)]">
+        <DialogContent size="m">
           <DialogTitle className="text-lg font-semibold">取引を編集</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            取引内容を更新します。
-          </DialogDescription>
+          <DialogDescription className="mt-2 text-sm text-ink-2">取引内容を更新します。</DialogDescription>
           <TransactionEditModal
             accounts={accounts}
             form={editForm}
@@ -607,46 +716,17 @@ export function TransactionsPage() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={Boolean(deletingTransaction)} onOpenChange={(open) => !open && closeDelete()}>
-        <DialogContent className="w-[min(94vw,32rem)]">
-          <DialogTitle className="text-lg font-semibold">取引を削除</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-ink-2">
-            この操作は取り消せません。削除すると口座残高が元に戻ります。
-          </DialogDescription>
-          {deletingTransaction ? (
-            <div className="mt-6 grid gap-3 rounded-2xl border border-line bg-surface-2 p-4 text-sm">
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-ink-2">日付</span>
-                <span>{formatDateWithYear(deletingTransaction.date)}</span>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-ink-2">内容</span>
-                <span className="min-w-0 break-words text-right">{deletingTransaction.description}</span>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-ink-2">金額</span>
-                <span>
-                  {formatTransactionAmount(deletingTransaction)}
-                </span>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-ink-2">対象口座</span>
-                <span className="min-w-0 break-words text-right">
-                  {formatTransactionAccounts(deletingTransaction)}
-                </span>
-              </div>
-            </div>
-          ) : null}
-          <div className="mt-6 flex justify-end gap-3">
-            <Button variant="ghost" onClick={closeDelete}>
-              キャンセル
-            </Button>
-            <Button variant="danger" onClick={confirmDelete}>
-              削除
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={Boolean(deletingTransaction)}
+        onOpenChange={(open) => !open && closeDelete()}
+        title="取引を削除しますか？"
+        description={
+          deletingTransaction
+            ? `「${deletingTransaction.description}」（${formatTransactionAmount(deletingTransaction)}）を削除します。残高が元に戻ります。この操作は取り消せません。`
+            : undefined
+        }
+        onConfirm={confirmDelete}
+      />
     </div>
   );
 }
@@ -668,167 +748,117 @@ function TransactionEditModal({
   onSave: () => void;
   actionLabel?: string;
 }) {
-  return (
-    <div className="mt-6 grid gap-5">
-      <section className="grid gap-4">
-        <div className="text-xs font-medium text-ink-3">基本情報</div>
-        <div className="grid gap-4 md:grid-cols-2">
-          <TransactionFormFields accounts={accounts} form={form} onChange={onChange} />
-        </div>
-      </section>
-      <div className="flex justify-end gap-3 border-t border-line pt-4">
-        <Button variant="ghost" onClick={onCancel}>
-          キャンセル
-        </Button>
-        <Button disabled={!canSave} onClick={onSave}>
-          {actionLabel}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function TransactionFormFields({
-  accounts,
-  form,
-  onChange,
-}: {
-  accounts: Account[];
-  form: TransactionForm;
-  onChange: (next: TransactionForm) => void;
-}) {
   const sourceAccount = accounts.find((account) => account.id === form.accountId) ?? null;
   const destinationAccount = accounts.find((account) => account.id === form.transferToAccountId) ?? null;
   const currencyCode: SupportedCurrencyCode = sourceAccount?.currencyCode ?? destinationAccount?.currencyCode ?? "JPY";
-  const amountStep = currencyCode === "JPY" ? 1 : 0.01;
   const transferDestinationAccounts = accounts.filter(
-    (account) =>
-      account.id !== form.accountId &&
-      (!sourceAccount || account.currencyCode === sourceAccount.currencyCode),
+    (account) => account.id !== form.accountId && (!sourceAccount || account.currencyCode === sourceAccount.currencyCode),
   );
+  const descriptionId = useId();
+  const amountId = useId();
+  const dateId = useId();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const missing = getMissingFields(form);
+
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
 
   return (
-    <>
-      <Select
-        aria-label="取引口座"
+    <form
+      className="mt-6 grid gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (canSave) {
+          onSave();
+        }
+      }}
+    >
+      <FormField label="内容" htmlFor={descriptionId} required>
+        <Input
+          id={descriptionId}
+          ref={firstFieldRef}
+          placeholder="内容"
+          value={form.description}
+          onChange={(event) => onChange({ ...form, description: event.target.value })}
+        />
+      </FormField>
+
+      <FormField label="取引種別" htmlFor="transaction-type">
+        <SegmentedControl
+          aria-label="取引種別"
+          value={form.type}
+          options={transactionTypeOptions}
+          onChange={(type) =>
+            onChange({
+              ...form,
+              type,
+              transferToAccountId: type === "transfer" ? form.transferToAccountId : "",
+            })}
+        />
+      </FormField>
+
+      <FormField label="金額" htmlFor={amountId} required>
+        <MoneyInput id={amountId} currencyCode={currencyCode} value={form.amount} onChange={(value) => onChange({ ...form, amount: value })} />
+      </FormField>
+
+      <FormField label="取引日" htmlFor={dateId} required>
+        <Input id={dateId} type="date" value={form.date} onChange={(event) => onChange({ ...form, date: event.target.value })} />
+      </FormField>
+
+      <AccountSelect
+        id="transaction-account"
+        label={form.type === "transfer" ? "送金元口座" : "対象口座"}
+        accounts={accounts}
         value={form.accountId}
-        onChange={(event) => {
-          const nextAccount = accounts.find((account) => account.id === event.target.value) ?? null;
-          const currentDestination = accounts.find((account) => account.id === form.transferToAccountId) ?? null;
+        required={false}
+        placeholder={form.type === "transfer" ? "送金元口座なし" : "対象口座を選択"}
+        onChange={(accountId) => {
+          const nextAccount = accounts.find((account) => account.id === accountId) ?? null;
           onChange({
             ...form,
-            accountId: event.target.value,
+            accountId,
             transferToAccountId:
-              nextAccount && currentDestination?.currencyCode !== nextAccount.currencyCode
-                ? ""
-                : form.transferToAccountId,
+              nextAccount && destinationAccount?.currencyCode !== nextAccount.currencyCode ? "" : form.transferToAccountId,
           });
         }}
-      >
-        <option value="">{form.type === "transfer" ? "送金元口座なし" : "対象口座"}</option>
-        {accounts.map((account) => (
-          <option key={account.id} value={account.id}>
-            {account.name}
-          </option>
-        ))}
-      </Select>
-      <Select
-        aria-label="取引種別"
-        value={form.type}
-        onChange={(event) =>
-          onChange({
-            ...form,
-            type: event.target.value as "income" | "expense" | "transfer",
-            transferToAccountId: event.target.value === "transfer" ? form.transferToAccountId : "",
-          })}
-      >
-        <option value="income">収入</option>
-        <option value="expense">支出</option>
-        <option value="transfer">振替</option>
-      </Select>
-      <Input
-        aria-label="取引日"
-        type="date"
-        value={form.date}
-        onChange={(event) => onChange({ ...form, date: event.target.value })}
       />
-      {form.type === "transfer" ? (
-        <Select
-          aria-label="振替先口座"
+
+      <ConditionalField show={form.type === "transfer"}>
+        <AccountSelect
+          id="transaction-transfer-account"
+          label="振替先口座"
+          accounts={transferDestinationAccounts}
           value={form.transferToAccountId}
-          onChange={(event) => onChange({ ...form, transferToAccountId: event.target.value })}
-        >
-          <option value="">振替先口座なし</option>
-          {transferDestinationAccounts.map((account) => (
-            <option key={account.id} value={account.id}>
-              {account.name}
-            </option>
-          ))}
-        </Select>
-      ) : null}
-      <Input
-        className={form.type === "transfer" ? undefined : "md:col-span-2"}
-        placeholder="内容"
-        value={form.description}
-        onChange={(event) => onChange({ ...form, description: event.target.value })}
-      />
-      <Input
-        type="number"
-        inputMode="decimal"
-        step={amountStep}
-        placeholder={`金額 (${currencyCode})`}
-        value={formatCurrencyInputValue(form.amount, currencyCode)}
-        onChange={(event) => onChange({
-          ...form,
-          amount: parseCurrencyInputValue(event.target.value, currencyCode),
-        })}
-      />
-    </>
+          required={false}
+          placeholder="振替先口座なし"
+          onChange={(accountId) => onChange({ ...form, transferToAccountId: accountId })}
+        />
+      </ConditionalField>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-4">
+        <div className="text-xs text-ink-3">{!canSave && missing.length > 0 ? `必須: ${missing.join("、")}` : ""}</div>
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={!canSave}>
+            {actionLabel}
+          </Button>
+        </div>
+      </div>
+    </form>
   );
 }
 
-function TransactionRow({
-  transaction,
-  onEdit,
-  onDelete,
-}: {
-  transaction: Transaction;
-  onEdit: (transaction: Transaction) => void;
-  onDelete: (transaction: Transaction) => void;
-}) {
+function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
-    <tr className="border-b border-line">
-      <td className="font-data px-3 py-3 text-ink-2">{formatDateWithYear(transaction.date)}</td>
-      <td className="px-3 py-3">
-        <span className={getTransactionTypeClassName(transaction.type)}>
-          {transactionTypeLabels[transaction.type]}
-        </span>
-      </td>
-      <td className="px-3 py-3">{transaction.description}</td>
-      <td className="font-data px-3 py-3">
-        {formatTransactionAmount(transaction)}
-      </td>
-      <td className="px-3 py-3">
-        {formatTransactionAccounts(transaction)}
-      </td>
-      <td className="px-3 py-3 text-right">
-        <div className="flex justify-end gap-2">
-          {transaction.type !== "adjustment" ? (
-            <Button variant="ghost" onClick={() => onEdit(transaction)}>
-              編集
-            </Button>
-          ) : null}
-          <Button
-            variant="ghost"
-            className="text-critical hover:bg-critical/10 disabled:text-ink-3 disabled:hover:bg-transparent"
-            disabled={transaction.forecastEventId !== null}
-            onClick={() => onDelete(transaction)}
-          >
-            削除
-          </Button>
-        </div>
-      </td>
-    </tr>
+    <div className="grid gap-3 rounded-xl border border-critical/40 bg-critical/10 p-4 text-sm text-ink">
+      <p role="alert">{message}</p>
+      <Button className="justify-self-start" variant="secondary" onClick={onRetry}>
+        再試行
+      </Button>
+    </div>
   );
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ const testDatabaseUrl = "postgresql://sui_test:sui_test@localhost:5555/sui_test"
 export default defineConfig({
   testDir: "e2e",
   timeout: 30_000,
-  retries: 0,
+  retries: process.env.CI ? 2 : 0,
   workers: 1,
   use: {
     baseURL: "http://localhost:5174",


### PR DESCRIPTION
## 概要

`20260702-frontend.md` レビュー C-8 ロードマップの **ステージ3（フォームと管理ページの型化）**。#291 の続き。この段で **Issue #223（数値入力がやりにくい）** と **Issue #224（UI の統一感がない）** を閉じる。

### 共有フォーム部品（C-5 規約5）
- `FormField`（ラベル/必須/ヘルプ/エラーの5スロット）、`MoneyInput`、`SegmentedControl`、`Switch`、`Disclosure`、`ConditionalField`、`DateShiftField`（3複製を解消）
- **`MoneyInput` で Issue #223 を根治**: フォーカス中はローカル文字列ドラフトのみ更新、整形は blur/送信時のみ（空欄・末尾ドットを許容）。`type="text"` + `inputMode="decimal"` + パターン検証、フォーカス時全選択。固定収支/サブスク/ローンの生 `Number()` 処理と「(円)」直書きを全廃

### フォームレイアウト規約（C-5 規約1〜4,6）
- 1カラム既定・ダイアログ幅トークン3種（S/M/L）、条件フィールドは制御元直下に全幅＋インデント罫＋150msトランジション（他フィールドの幅・位置を変えない）
- フォームの形を変える選択（取引種別・支払方法・ローン起点）を先頭のセグメンテッドコントロールに、モード切替後もフィールド順序を安定
- 全フォーム `<form onSubmit>` 化（Enter送信・自動補完・初期フォーカス）、エラーは --critical で直下に `role="alert"`（水色エラー廃止）、「表示順」「有効」を詳細設定ディスクロージャへ

### テーブル・破壊的操作・ナビ（C-4, B-6, A-3）
- `ResponsiveTable`: デスクトップ水平罫線＋右揃えMono＋`scope`＋JPY2行併記、モバイルはリスト行。min-w級テーブルの横スクロール依存を解消、行内は IconButton
- `ConfirmDialog` で `window.confirm` 全廃（対象名・影響表示、既定フォーカスはキャンセル）
- 全ミューテーションを成功/失敗トーストに配線
- ナビをグループ見出し付きサイドバー＋モバイル下部タブバーに刷新、ダッシュボードに未確定件数バッジ

## テスト

- `make lint` / `make typecheck` / `make build` / `make test-unit` / `make test-e2e`（59 passed）すべて通過
- E2E は各管理ページ・window.confirm 廃止・ナビ・レスポンシブの spec を新 UI に追随

Closes #223, Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)