### PR TITLE
feat: フロントエンド再設計 Stage 4 — 磨き（最終）

### DIFF
--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -1,8 +1,9 @@
+import { useEffect, useRef } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { useRegisterSW } from "virtual:pwa-register/react";
 import { AppLayout } from "./components/layout";
-import { Button } from "./components/ui/button";
 import { Toaster } from "./components/ui/toast";
+import { useToast } from "./hooks/use-toast";
 import { AccountsPage } from "./routes/accounts";
 import { CreditCardsPage } from "./routes/credit-cards";
 import { DataManagementPage } from "./routes/data-management";
@@ -34,22 +35,31 @@ export function App() {
   );
 }
 
+/**
+ * PWA 更新プロンプト。ステージ1のトースト基盤に統合し、専用の固定バナーは持たない
+ * （B-1「更新プロンプト」）。新バージョン検知は一度きりのイベントなので、toast 発火も
+ * hasNotifiedRef で一度だけに絞る。
+ */
 function PwaUpdatePrompt() {
+  const { toast } = useToast();
+  const hasNotifiedRef = useRef(false);
   const {
     needRefresh: [needRefresh],
     updateServiceWorker,
   } = useRegisterSW();
 
-  if (!needRefresh) {
-    return null;
-  }
+  useEffect(() => {
+    if (!needRefresh || hasNotifiedRef.current) {
+      return;
+    }
 
-  return (
-    <div className="fixed inset-x-3 bottom-3 z-50 mx-auto flex max-w-xl flex-wrap items-center justify-between gap-3 rounded-[var(--radius-m)] border border-line bg-surface-1 p-3 text-sm shadow-[var(--elev-1)]">
-      <span className="min-w-0 break-words text-ink">新しいバージョンがあります。</span>
-      <Button className="min-h-10" onClick={() => void updateServiceWorker(true)}>
-        更新
-      </Button>
-    </div>
-  );
+    hasNotifiedRef.current = true;
+    toast({
+      title: "新しいバージョンがあります。",
+      variant: "info",
+      action: { label: "更新", onClick: () => void updateServiceWorker(true) },
+    });
+  }, [needRefresh, toast, updateServiceWorker]);
+
+  return null;
 }

--- a/packages/frontend/src/components/account-level-list.tsx
+++ b/packages/frontend/src/components/account-level-list.tsx
@@ -1,5 +1,5 @@
 import type { SupportedCurrencyCode } from "@sui/shared";
-import { formatCurrencyWithJpy, formatDateWithYear } from "../lib/format";
+import { formatCurrency, formatCurrencyParts, formatDateWithYear } from "../lib/format";
 import { cn } from "../lib/utils";
 import { StatusChip, type StatusChipTone } from "./ui/status-chip";
 
@@ -78,13 +78,26 @@ export function AccountLevelList({
                 />
               </div>
             </div>
-            <div className="grid min-w-0 gap-0.5 text-right">
-              <div className="font-data overflow-x-auto whitespace-nowrap text-sm font-semibold">
-                {formatCurrencyWithJpy(row.currentBalance, row.currencyCode, row.currentBalanceJpy)}
-              </div>
+            <div className="grid min-w-0 gap-1 text-right">
+              {(() => {
+                const currentParts = formatCurrencyParts(row.currentBalance, row.currencyCode, row.currentBalanceJpy);
+                return (
+                  <div>
+                    <div className="font-data overflow-x-auto whitespace-nowrap text-sm font-semibold">
+                      {currentParts.primary}
+                    </div>
+                    {currentParts.secondary ? (
+                      <div className="font-data overflow-x-auto whitespace-nowrap text-xs text-ink-3">
+                        {currentParts.secondary}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })()}
               <div className="font-data overflow-x-auto whitespace-nowrap text-xs text-ink-2">
-                期間内最小 {formatCurrencyWithJpy(row.minBalance, row.currencyCode, row.minBalanceJpy)}（
-                {formatDateWithYear(row.minBalanceDate)}）
+                期間内最小 {formatCurrency(row.minBalance, row.currencyCode)}
+                {row.currencyCode === "JPY" ? "" : `（${formatCurrency(row.minBalanceJpy, "JPY")}）`}
+                （{formatDateWithYear(row.minBalanceDate)}）
               </div>
             </div>
           </button>

--- a/packages/frontend/src/components/balance-chart.tsx
+++ b/packages/frontend/src/components/balance-chart.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import { useEffect, useRef, useState } from "react";
 import type { SupportedCurrencyCode } from "@sui/shared";
+import { usePrefersReducedMotion } from "../hooks/use-prefers-reduced-motion";
 import { convertCurrencyInputToJpy, formatCurrency, formatDate, formatManUnit } from "../lib/format";
 import {
   buildBalanceChartSegments,
@@ -91,29 +92,6 @@ function useElementSize() {
   }, []);
 
   return [ref, size] as const;
-}
-
-function getPrefersReducedMotion() {
-  return typeof window !== "undefined" && typeof window.matchMedia === "function"
-    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
-    : false;
-}
-
-function usePrefersReducedMotion() {
-  const [reduced, setReduced] = useState(getPrefersReducedMotion);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
-    }
-
-    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const listener = (event: MediaQueryListEvent) => setReduced(event.matches);
-    query.addEventListener("change", listener);
-    return () => query.removeEventListener("change", listener);
-  }, []);
-
-  return reduced;
 }
 
 function isInDomain(point: DailyBalanceChartPoint, domain: [number, number]) {
@@ -236,7 +214,9 @@ export function BalanceChart({
 }) {
   const [chartRef, chartSize] = useElementSize();
   const prefersReducedMotion = usePrefersReducedMotion();
-  const hasAnimatedRef = useRef(false);
+  // 初回マウントの直後に true へ切り替える。以降の再レンダー（期間・口座・オフセットの
+  // 切替でデータが変わる場合）は shouldAnimate が false になり、再アニメーションを起こさない。
+  const [hasAnimatedOnce, setHasAnimatedOnce] = useState(false);
 
   const {
     actualLineSeries,
@@ -253,11 +233,8 @@ export function BalanceChart({
   });
 
   useEffect(() => {
-    if (hasAnimatedRef.current) {
-      return;
-    }
-
-    hasAnimatedRef.current = true;
+    const frame = requestAnimationFrame(() => setHasAnimatedOnce(true));
+    return () => cancelAnimationFrame(frame);
   }, []);
 
   if (actualLineSeries.length === 0 && forecastLineSeries.length === 0) {
@@ -330,7 +307,9 @@ export function BalanceChart({
     return plotTop + (1 - (value - chartDomain[0]) / (chartDomain[1] - chartDomain[0])) * plotHeight;
   };
 
-  const shouldAnimate = !prefersReducedMotion;
+  // 描線アニメーションは初回マウントの 400ms のみ（C-2）。以降のデータ更新（期間・口座・
+  // オフセットの切替）では isAnimationActive を false にし、再アニメーションを起こさない。
+  const shouldAnimate = !prefersReducedMotion && !hasAnimatedOnce;
 
   return (
     <div ref={chartRef} className="relative h-full min-h-0 min-w-0">

--- a/packages/frontend/src/components/layout.tsx
+++ b/packages/frontend/src/components/layout.tsx
@@ -2,6 +2,7 @@ import type { DashboardResponse } from "@sui/shared";
 import type { PropsWithChildren } from "react";
 import { useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
+import { OfflineBanner } from "./offline-banner";
 import { apiFetch } from "../lib/api";
 import { cn } from "../lib/utils";
 import {
@@ -94,135 +95,138 @@ export function AppLayout({ children }: PropsWithChildren) {
     allNavItems.find((item) => (item.to === "/" ? pathname === "/" : pathname.startsWith(item.to))) ?? allNavItems[0];
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-4 px-3 py-3 pb-20 sm:px-4 sm:py-4 lg:flex-row lg:gap-6 lg:px-6 lg:py-6 lg:pb-6">
-      <header className="rounded-[var(--radius-m)] border border-line bg-surface-1 p-3 lg:hidden">
-        <div className="text-xs tracking-[0.24em] text-brand">sui</div>
-        <div className="mt-1 truncate text-base font-semibold">{currentItem.label}</div>
-      </header>
+    <>
+      <OfflineBanner />
+      <div className="mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-4 px-3 py-3 pb-20 sm:px-4 sm:py-4 lg:flex-row lg:gap-6 lg:px-6 lg:py-6 lg:pb-6">
+        <header className="rounded-[var(--radius-m)] border border-line bg-surface-1 p-3 lg:hidden">
+          <div className="text-xs tracking-[0.24em] text-brand">sui</div>
+          <div className="mt-1 truncate text-base font-semibold">{currentItem.label}</div>
+        </header>
 
-      <aside className="hidden w-60 shrink-0 rounded-[var(--radius-l)] border border-line bg-surface-1 p-5 lg:block">
-        <div className="mb-6 text-xs tracking-[0.3em] text-brand">sui</div>
-        <nav className="grid gap-5">
-          {navGroups.map((group) => (
-            <div key={group.heading} className="grid gap-1.5">
-              <div className={cn("px-1 text-xs font-medium tracking-wide", group.muted ? "text-ink-3/70" : "text-ink-3")}>
-                {group.heading}
+        <aside className="hidden w-60 shrink-0 rounded-[var(--radius-l)] border border-line bg-surface-1 p-5 lg:block">
+          <div className="mb-6 text-xs tracking-[0.3em] text-brand">sui</div>
+          <nav className="grid gap-5">
+            {navGroups.map((group) => (
+              <div key={group.heading} className="grid gap-1.5">
+                <div className={cn("px-1 text-xs font-medium tracking-wide", group.muted ? "text-ink-3/70" : "text-ink-3")}>
+                  {group.heading}
+                </div>
+                <div className="grid gap-1">
+                  {group.items.map((item) => (
+                    <NavLink
+                      key={item.to}
+                      to={item.to}
+                      className={({ isActive }) =>
+                        cn(
+                          "flex min-w-0 items-center gap-2.5 rounded-[var(--radius-s)] px-3 py-2.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+                          isActive
+                            ? "bg-brand text-[#0B0E13]"
+                            : group.muted
+                              ? "text-ink-3 hover:bg-surface-2/70 hover:text-ink-2"
+                              : "text-ink-2 hover:bg-surface-2/70 hover:text-ink",
+                        )
+                      }
+                    >
+                      <item.icon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                      <span className="truncate">{item.label}</span>
+                      {item.to === "/" && overdueCount > 0 ? (
+                        <span
+                          aria-label={`未確定 ${overdueCount} 件`}
+                          className="font-data ml-auto inline-flex min-w-5 shrink-0 items-center justify-center rounded-full bg-warning/20 px-1.5 py-0.5 text-xs font-semibold text-warning"
+                        >
+                          {overdueCount}
+                        </span>
+                      ) : null}
+                    </NavLink>
+                  ))}
+                </div>
               </div>
-              <div className="grid gap-1">
-                {group.items.map((item) => (
+            ))}
+          </nav>
+        </aside>
+
+        <main className="min-w-0 flex-1">{children}</main>
+
+        <nav
+          aria-label="モバイルナビゲーション"
+          className="fixed inset-x-0 bottom-0 z-40 border-t border-line bg-surface-1 pb-[env(safe-area-inset-bottom)] lg:hidden"
+        >
+          <div className="grid grid-cols-4">
+            {mobileTabs.map((tab) => {
+              const isActive = tab.to
+                ? tab.to === "/"
+                  ? pathname === "/"
+                  : pathname.startsWith(tab.to)
+                : (tab.groupItems ?? []).some((item) => pathname.startsWith(item.to));
+
+              if (tab.to) {
+                return (
+                  <NavLink
+                    key={tab.key}
+                    to={tab.to}
+                    onClick={() => setOpenTabKey(null)}
+                    className={cn(
+                      "flex min-h-14 flex-col items-center justify-center gap-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-inset",
+                      isActive ? "text-brand" : "text-ink-2",
+                    )}
+                  >
+                    <span className="relative">
+                      <tab.icon aria-hidden="true" className="h-5 w-5" />
+                      {tab.to === "/" && overdueCount > 0 ? (
+                        <span
+                          aria-label={`未確定 ${overdueCount} 件`}
+                          className="font-data absolute -right-2.5 -top-1.5 inline-flex min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-semibold leading-4 text-[#0B0E13]"
+                        >
+                          {overdueCount}
+                        </span>
+                      ) : null}
+                    </span>
+                    {tab.label}
+                  </NavLink>
+                );
+              }
+
+              return (
+                <button
+                  key={tab.key}
+                  type="button"
+                  aria-expanded={openTabKey === tab.key}
+                  onClick={() => setOpenTabKey((current) => (current === tab.key ? null : tab.key))}
+                  className={cn(
+                    "flex min-h-14 flex-col items-center justify-center gap-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-inset",
+                    isActive || openTabKey === tab.key ? "text-brand" : "text-ink-2",
+                  )}
+                >
+                  <tab.icon aria-hidden="true" className="h-5 w-5" />
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+          {openTabKey ? (
+            <div className="absolute inset-x-3 bottom-[calc(100%+0.5rem)] grid gap-1 rounded-[var(--radius-m)] border border-line bg-surface-1 p-2 shadow-[var(--elev-1)]">
+              {mobileTabs
+                .find((tab) => tab.key === openTabKey)
+                ?.groupItems?.map((item) => (
                   <NavLink
                     key={item.to}
                     to={item.to}
+                    onClick={() => setOpenTabKey(null)}
                     className={({ isActive }) =>
                       cn(
-                        "flex min-w-0 items-center gap-2.5 rounded-[var(--radius-s)] px-3 py-2.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-                        isActive
-                          ? "bg-brand text-[#0B0E13]"
-                          : group.muted
-                            ? "text-ink-3 hover:bg-surface-2/70 hover:text-ink-2"
-                            : "text-ink-2 hover:bg-surface-2/70 hover:text-ink",
+                        "flex items-center gap-2.5 rounded-[var(--radius-s)] px-3 py-2.5 text-sm font-medium transition",
+                        isActive ? "bg-brand text-[#0B0E13]" : "text-ink-2 hover:bg-surface-2",
                       )
                     }
                   >
                     <item.icon aria-hidden="true" className="h-4 w-4 shrink-0" />
-                    <span className="truncate">{item.label}</span>
-                    {item.to === "/" && overdueCount > 0 ? (
-                      <span
-                        aria-label={`未確定 ${overdueCount} 件`}
-                        className="font-data ml-auto inline-flex min-w-5 shrink-0 items-center justify-center rounded-full bg-warning/20 px-1.5 py-0.5 text-xs font-semibold text-warning"
-                      >
-                        {overdueCount}
-                      </span>
-                    ) : null}
+                    {item.label}
                   </NavLink>
                 ))}
-              </div>
             </div>
-          ))}
+          ) : null}
         </nav>
-      </aside>
-
-      <main className="min-w-0 flex-1">{children}</main>
-
-      <nav
-        aria-label="モバイルナビゲーション"
-        className="fixed inset-x-0 bottom-0 z-40 border-t border-line bg-surface-1 pb-[env(safe-area-inset-bottom)] lg:hidden"
-      >
-        <div className="grid grid-cols-4">
-          {mobileTabs.map((tab) => {
-            const isActive = tab.to
-              ? tab.to === "/"
-                ? pathname === "/"
-                : pathname.startsWith(tab.to)
-              : (tab.groupItems ?? []).some((item) => pathname.startsWith(item.to));
-
-            if (tab.to) {
-              return (
-                <NavLink
-                  key={tab.key}
-                  to={tab.to}
-                  onClick={() => setOpenTabKey(null)}
-                  className={cn(
-                    "flex min-h-14 flex-col items-center justify-center gap-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-inset",
-                    isActive ? "text-brand" : "text-ink-2",
-                  )}
-                >
-                  <span className="relative">
-                    <tab.icon aria-hidden="true" className="h-5 w-5" />
-                    {tab.to === "/" && overdueCount > 0 ? (
-                      <span
-                        aria-label={`未確定 ${overdueCount} 件`}
-                        className="font-data absolute -right-2.5 -top-1.5 inline-flex min-w-4 items-center justify-center rounded-full bg-warning px-1 text-[10px] font-semibold leading-4 text-[#0B0E13]"
-                      >
-                        {overdueCount}
-                      </span>
-                    ) : null}
-                  </span>
-                  {tab.label}
-                </NavLink>
-              );
-            }
-
-            return (
-              <button
-                key={tab.key}
-                type="button"
-                aria-expanded={openTabKey === tab.key}
-                onClick={() => setOpenTabKey((current) => (current === tab.key ? null : tab.key))}
-                className={cn(
-                  "flex min-h-14 flex-col items-center justify-center gap-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-inset",
-                  isActive || openTabKey === tab.key ? "text-brand" : "text-ink-2",
-                )}
-              >
-                <tab.icon aria-hidden="true" className="h-5 w-5" />
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
-        {openTabKey ? (
-          <div className="absolute inset-x-3 bottom-[calc(100%+0.5rem)] grid gap-1 rounded-[var(--radius-m)] border border-line bg-surface-1 p-2 shadow-[var(--elev-1)]">
-            {mobileTabs
-              .find((tab) => tab.key === openTabKey)
-              ?.groupItems?.map((item) => (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  onClick={() => setOpenTabKey(null)}
-                  className={({ isActive }) =>
-                    cn(
-                      "flex items-center gap-2.5 rounded-[var(--radius-s)] px-3 py-2.5 text-sm font-medium transition",
-                      isActive ? "bg-brand text-[#0B0E13]" : "text-ink-2 hover:bg-surface-2",
-                    )
-                  }
-                >
-                  <item.icon aria-hidden="true" className="h-4 w-4 shrink-0" />
-                  {item.label}
-                </NavLink>
-              ))}
-          </div>
-        ) : null}
-      </nav>
-    </div>
+      </div>
+    </>
   );
 }

--- a/packages/frontend/src/components/level-header.tsx
+++ b/packages/frontend/src/components/level-header.tsx
@@ -1,3 +1,5 @@
+import { useCountUp } from "../hooks/use-count-up";
+import { formatCurrency } from "../lib/format";
 import { cn } from "../lib/utils";
 import { StatusChip } from "./ui/status-chip";
 
@@ -24,7 +26,7 @@ export function LevelHeader({
   status,
   heroText,
   criticalDays,
-  totalBalanceLabel,
+  totalBalance,
   minBalanceLabel,
   onMinBalanceClick,
   nextIncomeLabel,
@@ -33,12 +35,16 @@ export function LevelHeader({
   status: LevelHeaderStatus;
   heroText: string;
   criticalDays?: number;
-  totalBalanceLabel: string;
+  totalBalance: number;
   minBalanceLabel: string;
   onMinBalanceClick?: () => void;
   nextIncomeLabel: string;
   nextExpenseLabel: string;
 }) {
+  // 判定数値のカウントアップ（C-2）: 総資産とあと N 日は初回のみ 500ms でカウントアップする。
+  const displayedTotalBalance = useCountUp(totalBalance);
+  const displayedCriticalDays = useCountUp(criticalDays ?? 0);
+
   return (
     <div className="relative overflow-hidden">
       <div
@@ -55,7 +61,7 @@ export function LevelHeader({
           <div className="text-right">
             <div className="text-xs font-medium text-ink-3">総資産</div>
             <div className="font-data overflow-x-auto whitespace-nowrap text-lg font-semibold">
-              {totalBalanceLabel}
+              {formatCurrency(displayedTotalBalance)}
             </div>
           </div>
         </div>
@@ -66,7 +72,7 @@ export function LevelHeader({
           </p>
           {status === "critical" && typeof criticalDays === "number" ? (
             <div className="flex items-baseline gap-1 text-critical">
-              <span className="font-data text-[40px] font-semibold leading-[48px]">{criticalDays}</span>
+              <span className="font-data text-[40px] font-semibold leading-[48px]">{displayedCriticalDays}</span>
               <span className="text-sm font-medium">日</span>
             </div>
           ) : null}

--- a/packages/frontend/src/components/offline-banner.tsx
+++ b/packages/frontend/src/components/offline-banner.tsx
@@ -1,0 +1,26 @@
+import { WifiOff } from "lucide-react";
+import { useIsOffline } from "../hooks/use-online-status";
+
+/**
+ * オフラインバナー（B-1）。navigator.onLine とフェッチ失敗を組み合わせて判定する
+ * useIsOffline を購読し、通信不能時のみ非侵襲な帯として表示する。
+ * 通常フロー内の要素として上部に挿入し、フルスクリーンのオーバーレイにはしない。
+ */
+export function OfflineBanner() {
+  const isOffline = useIsOffline();
+
+  if (!isOffline) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="offline-banner flex items-center justify-center gap-2 border-b border-line bg-surface-2 px-3 py-2 text-xs font-medium text-ink-2 sm:text-sm"
+    >
+      <WifiOff aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
+      オフラインです。通信が回復すると自動的に最新の状態に戻ります。
+    </div>
+  );
+}

--- a/packages/frontend/src/components/offset-toggle.tsx
+++ b/packages/frontend/src/components/offset-toggle.tsx
@@ -1,5 +1,12 @@
 import { Switch } from "./ui/switch";
 
+const label = "可処分残高で表示";
+const description = "オフセット分を差し引いた可処分残高で計算します（オフのときは実残高で計算します）。";
+
+/**
+ * 用語統一（P9）: 「残高オフセットを適用」という、何が起きるか分からない文言をやめ、
+ * 何が表示されるかを言い切る（可処分残高／実残高の切替であることを明示する）。
+ */
 export function OffsetToggle({
   checked,
   onChange,
@@ -8,9 +15,12 @@ export function OffsetToggle({
   onChange: (value: boolean) => void;
 }) {
   return (
-    <div className="flex max-w-full min-w-0 items-center gap-3 rounded-[var(--radius-s)] border border-line bg-surface-2 px-4 py-2 text-sm">
-      <span className="min-w-0 truncate">残高オフセットを適用</span>
-      <Switch checked={checked} onChange={onChange} aria-label="残高オフセットを適用" />
+    <div
+      className="flex max-w-full min-w-0 items-center gap-3 rounded-[var(--radius-s)] border border-line bg-surface-2 px-4 py-2 text-sm"
+      title={description}
+    >
+      <span className="min-w-0 truncate">{label}</span>
+      <Switch checked={checked} onChange={onChange} aria-label={`${label}。${description}`} />
     </div>
   );
 }

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -27,10 +27,10 @@ export function DialogContent({
   Omit<ComponentProps<typeof DialogPrimitive.Content>, "className">) {
   return (
     <DialogPrimitive.Portal>
-      <DialogPrimitive.Overlay className="fixed inset-0 bg-black/70" />
+      <DialogPrimitive.Overlay className="dialog-overlay fixed inset-0 bg-black/70" />
       <DialogPrimitive.Content
         className={cn(
-          "fixed left-1/2 top-1/2 max-h-[90dvh] min-w-0 -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-[var(--radius-l)] border border-line bg-surface-1 p-4 shadow-[var(--elev-1)] sm:p-6",
+          "dialog-content fixed left-1/2 top-1/2 max-h-[90dvh] min-w-0 -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-[var(--radius-l)] border border-line bg-surface-1 p-4 shadow-[var(--elev-1)] sm:p-6",
           sizeClass[size],
           className,
         )}

--- a/packages/frontend/src/components/ui/toast.tsx
+++ b/packages/frontend/src/components/ui/toast.tsx
@@ -3,8 +3,8 @@ import { useToast } from "../../hooks/use-toast";
 import { cn } from "../../lib/utils";
 
 /**
- * トースト基盤。成功は 3 秒で自動クローズ、失敗は手動クローズのみ。
- * layout 直下に一度だけマウントする。
+ * トースト基盤。成功は 3 秒で自動クローズ、失敗と情報（PWA 更新プロンプトなど）は
+ * 手動クローズまたは action の実行まで残す。layout 直下に一度だけマウントする。
  */
 export function Toaster() {
   const { toasts, dismiss } = useToast();
@@ -23,7 +23,9 @@ export function Toaster() {
           }}
           className={cn(
             "grid grid-cols-[1fr_auto] items-start gap-x-3 rounded-[var(--radius-m)] border p-4 shadow-[var(--elev-1)]",
-            item.variant === "success" ? "border-line bg-surface-1" : "border-critical/50 bg-surface-1",
+            item.variant === "success" && "border-line bg-surface-1",
+            item.variant === "error" && "border-critical/50 bg-surface-1",
+            item.variant === "info" && "border-brand/40 bg-surface-1",
           )}
         >
           <div className="grid gap-1 min-w-0">
@@ -34,12 +36,28 @@ export function Toaster() {
               </ToastPrimitive.Description>
             ) : null}
           </div>
-          <ToastPrimitive.Close
-            aria-label="閉じる"
-            className="shrink-0 rounded-[var(--radius-s)] px-2 py-1 text-xs font-medium text-ink-3 transition hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-          >
-            閉じる
-          </ToastPrimitive.Close>
+          <div className="flex shrink-0 items-center gap-2">
+            {item.action ? (
+              <ToastPrimitive.Action asChild altText={item.action.label}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    item.action?.onClick();
+                    dismiss(item.id);
+                  }}
+                  className="rounded-[var(--radius-s)] border border-brand/50 px-3 py-1.5 text-xs font-semibold text-brand transition hover:bg-brand/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                >
+                  {item.action.label}
+                </button>
+              </ToastPrimitive.Action>
+            ) : null}
+            <ToastPrimitive.Close
+              aria-label="閉じる"
+              className="rounded-[var(--radius-s)] px-2 py-1 text-xs font-medium text-ink-3 transition hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+            >
+              閉じる
+            </ToastPrimitive.Close>
+          </div>
         </ToastPrimitive.Root>
       ))}
       <ToastPrimitive.Viewport

--- a/packages/frontend/src/hooks/use-count-up.ts
+++ b/packages/frontend/src/hooks/use-count-up.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
+
+function easeOutCubic(progress: number) {
+  return 1 - (1 - progress) ** 3;
+}
+
+/**
+ * 判定数値のカウントアップ（C-2 モーション原則）。0 から目標値まで、マウント後の
+ * 一度きり `durationMs` かけてアニメーションする。完了後（`hasAnimated`）は target を
+ * そのまま返すだけの派生値になるため、以降の値変更は自動的に即時反映される
+ * （初回のみの規約。effect 内で state を props に同期させる必要がない）。
+ * `prefers-reduced-motion: reduce` では最初から即時表示にする。
+ */
+export function useCountUp(target: number, durationMs = 500) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [hasAnimated, setHasAnimated] = useState(prefersReducedMotion);
+  const [animatingValue, setAnimatingValue] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (hasAnimated) {
+      return;
+    }
+
+    const start = performance.now();
+    let frame = requestAnimationFrame(function step(now) {
+      const progress = Math.min(1, (now - start) / durationMs);
+      setAnimatingValue(Math.round(target * easeOutCubic(progress)));
+      if (progress < 1) {
+        frame = requestAnimationFrame(step);
+      } else {
+        setHasAnimated(true);
+      }
+    });
+
+    return () => cancelAnimationFrame(frame);
+    // マウント時の一度きりのアニメーションなので、依存はここで固定する。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return hasAnimated ? target : (animatingValue ?? 0);
+}

--- a/packages/frontend/src/hooks/use-online-status.ts
+++ b/packages/frontend/src/hooks/use-online-status.ts
@@ -1,0 +1,11 @@
+import { useSyncExternalStore } from "react";
+import { getIsOffline, subscribeOffline } from "../lib/network-status";
+
+function getServerSnapshot() {
+  return false;
+}
+
+/** オフラインバナー用。navigator.onLine とフェッチ失敗の両方から更新される。 */
+export function useIsOffline() {
+  return useSyncExternalStore(subscribeOffline, getIsOffline, getServerSnapshot);
+}

--- a/packages/frontend/src/hooks/use-prefers-reduced-motion.ts
+++ b/packages/frontend/src/hooks/use-prefers-reduced-motion.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+function getPrefersReducedMotion() {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : false;
+}
+
+/**
+ * `prefers-reduced-motion: reduce` の購読。カウントアップやチャート描線など、
+ * JS で駆動するモーションを CSS の `@media` だけでは制御できない箇所で使う。
+ */
+export function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(getPrefersReducedMotion);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const listener = (event: MediaQueryListEvent) => setReduced(event.matches);
+    query.addEventListener("change", listener);
+    return () => query.removeEventListener("change", listener);
+  }, []);
+
+  return reduced;
+}

--- a/packages/frontend/src/hooks/use-toast.ts
+++ b/packages/frontend/src/hooks/use-toast.ts
@@ -1,12 +1,18 @@
 import { useEffect, useState } from "react";
 
-export type ToastVariant = "success" | "error";
+export type ToastVariant = "success" | "error" | "info";
+
+export type ToastAction = {
+  label: string;
+  onClick: () => void;
+};
 
 export type ToastItem = {
   id: string;
   title: string;
   description?: string;
   variant: ToastVariant;
+  action?: ToastAction;
 };
 
 type Listener = (toasts: ToastItem[]) => void;
@@ -33,15 +39,30 @@ export function dismissToast(id: string) {
   emit();
 }
 
-export function showToast(input: { title: string; description?: string; variant?: ToastVariant }) {
+export function showToast(input: {
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+  action?: ToastAction;
+}) {
   const id = createId();
-  toasts = [...toasts, { id, title: input.title, description: input.description, variant: input.variant ?? "success" }];
+  toasts = [
+    ...toasts,
+    {
+      id,
+      title: input.title,
+      description: input.description,
+      variant: input.variant ?? "success",
+      action: input.action,
+    },
+  ];
   emit();
   return id;
 }
 
 /**
- * 成功/失敗トーストの購読と発火。成功は 3 秒で自動クローズ、失敗は手動クローズ（<Toaster /> 側で制御）。
+ * 成功/失敗/情報トーストの購読と発火。成功は 3 秒で自動クローズ、失敗と情報（PWA 更新
+ * プロンプトなど）は手動クローズまたは action の実行までとどまる（<Toaster /> 側で制御）。
  */
 export function useToast() {
   const [items, setItems] = useState(toasts);

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -151,3 +151,161 @@ textarea:focus-visible,
   outline: 2px solid var(--brand);
   outline-offset: 2px;
 }
+
+/*
+ * 初回リビール（C-2 モーション原則）。ダッシュボード初回ロードの 3 段
+ * （判定 → チャート → リスト）を各 60ms ずらしてフェード+4px 上昇させる。
+ * データを持たないマウント時の一度きりの演出であり、ループやホバー発光はしない。
+ */
+@keyframes reveal-up {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes reveal-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.reveal-stage-1,
+.reveal-stage-2,
+.reveal-stage-3 {
+  animation: reveal-up 240ms ease-out both;
+}
+
+.reveal-stage-1 {
+  animation-delay: 0ms;
+}
+
+.reveal-stage-2 {
+  animation-delay: 60ms;
+}
+
+.reveal-stage-3 {
+  animation-delay: 120ms;
+}
+
+/*
+ * ダイアログの開閉フィードバック（150〜200ms ease-out）。Radix の Presence が
+ * data-state="closed" のアニメーション完了を待ってからアンマウントするため、
+ * プレーン CSS の @keyframes だけで成立する（追加ライブラリなし）。
+ * transform ではなく scale/opacity を使い、ボトムシート化のための translate
+ * 上書き（dashboard.tsx の確定ダイアログ）と衝突させない。
+ */
+@keyframes dialog-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialog-overlay-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes dialog-content-in {
+  from {
+    opacity: 0;
+    scale: 0.98;
+  }
+  to {
+    opacity: 1;
+    scale: 1;
+  }
+}
+
+@keyframes dialog-content-out {
+  from {
+    opacity: 1;
+    scale: 1;
+  }
+  to {
+    opacity: 0;
+    scale: 0.98;
+  }
+}
+
+.dialog-overlay {
+  animation: dialog-overlay-in 180ms ease-out both;
+}
+
+.dialog-overlay[data-state="closed"] {
+  animation: dialog-overlay-out 180ms ease-out both;
+}
+
+.dialog-content {
+  animation: dialog-content-in 180ms ease-out both;
+}
+
+.dialog-content[data-state="closed"] {
+  animation: dialog-content-out 180ms ease-out both;
+}
+
+/* オフラインバナー（B-1）。非侵襲な通常フローの帯として現れるだけなので、フェードのみ。 */
+@keyframes offline-banner-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.offline-banner {
+  animation: offline-banner-in 200ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-stage-1,
+  .reveal-stage-2,
+  .reveal-stage-3 {
+    animation-name: reveal-fade;
+  }
+
+  .dialog-content {
+    animation-name: dialog-fade-in;
+  }
+
+  .dialog-content[data-state="closed"] {
+    animation-name: dialog-fade-out;
+  }
+
+  .offline-banner {
+    animation-duration: 1ms;
+  }
+}
+
+@keyframes dialog-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialog-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { reportFetchFailure, reportFetchSuccess } from "./network-status";
+
 const JSON_HEADERS = {
   "Content-Type": "application/json",
   "x-sui-client": "web",
@@ -14,8 +16,13 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
       },
     });
   } catch {
+    // fetch 自体の例外は大抵オフラインが原因（B-1 オフラインバナー）。
+    reportFetchFailure();
     throw new Error("ネットワークに接続できません。通信状態を確認してください。");
   }
+
+  // ステータスに関わらず応答が返ってきたのはオンラインの証拠。
+  reportFetchSuccess();
 
   if (response.status === 204) {
     return undefined as T;

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -52,6 +52,70 @@ export function formatCurrencyParts(
   };
 }
 
+/** 符号規約（B-7）で使う取引種別。調整は元データが符号付き、それ以外は常に正の絶対値で渡される。 */
+export type SignableTransactionType = "income" | "expense" | "transfer" | "adjustment";
+
+function resolveSignedAmount(type: SignableTransactionType, amount: number): number {
+  if (type === "expense") {
+    return -amount;
+  }
+
+  // income は常に正、adjustment は元々符号付き、transfer は符号を付けない（呼び出し側で無視する）。
+  return amount;
+}
+
+/** 正なら「+」、負なら「-」、ゼロなら符号なしで整形する。 */
+export function formatSignedCurrency(value: number, currencyCode: SupportedCurrencyCode = DEFAULT_CURRENCY_CODE) {
+  if (value > 0) {
+    return `+${formatCurrency(value, currencyCode)}`;
+  }
+
+  if (value < 0) {
+    return `-${formatCurrency(Math.abs(value), currencyCode)}`;
+  }
+
+  return formatCurrency(0, currencyCode);
+}
+
+/**
+ * 符号規約（B-7）: 収入は+、支出は-、色は状態にのみ使う。振替は符号を付けない。
+ * 調整取引だけに「+」が付いていた現状をやめ、収入・支出にも同じ規約を適用する。
+ */
+export function formatTypedAmount(
+  type: SignableTransactionType,
+  amount: number,
+  currencyCode: SupportedCurrencyCode = DEFAULT_CURRENCY_CODE,
+) {
+  if (type === "transfer") {
+    return formatCurrency(amount, currencyCode);
+  }
+
+  return formatSignedCurrency(resolveSignedAmount(type, amount), currencyCode);
+}
+
+/**
+ * ResponsiveTable の金額セル用。主金額（符号付き）と JPY 換算額（符号付き）を分けて返す。
+ */
+export function formatTypedAmountParts(
+  type: SignableTransactionType,
+  amount: number,
+  currencyCode: SupportedCurrencyCode,
+  amountJpy: number,
+): { primary: string; secondary: string | null } {
+  const primary = formatTypedAmount(type, amount, currencyCode);
+
+  if (currencyCode === "JPY") {
+    return { primary, secondary: null };
+  }
+
+  const secondary =
+    type === "transfer"
+      ? formatCurrency(amountJpy, "JPY")
+      : formatSignedCurrency(resolveSignedAmount(type, amountJpy), "JPY");
+
+  return { primary, secondary };
+}
+
 export function formatCurrencyInputValue(value: number, currencyCode: SupportedCurrencyCode) {
   const minorUnits = getCurrencyMinorUnits(currencyCode);
   if (minorUnits === 0) {

--- a/packages/frontend/src/lib/network-status.ts
+++ b/packages/frontend/src/lib/network-status.ts
@@ -1,0 +1,42 @@
+type Listener = () => void;
+
+let offline = typeof navigator !== "undefined" && "onLine" in navigator ? !navigator.onLine : false;
+const listeners = new Set<Listener>();
+
+function setOffline(next: boolean) {
+  if (offline === next) {
+    return;
+  }
+
+  offline = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("online", () => setOffline(false));
+  window.addEventListener("offline", () => setOffline(true));
+}
+
+/**
+ * オフラインバナー（B-1）: `navigator.onLine` とフェッチ失敗を組み合わせて判定する。
+ * `navigator.onLine` はブラウザによって不正確なことがあるため、実際のフェッチ失敗
+ * （apiFetch の catch）でも offline とみなし、いずれかの応答成功で復帰させる。
+ */
+export function reportFetchFailure() {
+  setOffline(true);
+}
+
+export function reportFetchSuccess() {
+  setOffline(false);
+}
+
+export function subscribeOffline(listener: Listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getIsOffline() {
+  return offline;
+}

--- a/packages/frontend/src/routes/accounts.tsx
+++ b/packages/frontend/src/routes/accounts.tsx
@@ -262,7 +262,7 @@ export function AccountsPage() {
             columns={columns}
             rows={data ?? []}
             rowKey={(account) => account.id}
-            emptyMessage="口座が登録されていません。"
+            emptyMessage="口座が登録されていません。上部の「口座を追加」から登録してください。"
             mobileRow={(account) => (
               <>
                 <div className="flex items-start justify-between gap-3">
@@ -451,7 +451,11 @@ function AccountEditModal({
         />
       </FormField>
 
-      <FormField label={`オフセット (${form.currencyCode})`} htmlFor={offsetId}>
+      <FormField
+        label={`オフセット (${form.currencyCode})`}
+        htmlFor={offsetId}
+        help="この金額を残高から差し引いた額が可処分残高になります（例: 他人の預り金など、自由に使えない分を指定します）。"
+      >
         <MoneyInput
           id={offsetId}
           currencyCode={form.currencyCode}

--- a/packages/frontend/src/routes/credit-cards.tsx
+++ b/packages/frontend/src/routes/credit-cards.tsx
@@ -491,7 +491,7 @@ export function CreditCardsPage() {
             columns={cardColumns}
             rows={data?.cards ?? []}
             rowKey={(card) => card.id}
-            emptyMessage="カードが登録されていません。"
+            emptyMessage="カードが登録されていません。上部の「カードを追加」から登録してください。"
             mobileRow={(card) => (
               <>
                 <div className="flex items-start justify-between gap-3">

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -8,6 +8,8 @@ import type {
   SupportedCurrencyCode,
 } from "@sui/shared";
 import { useEffect, useMemo, useState, startTransition } from "react";
+import { useNavigate } from "react-router-dom";
+import { Repeat, TrendingUp, Wallet } from "lucide-react";
 import { AccountLevelList, type AccountLevelRow } from "../components/account-level-list";
 import { BalanceChart } from "../components/balance-chart";
 import { LevelHeader, type LevelHeaderStatus } from "../components/level-header";
@@ -24,6 +26,7 @@ import {
   DialogTitle,
 } from "../components/ui/dialog";
 import { Input } from "../components/ui/input";
+import { MoneyCell } from "../components/ui/responsive-table";
 import { Select } from "../components/ui/select";
 import { Switch } from "../components/ui/switch";
 import { Table, TableWrapper } from "../components/ui/table";
@@ -35,6 +38,8 @@ import {
   formatCurrencyInputValue,
   formatCurrencyWithJpy,
   formatDateWithYear,
+  formatTypedAmount,
+  formatTypedAmountParts,
   parseCurrencyInputValue,
 } from "../lib/format";
 import {
@@ -277,6 +282,7 @@ function pickEarliestWarning<T extends { firstNegativeDate: string }>(list: T[])
 
 export function DashboardPage() {
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [reloadKey, setReloadKey] = useState(0);
   const [selectedAccountId, setSelectedAccountId] = useState<string | "total">("total");
   const [periodPreset, setPeriodPreset] = useState<DashboardPeriodPreset>(DEFAULT_DASHBOARD_PERIOD);
@@ -360,10 +366,10 @@ export function DashboardPage() {
     selectedAccountForecast?.currentBalance ?? dashboardData?.dashboard.totalBalance ?? 0;
   const displayCurrencyCode: SupportedCurrencyCode = selectedAccountForecast?.currencyCode ?? "JPY";
   const chartExchangeRateToJpy = selectedAccountForecast?.exchangeRateToJpy ?? 1;
-  const chartLabel = selectedAccountForecast?.accountName ?? "総所持金";
+  const chartLabel = selectedAccountForecast?.accountName ?? "全体";
   const todayChartPoint = {
     date: today,
-    description: selectedAccountForecast ? `${selectedAccountForecast.accountName} 現在残高` : "総所持金",
+    description: selectedAccountForecast ? `${selectedAccountForecast.accountName} 現在残高` : "全体 現在残高",
     balance: currentBalance,
   };
   const chartData = useMemo(
@@ -681,12 +687,16 @@ export function DashboardPage() {
 
   return (
     <div className="grid gap-6">
-      <Card className="grid gap-6">
+      {!dashboardLoading && accounts.length === 0 ? (
+        <OnboardingCard onNavigate={navigate} />
+      ) : null}
+
+      <Card className="reveal-stage-1 grid gap-6">
         <LevelHeader
           status={levelStatus}
           heroText={heroText}
           criticalDays={criticalDays}
-          totalBalanceLabel={formatCurrency(dashboardData?.dashboard.totalBalance ?? 0)}
+          totalBalance={dashboardData?.dashboard.totalBalance ?? 0}
           minBalanceLabel={formatCurrency(dashboardData?.dashboard.minBalance ?? 0)}
           onMinBalanceClick={
             dashboardData
@@ -735,13 +745,13 @@ export function DashboardPage() {
         </div>
       </Card>
 
-      <Card>
+      <Card className="reveal-stage-2">
         <h2 className="mb-4 text-lg font-semibold">口座別の水位</h2>
         <AccountLevelList rows={accountLevelRows} selectedId={selectedAccountId} onSelect={setSelectedAccountId} />
       </Card>
 
       {visibleOverdueForecast.length > 0 ? (
-        <Card>
+        <Card className="reveal-stage-3">
           <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-3">
               <h2 className="text-lg font-semibold">確定キュー</h2>
@@ -777,7 +787,7 @@ export function DashboardPage() {
                         <tr
                           key={event.id}
                           className={cn(
-                            "border-b border-line align-top",
+                            "border-b border-line align-top transition-opacity duration-200 ease-out motion-reduce:transition-none",
                             !isConfirmed && "cursor-pointer hover:bg-surface-2",
                             isConfirmed && "opacity-50",
                           )}
@@ -875,7 +885,7 @@ export function DashboardPage() {
         </Card>
       ) : null}
 
-      <Card>
+      <Card className="reveal-stage-3">
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
           <h2 className="min-w-0 break-words text-xl font-semibold">
             {selectedAccountForecast ? `${selectedAccountForecast.accountName} の予測イベント` : "予測イベント"}
@@ -906,8 +916,8 @@ export function DashboardPage() {
                   <th scope="col" className="px-3 py-3">日付</th>
                   <th scope="col" className="px-3 py-3">種別</th>
                   <th scope="col" className="px-3 py-3">内容</th>
-                  <th scope="col" className="px-3 py-3">金額</th>
-                  <th scope="col" className="px-3 py-3">残高</th>
+                  <th scope="col" className="px-3 py-3 text-right">金額</th>
+                  <th scope="col" className="px-3 py-3 text-right">残高</th>
                   <th scope="col" className="px-3 py-3">対象口座</th>
                   <th scope="col" className="px-3 py-3" />
                 </tr>
@@ -920,7 +930,7 @@ export function DashboardPage() {
                     <tr
                       key={event.id}
                       className={cn(
-                        "border-b border-line",
+                        "border-b border-line transition-opacity duration-200 ease-out motion-reduce:transition-none",
                         !isConfirmed && "cursor-pointer hover:bg-surface-2",
                         isConfirmed && "opacity-50",
                       )}
@@ -938,13 +948,21 @@ export function DashboardPage() {
                           {event.isAssumption ? <Badge tone="warning">仮定</Badge> : null}
                         </div>
                       </td>
-                      <td className="font-data px-3 py-3">
-                        {formatCurrencyWithJpy(event.amount, event.currencyCode, event.amountJpy)}
+                      <td className="px-3 py-3">
+                        {(() => {
+                          const parts = formatTypedAmountParts(event.type, event.amount, event.currencyCode, event.amountJpy);
+                          return <MoneyCell primary={parts.primary} secondary={parts.secondary} />;
+                        })()}
                       </td>
-                      <td className="font-data px-3 py-3">
-                        {selectedAccountForecast
-                          ? formatCurrencyWithJpy(event.balance, event.currencyCode, event.balanceJpy)
-                          : formatCurrency(event.balanceJpy)}
+                      <td className="px-3 py-3">
+                        {selectedAccountForecast ? (
+                          <MoneyCell
+                            primary={formatCurrency(event.balance, event.currencyCode)}
+                            secondary={event.currencyCode === "JPY" ? null : formatCurrency(event.balanceJpy, "JPY")}
+                          />
+                        ) : (
+                          <MoneyCell primary={formatCurrency(event.balanceJpy)} />
+                        )}
                       </td>
                       <td className="px-3 py-3">
                         {formatForecastAccounts(event, accounts)}
@@ -1037,8 +1055,8 @@ export function DashboardPage() {
                             <th scope="col" className="px-3 py-3">種別</th>
                             <th scope="col" className="px-3 py-3">source</th>
                             <th scope="col" className="px-3 py-3">内容</th>
-                            <th scope="col" className="px-3 py-3">金額</th>
-                            <th scope="col" className="px-3 py-3">残高</th>
+                            <th scope="col" className="px-3 py-3 text-right">金額</th>
+                            <th scope="col" className="px-3 py-3 text-right">残高</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -1061,10 +1079,10 @@ export function DashboardPage() {
                                   {event.isAssumption ? <Badge tone="warning">仮定</Badge> : null}
                                 </div>
                               </td>
-                              <td className="whitespace-nowrap px-3 py-3">
-                                {formatCurrency(event.amountJpy)}
+                              <td className="font-data whitespace-nowrap px-3 py-3 text-right">
+                                {formatTypedAmount(event.type, event.amountJpy)}
                               </td>
-                              <td className="whitespace-nowrap px-3 py-3">
+                              <td className="font-data whitespace-nowrap px-3 py-3 text-right">
                                 {formatCurrency(event.runningBalance)}
                               </td>
                             </tr>
@@ -1101,7 +1119,9 @@ export function DashboardPage() {
                   <div>{selectedEvent.description}</div>
                   <div className="mt-1 text-ink-2">
                     {formatDateWithYear(selectedEvent.date)} /{" "}
-                    {formatCurrencyWithJpy(selectedEvent.amount, selectedEvent.currencyCode, selectedEvent.amountJpy)}
+                    {selectedEvent.currencyCode === "JPY"
+                      ? formatTypedAmount(selectedEvent.type, selectedEvent.amount, selectedEvent.currencyCode)
+                      : `${formatTypedAmount(selectedEvent.type, selectedEvent.amount, selectedEvent.currencyCode)}（${formatTypedAmount(selectedEvent.type, selectedEvent.amountJpy, "JPY")}）`}
                   </div>
                 </>
               )}
@@ -1158,6 +1178,68 @@ export function DashboardPage() {
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+const onboardingSteps = [
+  {
+    icon: Wallet,
+    title: "口座を登録",
+    description: "現在の残高を持つ口座を追加します。予測の起点になります。",
+    actionLabel: "口座を追加",
+    to: "/accounts",
+  },
+  {
+    icon: Repeat,
+    title: "固定収支を登録",
+    description: "給与や家賃など、毎月決まって動くお金を登録します。",
+    actionLabel: "固定収支を追加",
+    to: "/recurring",
+  },
+  {
+    icon: TrendingUp,
+    title: "予測が生まれる",
+    description: "登録した口座と固定収支から、残高の予測がここに自動で表示されます。",
+  },
+] as const;
+
+/**
+ * オンボーディング空状態（B-1 empty）。口座ゼロの初回起動時は「¥0 カード＋空メッセージ」
+ * ではなく、次に何をすべきかの 3 ステップを導線として示す。
+ */
+function OnboardingCard({ onNavigate }: { onNavigate: (to: string) => void }) {
+  return (
+    <Card className="reveal-stage-1 grid gap-4">
+      <div>
+        <h2 className="text-lg font-semibold">はじめに</h2>
+        <p className="mt-1 text-sm text-ink-2">
+          口座と固定収支を登録すると、残高の予測がこのダッシュボードに表示されます。
+        </p>
+      </div>
+      <ol className="grid gap-3 sm:grid-cols-3">
+        {onboardingSteps.map((step, index) => (
+          <li key={step.title} className="grid gap-2 rounded-[var(--radius-m)] border border-line bg-surface-2 p-4">
+            <div className="flex items-center gap-2 text-ink-3">
+              <span className="font-data flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-line-strong text-xs">
+                {index + 1}
+              </span>
+              <step.icon aria-hidden="true" className="h-4 w-4" />
+            </div>
+            <div className="text-sm font-semibold">{step.title}</div>
+            <p className="text-xs text-ink-2">{step.description}</p>
+            {"to" in step ? (
+              <Button
+                variant="secondary"
+                className="mt-1 justify-self-start"
+                onClick={() => onNavigate(step.to)}
+              >
+                {step.actionLabel}
+              </Button>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </Card>
   );
 }
 

--- a/packages/frontend/src/routes/loans.tsx
+++ b/packages/frontend/src/routes/loans.tsx
@@ -222,7 +222,7 @@ export function LoansPage() {
         {error ? (
           <ErrorBlock message={error} onRetry={reload} />
         ) : loans.length === 0 ? (
-          <p className="text-sm text-ink-3">ローンが登録されていません。</p>
+          <p className="text-sm text-ink-3">ローンが登録されていません。上部の「ローンを追加」から登録してください。</p>
         ) : (
           loans.map((loan) => (
             <LoanRow key={loan.id} loan={loan} accounts={accounts} onEdit={openEdit} onDelete={requestDelete} />

--- a/packages/frontend/src/routes/recurring.tsx
+++ b/packages/frontend/src/routes/recurring.tsx
@@ -323,7 +323,7 @@ export function RecurringPage() {
             columns={columns}
             rows={data?.items ?? []}
             rowKey={(item) => item.id}
-            emptyMessage="固定収支が登録されていません。"
+            emptyMessage="固定収支が登録されていません。上部の「固定収支を追加」から登録してください。"
             mobileRow={(item) => (
               <>
                 <div className="flex items-start justify-between gap-3">

--- a/packages/frontend/src/routes/subscriptions.tsx
+++ b/packages/frontend/src/routes/subscriptions.tsx
@@ -401,7 +401,7 @@ export function SubscriptionsPage() {
             columns={columns}
             rows={subscriptions}
             rowKey={(subscription) => subscription.id}
-            emptyMessage="サブスクが登録されていません。"
+            emptyMessage="サブスクが登録されていません。上部の「サブスクを追加」から登録してください。"
             mobileRow={(subscription) => (
               <>
                 <div className="flex items-start justify-between gap-3">

--- a/packages/frontend/src/routes/transactions.tsx
+++ b/packages/frontend/src/routes/transactions.tsx
@@ -28,9 +28,9 @@ import { apiFetch } from "../lib/api";
 import {
   convertCurrencyInputToJpy,
   formatCurrency,
-  formatCurrencyParts,
-  formatCurrencyWithJpy,
   formatDateWithYear,
+  formatTypedAmount,
+  formatTypedAmountParts,
 } from "../lib/format";
 import { getTodayDate } from "../lib/utils";
 import { Pencil, Trash2 } from "lucide-react";
@@ -257,39 +257,18 @@ function formatTransactionAccounts(transaction: Transaction) {
   return sourceName;
 }
 
-function formatSignedCurrency(value: number, currencyCode: SupportedCurrencyCode) {
-  const formatted = formatCurrency(value, currencyCode);
-  return value > 0 ? `+${formatted}` : formatted;
-}
-
+// 符号規約（B-7）: 収入は+、支出は-、振替は符号なし。調整取引だけに「+」が付いていた
+// 現状をやめ、formatTypedAmount/formatTypedAmountParts（lib/format.ts）へ一本化する。
 function formatTransactionAmount(transaction: Transaction) {
-  if (transaction.type !== "adjustment") {
-    return formatCurrencyWithJpy(transaction.amount, transaction.currencyCode, transaction.amountJpy);
-  }
-
   if (transaction.currencyCode === "JPY") {
-    return formatSignedCurrency(transaction.amount, transaction.currencyCode);
+    return formatTypedAmount(transaction.type, transaction.amount, transaction.currencyCode);
   }
 
-  return [
-    formatSignedCurrency(transaction.amount, transaction.currencyCode),
-    formatSignedCurrency(transaction.amountJpy, "JPY"),
-  ].join(" / ");
+  return `${formatTypedAmount(transaction.type, transaction.amount, transaction.currencyCode)} / ${formatTypedAmount(transaction.type, transaction.amountJpy, "JPY")}`;
 }
 
 function getTransactionAmountParts(transaction: Transaction) {
-  if (transaction.type !== "adjustment") {
-    return formatCurrencyParts(transaction.amount, transaction.currencyCode, transaction.amountJpy);
-  }
-
-  if (transaction.currencyCode === "JPY") {
-    return { primary: formatSignedCurrency(transaction.amount, transaction.currencyCode), secondary: null };
-  }
-
-  return {
-    primary: formatSignedCurrency(transaction.amount, transaction.currencyCode),
-    secondary: formatSignedCurrency(transaction.amountJpy, "JPY"),
-  };
+  return formatTypedAmountParts(transaction.type, transaction.amount, transaction.currencyCode, transaction.amountJpy);
 }
 
 function getAccountBalanceJpy(account: Account, applyOffset: boolean) {
@@ -370,7 +349,7 @@ export function TransactionsPage() {
           {
             date: today,
             balance: currentBalance,
-            description: selectedAccount ? `${selectedAccount.name} 現在残高` : "総所持金",
+            description: selectedAccount ? `${selectedAccount.name} 現在残高` : "全体 現在残高",
           },
         ]
       : chartPoints;
@@ -513,7 +492,7 @@ export function TransactionsPage() {
     <div className="grid gap-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h2 className="text-2xl font-semibold">取引管理</h2>
+          <h2 className="text-2xl font-semibold">取引履歴</h2>
           <p className="mt-2 text-sm text-ink-2">手動取引の記録と履歴の確認を行います。</p>
         </div>
         <Button className="min-h-10 gap-2" onClick={() => setCreateOpen(true)}>
@@ -542,7 +521,7 @@ export function TransactionsPage() {
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
             <h2 className="break-words text-xl font-semibold">
-              {selectedAccount ? `${selectedAccount.name} の残高推移` : "所持金推移"}
+              {selectedAccount ? `${selectedAccount.name} の残高推移` : "残高推移"}
             </h2>
             <p className="text-sm text-ink-2">
               {selectedAccount ? "選択した口座に関係する確定取引から過去残高を復元します。" : "全口座合算の過去実績を表示します。"}
@@ -564,7 +543,7 @@ export function TransactionsPage() {
             <BalanceChart
               data={chartData}
               currentBalance={currentBalance}
-              label={selectedAccount?.name ?? "総所持金"}
+              label={selectedAccount?.name ?? "全体"}
               currencyCode={currentBalanceCurrencyCode}
             />
           </div>
@@ -574,7 +553,7 @@ export function TransactionsPage() {
       <Card>
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-xl font-semibold">取引履歴</h2>
+            <h2 className="text-xl font-semibold">取引一覧</h2>
             <p className="mt-1 text-sm text-ink-2">{loading ? "読み込み中..." : `${transactions?.total ?? 0} 件`}</p>
           </div>
           <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## 概要

`20260702-frontend.md` レビュー C-8 ロードマップの **ステージ4（磨き）**。#293 の続きで、再設計の最終段。

### モーション（C-2）
- ダッシュボード初回リビール（判定→チャート→リストを 60ms ずらし、4px 上昇＋フェード）、判定数値のカウントアップ（500ms 初回のみ、`useCountUp`）、ダイアログ開閉 150〜200ms ease-out、確定行の収納フェード。すべて `prefers-reduced-motion` でフェードのみに縮退。CSS のみ（ライブラリ追加なし）
- チャート描線アニメが毎更新で再生されていた実バグ（初回のみのはずが period/口座/オフセット切替でも再生）を修正

### オンボーディング空状態（B-1）
- 口座ゼロ時のダッシュボードに「口座を登録→固定収支を登録→予測が生まれる」の3ステップ導線カード。各一覧ページの空状態にも軽い誘導文

### オフラインバナー / PWA トースト統合（B-1）
- `navigator.onLine` ＋フェッチ失敗を組み合わせたオフラインバナー
- `PwaUpdatePrompt` を独自バナーからトースト基盤（info variant ＋アクションボタン）に統合

### 用語統一・符号規約（P9, B-7）
- 「取引管理」→「取引履歴」、「所持金推移」→「残高推移」、「総所持金」→「全体」に横断で収束。「残高オフセットを適用」→「可処分残高で表示」（説明文付き）
- 符号規約: 収入は＋・支出は−・振替は符号なし・色は状態にのみ（`formatTypedAmount`）。調整取引だけ＋が付いていた現状を是正
- ダッシュボードの予測/確定キュー/寄与分解テーブルに残っていた旧1行 JPY 表記を ResponsiveTable の2行併記に統一

## テスト

- `make lint` / `make typecheck` / `make build` / `make test-unit`（124）/ `make test-e2e`（59）すべて通過

これでレビュー全 4 段（P1〜P9、B-1〜B-10、C-1〜C-8）の対応が完了します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)