### PR TITLE
fix: 残高チャートを水位エリア＋角丸ステップに刷新し取引履歴から予測を除去

### DIFF
--- a/packages/frontend/src/components/balance-chart.tsx
+++ b/packages/frontend/src/components/balance-chart.tsx
@@ -1,7 +1,7 @@
 import {
+  Area,
   CartesianGrid,
-  Line,
-  LineChart,
+  ComposedChart,
   ReferenceArea,
   ReferenceDot,
   ReferenceLine,
@@ -21,6 +21,7 @@ import {
   dateOnlyToTimestamp,
   formatChartAxisTick,
   isMoreThanThreeMonths,
+  roundedStepAfter,
   timestampToDateOnly,
   type BalanceChartInputPoint,
   type DailyBalanceChartPoint,
@@ -43,6 +44,8 @@ const CHART_MARGIN = { left: 12, right: 12, top: 12, bottom: 8 };
 const Y_AXIS_WIDTH = 56;
 const X_AXIS_HEIGHT = 28;
 const INITIAL_ANIMATION_MS = 400;
+// 角を丸めた階段曲線。残高の階段的な意味論は保ちつつ、段差の 90 度の角をやわらげる。
+const roundedStepCurve = roundedStepAfter();
 
 function useElementSize() {
   const ref = useRef<HTMLDivElement>(null);
@@ -172,17 +175,19 @@ function BalanceTooltip({
   );
 }
 
-function ChartLegend() {
+function ChartLegend({ showForecast }: { showForecast: boolean }) {
   return (
     <div className="pointer-events-none absolute right-2 top-2 flex items-center gap-3 rounded-full border border-line bg-[rgba(17,21,28,0.72)] px-2.5 py-1 text-[11px] text-ink-2">
       <span className="flex items-center gap-1.5">
         <span className="inline-block h-0 w-3 border-t-2 border-solid border-chart-actual" />
         実績
       </span>
-      <span className="flex items-center gap-1.5">
-        <span className="inline-block h-0 w-3 border-t-2 border-dashed border-chart-forecast" />
-        予測
-      </span>
+      {showForecast ? (
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-0 w-3 border-t-2 border-dashed border-chart-forecast" />
+          予測
+        </span>
+      ) : null}
     </div>
   );
 }
@@ -224,6 +229,7 @@ export function BalanceChart({
     forecastLineSeries,
     xDomain,
   } = buildBalanceChartSegments({
+    // 予測データや「今日」境界が渡されないチャート（取引履歴＝事実のみ）では予測系列は空になる。
     actualPoints: data,
     forecastPoints: forecastData,
     todayPoint,
@@ -315,12 +321,22 @@ export function BalanceChart({
     <div ref={chartRef} className="relative h-full min-h-0 min-w-0">
       {chartSize.width > 0 && chartSize.height > 0 ? (
         <>
-          <LineChart
+          <ComposedChart
             data={chartData}
             height={chartSize.height}
             margin={CHART_MARGIN}
             width={chartSize.width}
           >
+            <defs>
+              <linearGradient id="balance-actual-fill" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="var(--chart-actual)" stopOpacity={0.22} />
+                <stop offset="100%" stopColor="var(--chart-actual)" stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="balance-forecast-fill" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="var(--chart-forecast)" stopOpacity={0.2} />
+                <stop offset="100%" stopColor="var(--chart-forecast)" stopOpacity={0} />
+              </linearGradient>
+            </defs>
             <CartesianGrid horizontal vertical={false} stroke="var(--line)" strokeOpacity={0.4} />
             {showNegativeArea ? (
               <ReferenceArea
@@ -400,12 +416,15 @@ export function BalanceChart({
               cursor={{ stroke: "var(--line-strong)", strokeDasharray: "4 4" }}
             />
             {actualLineSeries.length > 0 ? (
-              <Line
-                type="stepAfter"
+              <Area
+                type={roundedStepCurve}
                 dataKey="actualBalance"
+                baseValue={chartDomain[0]}
                 stroke="var(--chart-actual)"
                 strokeWidth={2}
                 strokeOpacity={0.55}
+                fill="url(#balance-actual-fill)"
+                fillOpacity={0.55}
                 dot={false}
                 activeDot={{ r: 4 }}
                 isAnimationActive={shouldAnimate}
@@ -414,12 +433,15 @@ export function BalanceChart({
               />
             ) : null}
             {forecastLineSeries.length > 0 ? (
-              <Line
-                type="stepAfter"
+              <Area
+                type={roundedStepCurve}
                 dataKey="forecastBalance"
+                baseValue={chartDomain[0]}
                 stroke="var(--chart-forecast)"
                 strokeDasharray="7 6"
                 strokeWidth={2}
+                fill="url(#balance-forecast-fill)"
+                fillOpacity={1}
                 dot={(dotProps: { cx?: number; cy?: number; payload?: BalanceChartDatum; index?: number }) => {
                   const { cx, cy, payload, index } = dotProps;
                   if (
@@ -444,8 +466,8 @@ export function BalanceChart({
                 connectNulls
               />
             ) : null}
-          </LineChart>
-          <ChartLegend />
+          </ComposedChart>
+          <ChartLegend showForecast={forecastLineSeries.length > 0} />
           {showTodayLine ? (
             <div
               className="pointer-events-none absolute -translate-x-1/2 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-[11px] text-ink-2"

--- a/packages/frontend/src/lib/balance-chart.ts
+++ b/packages/frontend/src/lib/balance-chart.ts
@@ -299,16 +299,22 @@ export function buildBalanceChartSegments({
   const forecastStartTimestamp = boundaryPoint
     ? Math.min(Math.max(boundaryPoint.timestamp, xDomain[0]), xDomain[1])
     : xDomain[0];
+  // 予測系列は「今日」境界か実際の予測データがあるときだけ生成する。
+  // どちらも無い（取引履歴のような事実のみのチャート）場合は空にして、
+  // 現在残高の高さに水平な破線が湧く（合成端点の副作用）のを防ぐ。
+  const hasForecastContext = boundaryPoint !== null || forecastEventSeries.length > 0;
 
   return {
     actualLineSeries: ensureRangeEndpoints(actualBaseSeries, xDomain[0], actualEndTimestamp, currentBalance),
     forecastEventSeries,
-    forecastLineSeries: ensureRangeEndpoints(
-      forecastBaseSeries,
-      forecastStartTimestamp,
-      xDomain[1],
-      boundaryPoint?.balance ?? currentBalance,
-    ),
+    forecastLineSeries: hasForecastContext
+      ? ensureRangeEndpoints(
+          forecastBaseSeries,
+          forecastStartTimestamp,
+          xDomain[1],
+          boundaryPoint?.balance ?? currentBalance,
+        )
+      : [],
     xDomain,
   };
 }
@@ -365,6 +371,106 @@ export function formatChartAxisTick(value: number, ticks: number[], useMonthTick
   }
 
   return `${month}月`;
+}
+
+type PathContext = {
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+};
+
+type Vertex = [number, number];
+
+const DEFAULT_CORNER_RADIUS = 7;
+
+/** データ点を stepAfter（前の値で水平 → 新しい値へ垂直）の頂点列に展開する。 */
+function toStepAfterVertices(points: Vertex[]): Vertex[] {
+  if (points.length === 0) {
+    return [];
+  }
+
+  const vertices: Vertex[] = [points[0]];
+  for (let index = 1; index < points.length; index += 1) {
+    const [x, y] = points[index];
+    const previousY = points[index - 1][1];
+    vertices.push([x, previousY]);
+    vertices.push([x, y]);
+  }
+
+  return vertices;
+}
+
+/** 折れ線の各頂点を半径 radius で面取りしてパスに書き出す。start が true なら直前のパスに連結する（面の下辺用）。 */
+function emitRoundedPolyline(context: PathContext, vertices: Vertex[], radius: number, connect: boolean) {
+  if (vertices.length === 0) {
+    return;
+  }
+
+  if (connect) {
+    context.lineTo(vertices[0][0], vertices[0][1]);
+  } else {
+    context.moveTo(vertices[0][0], vertices[0][1]);
+  }
+  if (vertices.length <= 2) {
+    for (let index = 1; index < vertices.length; index += 1) {
+      context.lineTo(vertices[index][0], vertices[index][1]);
+    }
+    return;
+  }
+
+  for (let index = 1; index < vertices.length - 1; index += 1) {
+    const [px, py] = vertices[index - 1];
+    const [cx, cy] = vertices[index];
+    const [nx, ny] = vertices[index + 1];
+    const d1 = Math.hypot(cx - px, cy - py);
+    const d2 = Math.hypot(nx - cx, ny - cy);
+    if (d1 === 0 || d2 === 0) {
+      context.lineTo(cx, cy);
+      continue;
+    }
+
+    const r = Math.min(radius, d1 / 2, d2 / 2);
+    context.lineTo(cx + ((px - cx) / d1) * r, cy + ((py - cy) / d1) * r);
+    context.quadraticCurveTo(cx, cy, cx + ((nx - cx) / d2) * r, cy + ((ny - cy) / d2) * r);
+  }
+
+  const last = vertices[vertices.length - 1];
+  context.lineTo(last[0], last[1]);
+}
+
+/**
+ * 角を丸めた stepAfter 曲線ファクトリ（Recharts / d3-shape の CurveFactory 互換）。
+ * 残高が階段関数である意味論（#283・C-6）は保ちつつ、90 度の角を面取りして
+ * 「ガッタガタ」した見た目をやわらげる。line と area の両方（面の上辺・下辺）に対応する。
+ */
+export function roundedStepAfter(radius = DEFAULT_CORNER_RADIUS) {
+  return function curveRoundedStepAfter(context: PathContext) {
+    let buffer: Vertex[] = [];
+    // d3 の area は上辺→下辺の 2 本を続けて描くため、下辺は moveTo ではなく lineTo で連結する必要がある。
+    // lineFlag: NaN=単純な線 / 0=面の上辺（moveTo）/ 1=面の下辺（lineTo で連結）。
+    let lineFlag = Number.NaN;
+
+    return {
+      areaStart() {
+        lineFlag = 0;
+      },
+      areaEnd() {
+        lineFlag = Number.NaN;
+      },
+      lineStart() {
+        buffer = [];
+      },
+      lineEnd() {
+        emitRoundedPolyline(context, toStepAfterVertices(buffer), radius, lineFlag === 1);
+        if (lineFlag === 0 || lineFlag === 1) {
+          lineFlag = 1 - lineFlag;
+        }
+      },
+      point(x: number, y: number) {
+        buffer.push([Number(x), Number(y)]);
+      },
+    };
+  };
 }
 
 export function getDashboardChartStartDate(today: string) {

--- a/packages/frontend/src/lib/format.test.ts
+++ b/packages/frontend/src/lib/format.test.ts
@@ -125,6 +125,20 @@ describe("buildBalanceChartSegments", () => {
     expect(segments.forecastLineSeries.map((point) => point.balance)).toEqual([100_000, 100_000]);
   });
 
+  it("omits the forecast line entirely when there is no forecast context", () => {
+    // 取引履歴のような事実だけのチャート（予測データも「今日」境界も無い）では、
+    // 予測系列が現在残高の高さに水平な破線として湧かないこと。
+    const segments = buildBalanceChartSegments({
+      actualPoints: [{ date: "2026-03-14", balance: 50_000, description: "Salary" }],
+      displayStartDate: "2026-03-01",
+      displayEndDate: "2026-03-31",
+      currentBalance: 50_000,
+    });
+
+    expect(segments.forecastLineSeries).toEqual([]);
+    expect(segments.actualLineSeries.length).toBeGreaterThan(0);
+  });
+
   it("extends a single actual point to the visible range endpoints", () => {
     const segments = buildBalanceChartSegments({
       actualPoints: [{ date: "2026-03-14", balance: 50_000, description: "Salary" }],


### PR DESCRIPTION
## 背景

フロントエンド再設計後のチャートに関するフィードバック2点に対応。

### 1. 取引履歴チャートの「最大値の破線」バグ（点1）
取引履歴ページの残高チャートは `forecastData` も「今日」境界も渡していないのに、`ensureRangeEndpoints` が空配列から現在残高の高さに合成端点を2つ生成し、**予測（破線）系列が現在残高の高さで水平の破線として描かれていた**。現在残高が最大値付近だと「最大値に張り付いた意味不明な破線」に見える。

取引履歴は事実（実績）だけを出すべきという指摘のとおり、予測コンテキスト（`todayPoint` か実際の予測データ）が無いときは予測系列も凡例「予測」も描かないように修正。ダッシュボード（予測あり）は従来どおり。

### 2. 階段の「ガッタガタ」感（点2）
`stepAfter` の90度の角が連続して素っ気ない見た目だった。残高が階段関数である意味論（#283・レビューC-6）は維持したまま、
- **角丸ステップ曲線**（`roundedStepAfter`: d3-shape / Recharts の CurveFactory 互換。段差の角を面取り）
- **水位のグラデーション塗り**（`LineChart`→`ComposedChart` + `Area`。sui＝水 の"夜の水位計"方向に合致）

を導入。過去は減光・未来を主役にする塗り分け（C-6）は維持。

## テスト

- `make lint` / `make typecheck` / `make build` / `make test-unit`（17, +1）/ `make test-e2e`（59）すべて通過
- 追加した単体テスト: 予測コンテキストが無いとき `forecastLineSeries` が空になること
- Playwright で両チャートを実機確認（取引履歴＝実績のみ・破線なし、ダッシュボード＝角丸＋水位塗り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)