### PR TITLE
fix: 口座別水位バーの右端を揃える

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -310,6 +310,92 @@ test("shows a warning judgement for disposable balance without the critical one"
   await expect(page.getByRole("button", { name: /Disposable Warning Account/ })).toContainText("可処分注意");
 });
 
+test("aligns account level bar tracks across rows with mixed currencies and stacks vertically on mobile", async ({ page }) => {
+  await seedAccount({
+    name: "JPY Main",
+    balance: 1_000_000,
+    currencyCode: "JPY",
+    sortOrder: 1,
+  });
+  const usd = await seedAccount({
+    name: "USD Wallet",
+    balance: 200000,
+    currencyCode: "USD",
+    exchangeRateToJpy: 150,
+    sortOrder: 2,
+  });
+  const eur = await seedAccount({
+    name: "EUR Wallet",
+    balance: 10000,
+    currencyCode: "EUR",
+    exchangeRateToJpy: 170,
+    sortOrder: 3,
+  });
+
+  await seedRecurringItem({
+    name: "USD Hosting",
+    type: "expense",
+    amount: 10000,
+    dayOfMonth: getFutureDayOfMonth(),
+    accountId: usd.id,
+    sortOrder: 1,
+  });
+  await seedRecurringItem({
+    name: "EUR Subscription",
+    type: "expense",
+    amount: 2000,
+    dayOfMonth: getFutureDayOfMonth(),
+    accountId: eur.id,
+    sortOrder: 1,
+  });
+
+  await navigateTo(page, "/");
+  await expect(page.getByRole("heading", { name: "口座別の水位" })).toBeVisible();
+
+  // デスクトップ：各口座のバートラック右端が揃う
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.waitForTimeout(100);
+
+  const desktopTrackRights = await page.evaluate(() => {
+    const tracks = Array.from(document.querySelectorAll('[data-testid="account-level-bar-track"]'));
+    return tracks.map((track) => track.getBoundingClientRect().right);
+  });
+
+  expect(desktopTrackRights.length).toBeGreaterThanOrEqual(3);
+  const firstDesktop = desktopTrackRights[0];
+  for (const right of desktopTrackRights) {
+    expect(right).toBeCloseTo(firstDesktop, 0);
+  }
+
+  // モバイル：各口座の情報ブロックと金額ブロックが縦に積み、重ならない
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.waitForTimeout(100);
+
+  await expect(page.getByRole("navigation", { name: "モバイルナビゲーション" })).toBeVisible();
+
+  const mobileStacks = await page.evaluate(() => {
+    const rows = Array.from(document.querySelectorAll('[data-testid="account-level-info"]'));
+    return rows.map((info) => {
+      const amounts = info.parentElement?.querySelector('[data-testid="account-level-amounts"]');
+      const infoRect = info.getBoundingClientRect();
+      const amountsRect = amounts?.getBoundingClientRect();
+      return { infoRect, amountsRect };
+    });
+  });
+
+  expect(mobileStacks.length).toBeGreaterThanOrEqual(3);
+  for (const { infoRect, amountsRect } of mobileStacks) {
+    expect(amountsRect).toBeTruthy();
+    expect(amountsRect.top).toBeGreaterThanOrEqual(infoRect.bottom + 4);
+    expect(amountsRect.left).toBeCloseTo(infoRect.left, 0);
+  }
+
+  const noHorizontalScroll = await page.evaluate(() => {
+    return document.documentElement.scrollWidth <= document.documentElement.clientWidth;
+  });
+  expect(noHorizontalScroll).toBe(true);
+});
+
 test("shows actual and assumed credit card events together with loan events", async ({ page }) => {
   const account = await seedAccount({ name: "Main Account", balance: 100000, sortOrder: 1 });
   const actualCard = await seedCreditCard({

--- a/packages/frontend/src/components/account-level-list.test.tsx
+++ b/packages/frontend/src/components/account-level-list.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { AccountLevelList, type AccountLevelRow } from "./account-level-list";
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseRows: AccountLevelRow[] = [
+  {
+    id: "usd",
+    name: "USD Wallet",
+    currentBalance: 200000,
+    currentBalanceJpy: 30000000,
+    currencyCode: "USD",
+    minBalance: 10000,
+    minBalanceJpy: 1500000,
+    minBalanceDate: "2026-07-11",
+    warningLevel: "none",
+  },
+  {
+    id: "jpy",
+    name: "JPY Wallet",
+    currentBalance: 1000000,
+    currentBalanceJpy: 1000000,
+    currencyCode: "JPY",
+    minBalance: 500000,
+    minBalanceJpy: 500000,
+    minBalanceDate: "2026-07-11",
+    warningLevel: "yellow",
+  },
+  {
+    id: "eur",
+    name: "EUR Wallet",
+    currentBalance: 10000,
+    currentBalanceJpy: 1700000,
+    currencyCode: "EUR",
+    minBalance: 5000,
+    minBalanceJpy: 850000,
+    minBalanceDate: "2026-07-11",
+    warningLevel: "red",
+  },
+];
+
+describe("AccountLevelList", () => {
+  it("renders account names, balances, and min balance dates", () => {
+    render(<AccountLevelList rows={baseRows} selectedId="total" onSelect={() => {}} />);
+
+    expect(screen.getByText("USD Wallet")).toBeVisible();
+    expect(screen.getByText("JPY Wallet")).toBeVisible();
+    expect(screen.getByText("EUR Wallet")).toBeVisible();
+
+    expect(screen.getByText("$2,000.00")).toBeVisible();
+    expect(screen.getByText(/[¥￥]30,000,000/)).toBeVisible();
+    expect(screen.getByText(/[¥￥]1,000,000/)).toBeVisible();
+    expect(screen.getByText("€100.00")).toBeVisible();
+
+    expect(screen.getAllByText(/期間内最小/)).toHaveLength(3);
+    expect(screen.getAllByText(/2026年7月11日/)).toHaveLength(3);
+  });
+
+  it("shows the selected row with a different style", () => {
+    const { container } = render(<AccountLevelList rows={baseRows} selectedId="jpy" onSelect={() => {}} />);
+    const buttons = container.querySelectorAll("button");
+
+    const jpyButton = Array.from(buttons).find((button) => button.textContent?.includes("JPY Wallet"));
+    expect(jpyButton).toHaveClass("border-brand", "bg-surface-2");
+
+    const usdButton = Array.from(buttons).find((button) => button.textContent?.includes("USD Wallet"));
+    expect(usdButton).toHaveClass("border-line", "bg-surface-1");
+  });
+
+  it("calls onSelect when a row is clicked", () => {
+    const onSelect = vi.fn();
+    render(<AccountLevelList rows={baseRows} selectedId="total" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /EUR Wallet/ }));
+    expect(onSelect).toHaveBeenCalledWith("eur");
+  });
+
+  it("renders bar widths proportional to the largest JPY balance", () => {
+    const { container } = render(<AccountLevelList rows={baseRows} selectedId="total" onSelect={() => {}} />);
+    const fills = container.querySelectorAll('[data-testid="account-level-bar-fill"]');
+
+    expect(fills).toHaveLength(3);
+
+    const usd = baseRows[0].currentBalanceJpy;
+    const jpy = baseRows[1].currentBalanceJpy;
+    const eur = baseRows[2].currentBalanceJpy;
+    const max = Math.max(usd, jpy, eur);
+
+    expect(fills[0]).toHaveStyle({ width: `${Math.max((usd / max) * 100, 3)}%` });
+    expect(fills[1]).toHaveStyle({ width: `${Math.max((jpy / max) * 100, 3)}%` });
+    expect(fills[2]).toHaveStyle({ width: `${Math.max((eur / max) * 100, 3)}%` });
+  });
+
+  it("uses a subgrid layout so the bar column shares the same track across all rows", () => {
+    const { container } = render(<AccountLevelList rows={baseRows} selectedId="total" onSelect={() => {}} />);
+    const list = container.firstElementChild;
+    const buttons = container.querySelectorAll("button");
+
+    expect(list).toHaveClass("grid", "grid-cols-1", "gap-2", "gap-x-4", "sm:grid-cols-[minmax(0,1fr)_fit-content(75%)]");
+
+    for (const button of buttons) {
+      expect(button).toHaveClass("grid-cols-subgrid", "col-span-full", "gap-y-2");
+    }
+  });
+
+  it("keeps numeric amounts from wrapping", () => {
+    const { container } = render(<AccountLevelList rows={baseRows} selectedId="total" onSelect={() => {}} />);
+    const numericCells = container.querySelectorAll(".font-data.whitespace-nowrap");
+
+    expect(numericCells.length).toBeGreaterThan(0);
+    for (const cell of numericCells) {
+      expect(cell).toHaveClass("overflow-x-auto", "whitespace-nowrap");
+    }
+  });
+});

--- a/packages/frontend/src/components/account-level-list.tsx
+++ b/packages/frontend/src/components/account-level-list.tsx
@@ -49,7 +49,7 @@ export function AccountLevelList({
   const maxBalance = Math.max(1, ...rows.map((row) => Math.abs(row.currentBalanceJpy)));
 
   return (
-    <div className="grid gap-2">
+    <div className="grid grid-cols-1 gap-2 gap-x-4 sm:grid-cols-[minmax(0,1fr)_fit-content(75%)]">
       {rows.map((row) => {
         const ratio = Math.min(1, Math.abs(row.currentBalanceJpy) / maxBalance);
         const isSelected = selectedId === row.id;
@@ -60,25 +60,29 @@ export function AccountLevelList({
             type="button"
             onClick={() => onSelect(row.id)}
             className={cn(
-              "grid min-w-0 gap-2 rounded-[var(--radius-m)] border p-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4",
+              "grid min-w-0 grid-cols-subgrid col-span-full gap-y-2 rounded-[var(--radius-m)] border p-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg sm:items-center",
               isSelected ? "border-brand bg-surface-2" : "border-line bg-surface-1 hover:border-line-strong",
             )}
           >
-            <div className="min-w-0">
+            <div className="min-w-0" data-testid="account-level-info">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="truncate text-sm font-medium">{row.name}</span>
                 <StatusChip tone={toneByWarningLevel[row.warningLevel]}>
                   {labelByWarningLevel[row.warningLevel]}
                 </StatusChip>
               </div>
-              <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-surface-2">
+              <div
+                className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-surface-2"
+                data-testid="account-level-bar-track"
+              >
                 <div
                   className={cn("h-full rounded-full", barColorByWarningLevel[row.warningLevel])}
+                  data-testid="account-level-bar-fill"
                   style={{ width: `${Math.max(ratio * 100, 3)}%` }}
                 />
               </div>
             </div>
-            <div className="grid min-w-0 gap-1 text-right">
+            <div className="grid min-w-0 gap-1 text-right" data-testid="account-level-amounts">
               {(() => {
                 const currentParts = formatCurrencyParts(row.currentBalance, row.currencyCode, row.currentBalanceJpy);
                 return (


### PR DESCRIPTION
## Summary

- align account-level bar tracks by sharing responsive grid columns across rows
- preserve the stacked mobile layout and spacing
- add unit and browser-level regression coverage for mixed currencies and responsive layouts

## Root cause

Each account row defined its own `1fr auto` grid. The auto-sized amount column therefore differed by row, causing the adjacent bar track to end at a different horizontal position.

## User impact

Account-level bars now share the same start and end positions on desktop even when balances use different currencies or digit widths. Mobile rows remain vertically stacked without overlap or horizontal page scrolling.

## Validation

Executed by Devin CLI using SWE-1.7:

- `make test-unit` — passed (23 tests)
- `make lint` — passed
- `make typecheck` — passed
- `make build` — passed
- `make test-e2e` — passed (60 tests)

Closes #300
