### PR TITLE
feat: クレカ仮定額の提案を平均値へ変更

### DIFF
--- a/e2e/credit-cards.spec.ts
+++ b/e2e/credit-cards.spec.ts
@@ -93,10 +93,10 @@ test("edits and deletes a credit card", async ({ page }) => {
   await expect(page.getByText("Master Gold")).toHaveCount(0);
 });
 
-test("suggests and applies an assumption amount from past billing medians", async ({ page }) => {
+test("suggests and applies an assumption amount from past billing averages", async ({ page }) => {
   const account = await seedAccount({ name: "Settlement Account" });
   const card = await seedCreditCard({
-    name: "Median Card",
+    name: "Average Card",
     accountId: account.id,
     assumptionAmount: 10000,
     sortOrder: 1,
@@ -107,9 +107,10 @@ test("suggests and applies an assumption amount from past billing medians", asyn
 
   await navigateTo(page, "/credit-cards");
 
-  await page.getByRole("row", { name: /Median Card/ }).getByRole("button", { name: "編集" }).click();
+  await page.getByRole("row", { name: /Average Card/ }).getByRole("button", { name: "編集" }).click();
   await page.getByRole("button", { name: "過去実績から提案" }).click();
 
+  await expect(page.getByText("平均値")).toBeVisible();
   await expect(page.getByText(`提案額 ${formatCurrency(20000)}`)).toBeVisible();
   await expect(page.getByText("3 件")).toBeVisible();
 
@@ -120,7 +121,7 @@ test("suggests and applies an assumption amount from past billing medians", asyn
   await page.getByRole("button", { name: "保存" }).click();
   await waitForReload(page);
 
-  await expect(cardListRow(page, "Median Card")).toContainText(formatCurrency(21000));
+  await expect(cardListRow(page, "Average Card")).toContainText(formatCurrency(21000));
 });
 
 test("saves monthly billing and switches the badge to actual", async ({ page }) => {

--- a/packages/backend/src/routes/credit-cards.integration.test.ts
+++ b/packages/backend/src/routes/credit-cards.integration.test.ts
@@ -102,7 +102,7 @@ describe("credit cards routes", () => {
     expect(updated.dateShiftPolicy).toBe("next");
   });
 
-  it("suggests the median actual amount from the past six months", async () => {
+  it("suggests the average actual amount from the past six months", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-10T00:00:00.000Z"));
 
@@ -129,7 +129,7 @@ describe("credit cards routes", () => {
     expect(response.status).toBe(200);
     expect(await parseJson(response)).toEqual({
       creditCardId: card.id,
-      method: "median",
+      method: "average",
       months: 6,
       sampleCount: 3,
       sourceYearMonths: ["2026-01", "2026-02", "2026-03"],
@@ -137,7 +137,7 @@ describe("credit cards routes", () => {
     });
   });
 
-  it("rounds the average of the middle two samples and excludes zero, current, future, and older months", async () => {
+  it("ceils the fractional average and excludes zero, current, future, and older months", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-10T00:00:00.000Z"));
 
@@ -160,7 +160,11 @@ describe("credit cards routes", () => {
     });
     await createBilling(testPrisma, {
       yearMonth: "2026-04",
-      items: [{ creditCardId: card.id, amount: 20001 }],
+      items: [{ creditCardId: card.id, amount: 20000 }],
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-05",
+      items: [{ creditCardId: card.id, amount: 30001 }],
     });
     await createBilling(testPrisma, {
       yearMonth: "2026-06",
@@ -175,9 +179,37 @@ describe("credit cards routes", () => {
 
     expect(response.status).toBe(200);
     expect(await parseJson(response)).toMatchObject({
-      sampleCount: 2,
-      sourceYearMonths: ["2026-02", "2026-04"],
-      suggestedAmount: 15001,
+      method: "average",
+      sampleCount: 3,
+      sourceYearMonths: ["2026-02", "2026-04", "2026-05"],
+      suggestedAmount: 20001,
+    });
+  });
+
+  it("returns the single positive sample as the suggested amount", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T00:00:00.000Z"));
+
+    const account = await createAccount(testPrisma, { name: "Settlement" });
+    const card = await createCreditCard(testPrisma, {
+      name: "Visa",
+      accountId: account.id,
+    });
+    await createBilling(testPrisma, {
+      yearMonth: "2026-04",
+      items: [{ creditCardId: card.id, amount: 15000 }],
+    });
+
+    const response = await client.get(`/api/credit-cards/${card.id}/assumption-suggestion?months=6`);
+
+    expect(response.status).toBe(200);
+    expect(await parseJson(response)).toEqual({
+      creditCardId: card.id,
+      method: "average",
+      months: 6,
+      sampleCount: 1,
+      sourceYearMonths: ["2026-04"],
+      suggestedAmount: 15000,
     });
   });
 
@@ -193,6 +225,7 @@ describe("credit cards routes", () => {
     expect(response.status).toBe(200);
     expect(await parseJson(response)).toMatchObject({
       creditCardId: card.id,
+      method: "average",
       sampleCount: 0,
       sourceYearMonths: [],
       suggestedAmount: null,

--- a/packages/backend/src/services/credit-card-assumptions.test.ts
+++ b/packages/backend/src/services/credit-card-assumptions.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@sui/db";
+import { buildCreditCardAssumptionSuggestion } from "./credit-card-assumptions";
+
+function createMockPrisma(
+  billings: Array<{ yearMonth: string; items: Array<{ amount: number }> }>,
+) {
+  const findMany = vi.fn().mockResolvedValue(billings);
+  return { creditCardBilling: { findMany } } as unknown as PrismaClient;
+}
+
+describe("buildCreditCardAssumptionSuggestion", () => {
+  it("suggests the arithmetic average for a divisible sum", async () => {
+    const prisma = createMockPrisma([
+      { yearMonth: "2026-01", items: [{ amount: 10000 }] },
+      { yearMonth: "2026-02", items: [{ amount: 30000 }] },
+      { yearMonth: "2026-03", items: [{ amount: 20000 }] },
+    ]);
+
+    const result = await buildCreditCardAssumptionSuggestion(prisma, {
+      creditCardId: "card-1",
+      currentYearMonth: "2026-06",
+      months: 6,
+    });
+
+    expect(result).toEqual({
+      creditCardId: "card-1",
+      method: "average",
+      months: 6,
+      sampleCount: 3,
+      sourceYearMonths: ["2026-01", "2026-02", "2026-03"],
+      suggestedAmount: 20000,
+    });
+  });
+
+  it("ceils a fractional average to 1 yen", async () => {
+    const prisma = createMockPrisma([
+      { yearMonth: "2026-02", items: [{ amount: 10000 }] },
+      { yearMonth: "2026-04", items: [{ amount: 20000 }] },
+      { yearMonth: "2026-05", items: [{ amount: 30001 }] },
+    ]);
+
+    const result = await buildCreditCardAssumptionSuggestion(prisma, {
+      creditCardId: "card-1",
+      currentYearMonth: "2026-06",
+      months: 6,
+    });
+
+    expect(result.suggestedAmount).toBe(20001);
+  });
+
+  it("returns the single sample as the suggestion", async () => {
+    const prisma = createMockPrisma([
+      { yearMonth: "2026-04", items: [{ amount: 15000 }] },
+    ]);
+
+    const result = await buildCreditCardAssumptionSuggestion(prisma, {
+      creditCardId: "card-1",
+      currentYearMonth: "2026-06",
+      months: 6,
+    });
+
+    expect(result.suggestedAmount).toBe(15000);
+    expect(result.sampleCount).toBe(1);
+  });
+
+  it("returns null when there are no samples", async () => {
+    const prisma = createMockPrisma([]);
+
+    const result = await buildCreditCardAssumptionSuggestion(prisma, {
+      creditCardId: "card-1",
+      currentYearMonth: "2026-06",
+      months: 6,
+    });
+
+    expect(result.suggestedAmount).toBeNull();
+    expect(result.sampleCount).toBe(0);
+    expect(result.sourceYearMonths).toEqual([]);
+  });
+
+  it("queries the expected range and keeps positive amounts only", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const prisma = { creditCardBilling: { findMany } } as unknown as PrismaClient;
+
+    await buildCreditCardAssumptionSuggestion(prisma, {
+      creditCardId: "card-1",
+      currentYearMonth: "2026-06",
+      months: 6,
+    });
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          yearMonth: { gte: "2025-12", lt: "2026-06" },
+          items: { some: { creditCardId: "card-1", amount: { gt: 0 } } },
+        }),
+        include: expect.objectContaining({
+          items: {
+            where: { creditCardId: "card-1", amount: { gt: 0 } },
+            select: { amount: true },
+          },
+        }),
+        orderBy: { yearMonth: "asc" },
+      }),
+    );
+  });
+});

--- a/packages/backend/src/services/credit-card-assumptions.ts
+++ b/packages/backend/src/services/credit-card-assumptions.ts
@@ -2,19 +2,13 @@ import type { PrismaClient } from "@sui/db";
 import type { CreditCardAssumptionSuggestionResponse } from "@sui/shared";
 import { addMonthsToYearMonth } from "../lib/dates";
 
-function median(values: number[]) {
+function averageWithCeil(values: number[]): number | null {
   if (values.length === 0) {
     return null;
   }
 
-  const sorted = [...values].sort((left, right) => left - right);
-  const middle = Math.floor(sorted.length / 2);
-
-  if (sorted.length % 2 === 1) {
-    return sorted[middle] ?? null;
-  }
-
-  return Math.round(((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2);
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  return Math.ceil(sum / values.length);
 }
 
 export async function buildCreditCardAssumptionSuggestion(
@@ -59,10 +53,10 @@ export async function buildCreditCardAssumptionSuggestion(
 
   return {
     creditCardId,
-    method: "median",
+    method: "average",
     months,
     sampleCount: samples.length,
     sourceYearMonths: billings.map((billing) => billing.yearMonth),
-    suggestedAmount: median(samples),
+    suggestedAmount: averageWithCeil(samples),
   };
 }

--- a/packages/frontend/src/routes/credit-cards.tsx
+++ b/packages/frontend/src/routes/credit-cards.tsx
@@ -803,7 +803,7 @@ function CreditCardEditModal({
             ) : (
               <div className="grid gap-2">
                 <div className="flex flex-wrap items-center gap-2">
-                  <Badge tone="success">中央値</Badge>
+                  <Badge tone="success">平均値</Badge>
                   <span className="font-data font-medium text-ink">提案額 {formatCurrency(suggestion.suggestedAmount)}</span>
                   <span>{suggestion.sampleCount} 件</span>
                 </div>

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -552,7 +552,7 @@ describe("MCP server", () => {
     addRoute("GET", "/api/credit-cards/44444444-4444-4444-8444-444444444444/assumption-suggestion?months=12", {
       body: {
         creditCardId: "44444444-4444-4444-8444-444444444444",
-        method: "median",
+        method: "average",
         months: 12,
         sampleCount: 3,
         sourceYearMonths: ["2026-01", "2026-02", "2026-03"],

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -159,7 +159,7 @@ export type UpdateCreditCardPayload = CreateCreditCardPayload;
 
 export interface CreditCardAssumptionSuggestionResponse {
   creditCardId: string;
-  method: "median";
+  method: "average";
   months: number;
   sampleCount: number;
   sourceYearMonths: string[];


### PR DESCRIPTION
## 変更概要

- クレジットカードの仮定額提案を中央値から算術平均へ変更
- 平均に1円未満の端数がある場合は1円単位で切り上げ
- API型、UI表示、MCPテスト、統合テスト、E2Eを新仕様へ更新

## 対応理由

クレジットカード利用額の過去実績から仮定額を提案する際、中央値よりも利用総額を件数で均した平均値を使う方が、今後の支出見込みとして適切なためです。

## 計算仕様

- 直近6か月を既定の対象期間とする
- 正の実績額だけをサンプルに含める
- 0円、当月、未来月、対象期間外は除外する
- `合計 ÷ 件数` の算術平均を求める
- 1円未満の端数は1円単位で切り上げる
- サンプルがない場合は提案額を `null` とする

## APIへの影響

提案レスポンスの `method` は `median` から `average` へ変わります。リポジトリ内のFrontendとMCP関連テストは新しい値へ更新済みです。

## 検証内容

Devin CLI（SWE-1.7）が以下を実行し、すべて成功しました。

- `make lint`
- `make typecheck`
- `make test-unit`（Backend 58件成功）
- `make test-integration`（119件成功）
- `make build`
- `make test-e2e`（62件成功）

テストでは、割り切れる平均、端数切り上げ、1件、サンプルなし、期間・0円除外、APIのmethod、UIの「平均値」表示を確認しています。

Closes #304
