### PR TITLE
feat: クレカ請求入力に次月ボタンを追加

### DIFF
--- a/e2e/credit-cards.spec.ts
+++ b/e2e/credit-cards.spec.ts
@@ -217,6 +217,64 @@ test("validates monthly billing changes and confirms before switching months", a
   await expect(monthInput).toHaveValue(currentMonth);
 });
 
+test("advances to next month via the next month button and crosses years", async ({ page }) => {
+  const account = await seedAccount({ name: "Settlement Account" });
+  await seedCreditCard({
+    name: "Visa",
+    accountId: account.id,
+    assumptionAmount: 50000,
+    sortOrder: 1,
+  });
+
+  await navigateTo(page, "/credit-cards");
+
+  const monthInput = page.locator('input[type="month"]');
+
+  await page.getByRole("button", { name: "次月" }).click();
+  await expect(monthInput).toHaveValue(toYearMonth(getJstDate(1)));
+
+  await monthInput.fill("2026-12");
+  await waitForReload(page);
+  await page.getByRole("button", { name: "次月" }).click();
+  await expect(monthInput).toHaveValue("2027-01");
+
+  await monthInput.fill("2024-02");
+  await waitForReload(page);
+  await page.getByRole("button", { name: "次月" }).click();
+  await expect(monthInput).toHaveValue("2024-03");
+});
+
+test("confirms or cancels before switching to next month with unsaved changes", async ({ page }) => {
+  const account = await seedAccount({ name: "Settlement Account" });
+  await seedCreditCard({
+    name: "Visa",
+    accountId: account.id,
+    assumptionAmount: 50000,
+    sortOrder: 1,
+  });
+
+  await navigateTo(page, "/credit-cards");
+
+  const monthInput = page.locator('input[type="month"]');
+  const currentMonth = await monthInput.inputValue();
+
+  await billingInput(page, "Visa").fill("42000");
+  await expect(page.getByText("未保存の変更あり")).toBeVisible();
+
+  await page.getByRole("button", { name: "次月" }).click();
+  await expect(page.getByRole("heading", { name: "未保存の月次請求があります" })).toBeVisible();
+
+  await page.getByRole("button", { name: "キャンセル" }).click();
+  await expect(monthInput).toHaveValue(currentMonth);
+  await expect(billingInput(page, "Visa")).toHaveValue("42000");
+  await expect(page.getByText("未保存の変更あり")).toBeVisible();
+
+  await page.getByRole("button", { name: "次月" }).click();
+  await expect(page.getByRole("heading", { name: "未保存の月次請求があります" })).toBeVisible();
+  await page.getByRole("button", { name: "切り替える" }).click();
+  await expect(monthInput).toHaveValue(toYearMonth(getJstDate(1)));
+});
+
 test("supports keyboard entry across cards", async ({ page }) => {
   const account = await seedAccount({ name: "Settlement Account" });
   await seedCreditCard({

--- a/packages/frontend/src/lib/dates.test.ts
+++ b/packages/frontend/src/lib/dates.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { addMonthsToYearMonth } from "./dates";
+
+describe("addMonthsToYearMonth", () => {
+  it("advances by one month in normal and year-crossing cases", () => {
+    expect(addMonthsToYearMonth("2026-01", 1)).toBe("2026-02");
+    expect(addMonthsToYearMonth("2026-11", 1)).toBe("2026-12");
+    expect(addMonthsToYearMonth("2026-12", 1)).toBe("2027-01");
+  });
+
+  it("handles leap-year months without date parsing drift", () => {
+    expect(addMonthsToYearMonth("2024-01", 1)).toBe("2024-02");
+    expect(addMonthsToYearMonth("2024-02", 1)).toBe("2024-03");
+    expect(addMonthsToYearMonth("2024-12", 1)).toBe("2025-01");
+  });
+});

--- a/packages/frontend/src/lib/dates.ts
+++ b/packages/frontend/src/lib/dates.ts
@@ -1,0 +1,11 @@
+function pad(value: number) {
+  return String(value).padStart(2, "0");
+}
+
+export function addMonthsToYearMonth(yearMonth: string, offset: number): string {
+  const [year, month] = yearMonth.split("-").map(Number);
+  const total = year * 12 + (month - 1) + offset;
+  const nextYear = Math.floor(total / 12);
+  const nextMonth = (total % 12) + 1;
+  return `${nextYear}-${pad(nextMonth)}`;
+}

--- a/packages/frontend/src/routes/credit-cards.tsx
+++ b/packages/frontend/src/routes/credit-cards.tsx
@@ -24,6 +24,7 @@ import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import { formatCurrency } from "../lib/format";
 import { getCurrentYearMonth } from "../lib/utils";
+import { addMonthsToYearMonth } from "../lib/dates";
 import { Pencil, Trash2 } from "lucide-react";
 
 type CreditCardForm = {
@@ -332,6 +333,10 @@ export function CreditCardsPage() {
     setPendingYearMonth(null);
   };
 
+  const goToNextMonth = () => {
+    changeYearMonth(addMonthsToYearMonth(yearMonth, 1));
+  };
+
   const openEdit = (card: CreditCard) => {
     setEditingCard(card);
     setAssumptionSuggestion(null);
@@ -441,8 +446,11 @@ export function CreditCardsPage() {
             月次請求を保存
           </Button>
         </div>
-        <div className="flex justify-start">
+        <div className="flex items-center gap-2">
           <Input className="max-w-44" type="month" value={yearMonth} onChange={(event) => changeYearMonth(event.target.value)} />
+          <Button variant="secondary" aria-label="次月" onClick={goToNextMonth}>
+            次月
+          </Button>
         </div>
         <div className="grid min-w-0 gap-4 self-start">
           <div className="hidden min-w-0 md:block">


### PR DESCRIPTION
## 変更概要

- クレジットカード管理の月別請求入力に「次月」ボタンを追加
- タイムゾーンに依存しない月加算ヘルパーを追加
- 通常遷移、年跨ぎ、未保存時の確認フローをテスト

## 対応理由

月別請求入力では月選択欄しか用意されておらず、利用頻度の高い次月データの入力でも毎回カレンダーから月を選ぶ必要がありました。

## 利用者への影響

月選択欄の横にある「次月」ボタンから、表示月を1か月進められます。未保存の請求額がある場合は既存の確認ダイアログが表示され、キャンセルすると元の月と入力内容を維持します。

## 実装上の判断

- 月加算は `Date` のパースを使わず、`YYYY-MM` を月数へ変換して計算
- 12月から翌年1月への遷移に対応
- 既存の `changeYearMonth` を再利用し、未保存データの保護を維持
- Issueの範囲外となる前月・今月ボタンは追加していない

## 検証内容

Devin CLI（SWE-1.7）が以下を実行し、すべて成功しました。

- `make lint`
- `make typecheck`
- `make test-unit`（frontend 37件、backend 53件、MCP 55件）
- `make build`
- `make test-e2e`（62件成功）

E2Eでは、次月遷移、年跨ぎ、うるう年の月、未保存確認のキャンセルと確定を確認しています。

Closes #305
