### PR TITLE
feat: 残高チャートに移動平均トレンドを追加

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -434,3 +434,91 @@ test("shows actual and assumed credit card events together with loan events", as
   await expect(page.getByText("Assumption Card 仮定値").first()).toBeVisible();
   await expect(page.getByText("ローン: Laptop Loan").first()).toBeVisible();
 });
+
+test("toggles the moving average trend line and updates the label by period", async ({ page }) => {
+  const account = await seedAccount({ name: "Main Account", balance: 100000, sortOrder: 1 });
+
+  await seedRecurringItem({
+    name: "Salary",
+    type: "income",
+    amount: 300000,
+    dayOfMonth: getFutureDayOfMonth(),
+    accountId: account.id,
+    sortOrder: 1,
+  });
+  await seedRecurringItem({
+    name: "Rent",
+    type: "expense",
+    amount: 80000,
+    dayOfMonth: getFutureDayOfMonth(),
+    accountId: account.id,
+    sortOrder: 2,
+  });
+
+  await navigateTo(page, "/");
+
+  await expect(page.locator("svg.recharts-surface")).toBeVisible();
+  await expect(page.getByText("30日移動平均")).toHaveCount(0);
+  await expect(page.getByText("7日移動平均")).toHaveCount(0);
+
+  const trendSwitch = page.getByRole("switch", { name: "実績残高の後方移動平均線を表示" });
+  await expect(trendSwitch).toBeVisible();
+  await trendSwitch.click();
+  await expect(trendSwitch).toBeChecked();
+
+  await expect(page.getByText("30日移動平均").first()).toBeVisible();
+  await expect(page.locator("svg.recharts-surface")).toBeVisible();
+
+  await trendSwitch.click();
+  await expect(trendSwitch).not.toBeChecked();
+  await expect(page.getByText("30日移動平均")).toHaveCount(0);
+
+  await page.getByLabel("予測イベントの表示期間").selectOption("next1Month");
+  await trendSwitch.click();
+  await expect(trendSwitch).toBeChecked();
+  await expect(page.getByText("7日移動平均").first()).toBeVisible();
+  await expect(page.getByText("30日移動平均")).toHaveCount(0);
+});
+
+test("shows the moving average trend in the chart tooltip on hover", async ({ page }) => {
+  const account = await seedAccount({ name: "Main Account", balance: 100000, sortOrder: 1 });
+
+  await seedRecurringItem({
+    name: "Salary",
+    type: "income",
+    amount: 300000,
+    dayOfMonth: getFutureDayOfMonth(),
+    accountId: account.id,
+    sortOrder: 1,
+  });
+  await seedRecurringItem({
+    name: "Rent",
+    type: "expense",
+    amount: 80000,
+    dayOfMonth: getFutureDayOfMonth(),
+    accountId: account.id,
+    sortOrder: 2,
+  });
+
+  await navigateTo(page, "/");
+
+  await expect(page.locator("svg.recharts-surface")).toBeVisible();
+
+  const trendSwitch = page.getByRole("switch", { name: "実績残高の後方移動平均線を表示" });
+  await trendSwitch.click();
+  await expect(trendSwitch).toBeChecked();
+
+  const chartWrapper = page.locator(".recharts-wrapper");
+  await expect(chartWrapper).toBeVisible();
+
+  // Hover over the actual range (left 25% of the chart) so the active day is within the trend line.
+  const chartBox = await chartWrapper.boundingBox();
+  if (chartBox) {
+    await page.mouse.move(chartBox.x + chartBox.width * 0.25, chartBox.y + chartBox.height * 0.5);
+  }
+
+  const tooltip = page.locator(".recharts-tooltip-wrapper");
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toContainText("30日移動平均");
+  await expect(tooltip).toContainText(formatCurrency(100000));
+});

--- a/packages/frontend/src/components/balance-chart.tsx
+++ b/packages/frontend/src/components/balance-chart.tsx
@@ -2,6 +2,7 @@ import {
   Area,
   CartesianGrid,
   ComposedChart,
+  Line,
   ReferenceArea,
   ReferenceDot,
   ReferenceLine,
@@ -16,6 +17,8 @@ import { usePrefersReducedMotion } from "../hooks/use-prefers-reduced-motion";
 import { convertCurrencyInputToJpy, formatCurrency, formatDate, formatManUnit } from "../lib/format";
 import {
   buildBalanceChartSegments,
+  buildDenseChartData,
+  buildMovingAverageSeries,
   buildNiceYAxis,
   buildTimeScaleTicks,
   dateOnlyToTimestamp,
@@ -24,21 +27,14 @@ import {
   roundedStepAfter,
   timestampToDateOnly,
   type BalanceChartInputPoint,
+  type ChartDataPoint,
   type DailyBalanceChartPoint,
 } from "../lib/balance-chart";
 import { cn } from "../lib/utils";
 
 type BalanceChartPoint = BalanceChartInputPoint;
 
-type BalanceChartDatum = {
-  date: string;
-  timestamp: number;
-  order: number;
-  actualBalance?: number;
-  forecastBalance?: number;
-  actualDescription?: string;
-  forecastDescription?: string;
-};
+type BalanceChartDatum = ChartDataPoint;
 
 const CHART_MARGIN = { left: 12, right: 12, top: 12, bottom: 8 };
 const Y_AXIS_WIDTH = 56;
@@ -97,7 +93,7 @@ function useElementSize() {
   return [ref, size] as const;
 }
 
-function isInDomain(point: DailyBalanceChartPoint, domain: [number, number]) {
+function isInDomain(point: { timestamp: number }, domain: [number, number]) {
   return point.timestamp >= domain[0] && point.timestamp <= domain[1];
 }
 
@@ -112,9 +108,44 @@ function getMinimumForecastPoint(points: DailyBalanceChartPoint[], domain: [numb
 
 function getTooltipEntry(
   payload: TooltipContentProps["payload"],
-  dataKey: "actualBalance" | "forecastBalance",
+  dataKey: "actualBalance" | "forecastBalance" | "trendBalance",
 ) {
   return payload.find((entry) => entry.dataKey === dataKey && entry.value !== null && entry.value !== undefined);
+}
+
+function getTooltipSeriesLabel(
+  entry: TooltipContentProps["payload"][number],
+  defaultTrendLabel: string,
+): string | undefined {
+  if (entry.name != null && String(entry.name) !== entry.dataKey) {
+    return String(entry.name);
+  }
+
+  if (entry.dataKey === "actualBalance") {
+    return "実績";
+  }
+
+  if (entry.dataKey === "forecastBalance") {
+    return "予測";
+  }
+
+  if (entry.dataKey === "trendBalance") {
+    return defaultTrendLabel;
+  }
+
+  return undefined;
+}
+
+function getTooltipSeriesLineClass(entry: TooltipContentProps["payload"][number]) {
+  if (entry.dataKey === "forecastBalance") {
+    return "border-dashed border-chart-forecast";
+  }
+
+  if (entry.dataKey === "trendBalance") {
+    return "border-dotted border-chart-trend";
+  }
+
+  return "border-solid border-chart-actual";
 }
 
 function BalanceTooltip({
@@ -123,59 +154,77 @@ function BalanceTooltip({
   currencyCode,
   exchangeRateToJpy,
   showSeriesLabel,
+  defaultTrendLabel,
 }: TooltipContentProps & {
   currencyCode: SupportedCurrencyCode;
   exchangeRateToJpy: number;
   showSeriesLabel: boolean;
+  defaultTrendLabel: string;
 }) {
   if (!active || payload.length === 0) {
     return null;
   }
 
-  const actualEntry = getTooltipEntry(payload, "actualBalance");
-  const forecastEntry = getTooltipEntry(payload, "forecastBalance");
-  const selectedEntry = forecastEntry ?? actualEntry;
-  if (!selectedEntry || typeof selectedEntry.value !== "number") {
+  const entries = [
+    getTooltipEntry(payload, "actualBalance"),
+    getTooltipEntry(payload, "forecastBalance"),
+    getTooltipEntry(payload, "trendBalance"),
+  ].filter((entry): entry is NonNullable<typeof entry> => entry != null && typeof entry.value === "number");
+
+  if (entries.length === 0) {
     return null;
   }
 
-  const point = selectedEntry.payload as Partial<BalanceChartDatum> | undefined;
-  if (!point?.date) {
+  const firstPoint = entries[0].payload as Partial<BalanceChartDatum> | undefined;
+  if (!firstPoint?.date) {
     return null;
   }
-
-  const isForecast = selectedEntry.dataKey === "forecastBalance";
-  const seriesLabel = isForecast ? "予測" : "実績";
-  const description = isForecast ? point.forecastDescription : point.actualDescription;
-  const jpyValue =
-    currencyCode === "JPY" ? null : convertCurrencyInputToJpy(selectedEntry.value, currencyCode, exchangeRateToJpy);
 
   return (
     <div className="max-w-64 rounded-2xl border border-line bg-[rgba(18,22,30,0.96)] px-3 py-2 shadow-xl">
-      {showSeriesLabel ? (
-        <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-ink-3">
-          <span
-            className={cn(
-              "inline-block h-0 w-3 border-t-2",
-              isForecast ? "border-dashed border-chart-forecast" : "border-solid border-chart-actual",
-            )}
-          />
-          {seriesLabel}
-        </div>
-      ) : null}
-      <div className="font-data text-xs text-ink-2">{formatDate(point.date)}</div>
-      <div className="font-data mt-0.5 text-base font-semibold text-ink">
-        {formatCurrency(selectedEntry.value, currencyCode)}
-      </div>
-      {jpyValue !== null ? (
-        <div className="font-data mt-0.5 text-xs text-ink-2">{formatCurrency(jpyValue, "JPY")}</div>
-      ) : null}
-      {description ? <div className="mt-1 max-w-56 break-words text-xs text-ink-2">{description}</div> : null}
+      <div className="font-data text-xs text-ink-2">{formatDate(firstPoint.date)}</div>
+      {entries.map((entry) => {
+        const point = entry.payload as Partial<BalanceChartDatum> | undefined;
+        const seriesLabel = getTooltipSeriesLabel(entry, defaultTrendLabel);
+        const description =
+          entry.dataKey === "forecastBalance"
+            ? point?.forecastDescription
+            : entry.dataKey === "actualBalance"
+              ? point?.actualDescription
+              : undefined;
+        const value = entry.value as number;
+        const jpyValue =
+          currencyCode === "JPY" ? null : convertCurrencyInputToJpy(value, currencyCode, exchangeRateToJpy);
+
+        return (
+          <div key={String(entry.dataKey)} className="mt-1.5">
+            {showSeriesLabel ? (
+              <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-ink-3">
+                <span className={cn("inline-block h-0 w-3 border-t-2", getTooltipSeriesLineClass(entry))} />
+                {seriesLabel}
+              </div>
+            ) : null}
+            <div className="font-data text-base font-semibold text-ink">{formatCurrency(value, currencyCode)}</div>
+            {jpyValue !== null ? (
+              <div className="font-data mt-0.5 text-xs text-ink-2">{formatCurrency(jpyValue, "JPY")}</div>
+            ) : null}
+            {description ? <div className="mt-1 max-w-56 break-words text-xs text-ink-2">{description}</div> : null}
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-function ChartLegend({ showForecast }: { showForecast: boolean }) {
+function ChartLegend({
+  showForecast,
+  showTrend,
+  trendLabel,
+}: {
+  showForecast: boolean;
+  showTrend: boolean;
+  trendLabel: string;
+}) {
   return (
     <div className="pointer-events-none absolute right-2 top-2 flex items-center gap-3 rounded-full border border-line bg-[rgba(17,21,28,0.72)] px-2.5 py-1 text-[11px] text-ink-2">
       <span className="flex items-center gap-1.5">
@@ -186,6 +235,12 @@ function ChartLegend({ showForecast }: { showForecast: boolean }) {
         <span className="flex items-center gap-1.5">
           <span className="inline-block h-0 w-3 border-t-2 border-dashed border-chart-forecast" />
           予測
+        </span>
+      ) : null}
+      {showTrend ? (
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-0 w-3 border-t-2 border-dotted border-chart-trend" />
+          {trendLabel}
         </span>
       ) : null}
     </div>
@@ -204,6 +259,7 @@ export function BalanceChart({
   currencyCode = "JPY",
   exchangeRateToJpy = 1,
   disposableZero = false,
+  showTrend = false,
 }: {
   data: BalanceChartPoint[];
   forecastData?: BalanceChartPoint[];
@@ -216,6 +272,7 @@ export function BalanceChart({
   currencyCode?: SupportedCurrencyCode;
   exchangeRateToJpy?: number;
   disposableZero?: boolean;
+  showTrend?: boolean;
 }) {
   const [chartRef, chartSize] = useElementSize();
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -251,7 +308,15 @@ export function BalanceChart({
     );
   }
 
-  const visibleBalances = [...actualLineSeries, ...forecastLineSeries]
+  const useMonthTicks = isMoreThanThreeMonths(
+    timestampToDateOnly(xDomain[0]),
+    timestampToDateOnly(xDomain[1]),
+  );
+  const windowDays = useMonthTicks ? 30 : 7;
+  const trendLabel = windowDays === 7 ? "7日移動平均" : "30日移動平均";
+  const trendLineSeries = showTrend ? buildMovingAverageSeries(actualLineSeries, windowDays) : [];
+
+  const visibleBalances = [...actualLineSeries, ...forecastLineSeries, ...trendLineSeries]
     .filter((point) => isInDomain(point, xDomain))
     .map((point) => point.balance);
   const { domain: chartDomain, ticks: yTicks } = buildNiceYAxis(visibleBalances, currentBalance);
@@ -267,26 +332,12 @@ export function BalanceChart({
     todayTimestamp !== undefined && todayTimestamp >= xDomain[0] && todayTimestamp <= xDomain[1];
   const minimumForecastPoint = getMinimumForecastPoint(forecastEventSeries, xDomain);
   const forecastEventTimestamps = new Set(forecastEventSeries.map((point) => point.timestamp));
-  const chartData: BalanceChartDatum[] = [
-    ...actualLineSeries.map((point) => ({
-      date: point.date,
-      timestamp: point.timestamp,
-      order: 0,
-      actualBalance: point.balance,
-      actualDescription: point.description,
-    })),
-    ...forecastLineSeries.map((point, index) => ({
-      date: point.date,
-      timestamp: point.timestamp,
-      order: index === 0 && todayPoint ? 1 : 2,
-      forecastBalance: point.balance,
-      forecastDescription: point.description,
-    })),
-  ].sort((left, right) => left.timestamp - right.timestamp || left.order - right.order);
-  const useMonthTicks = isMoreThanThreeMonths(
-    timestampToDateOnly(xDomain[0]),
-    timestampToDateOnly(xDomain[1]),
-  );
+  const chartData = buildDenseChartData({
+    actualLineSeries,
+    forecastLineSeries,
+    trendLineSeries,
+    xDomain,
+  });
   const xTicks = buildTimeScaleTicks(timestampToDateOnly(xDomain[0]), timestampToDateOnly(xDomain[1]));
   const zeroLineLabel = disposableZero ? "¥0（可処分ゼロ）" : "¥0";
 
@@ -410,7 +461,8 @@ export function BalanceChart({
                   {...props}
                   currencyCode={currencyCode}
                   exchangeRateToJpy={exchangeRateToJpy}
-                  showSeriesLabel={forecastData !== undefined}
+                  showSeriesLabel={forecastData !== undefined || showTrend}
+                  defaultTrendLabel={trendLabel}
                 />
               )}
               cursor={{ stroke: "var(--line-strong)", strokeDasharray: "4 4" }}
@@ -466,8 +518,27 @@ export function BalanceChart({
                 connectNulls
               />
             ) : null}
+            {trendLineSeries.length > 0 ? (
+              <Line
+                type="linear"
+                dataKey="trendBalance"
+                name={trendLabel}
+                stroke="var(--chart-trend)"
+                strokeWidth={1.5}
+                strokeDasharray="2 2"
+                dot={false}
+                activeDot={{ r: 3 }}
+                isAnimationActive={shouldAnimate}
+                animationDuration={INITIAL_ANIMATION_MS}
+                connectNulls={false}
+              />
+            ) : null}
           </ComposedChart>
-          <ChartLegend showForecast={forecastLineSeries.length > 0} />
+          <ChartLegend
+            showForecast={forecastLineSeries.length > 0}
+            showTrend={trendLineSeries.length > 0}
+            trendLabel={trendLabel}
+          />
           {showTodayLine ? (
             <div
               className="pointer-events-none absolute -translate-x-1/2 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-[11px] text-ink-2"

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -33,6 +33,7 @@
   /* チャートマーク */
   --color-chart-actual: var(--chart-actual);
   --color-chart-forecast: var(--chart-forecast);
+  --color-chart-trend: var(--chart-trend);
   --color-chart-positive: var(--chart-positive);
   --color-chart-warning: var(--chart-warning);
 
@@ -75,6 +76,7 @@
   /* チャートマーク */
   --chart-actual: #3d93cc;
   --chart-forecast: #2e6e9e;
+  --chart-trend: #a9b0ba;
   --chart-positive: #2fa983;
   --chart-warning: #c08828;
 

--- a/packages/frontend/src/lib/balance-chart.test.ts
+++ b/packages/frontend/src/lib/balance-chart.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBalanceChartSegments,
+  buildDenseChartData,
+  buildMovingAverageSeries,
+  dateOnlyToTimestamp,
+  timestampToDateOnly,
+} from "./balance-chart";
+
+describe("buildMovingAverageSeries", () => {
+  it("returns an empty array for empty input", () => {
+    expect(buildMovingAverageSeries([], 7)).toEqual([]);
+  });
+
+  it("returns an empty array when windowDays is not positive", () => {
+    const points = [
+      { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 100_000, eventCount: 1 },
+    ];
+
+    expect(buildMovingAverageSeries(points, 0)).toEqual([]);
+    expect(buildMovingAverageSeries(points, -1)).toEqual([]);
+  });
+
+  it("returns a single point for a single-day actual line", () => {
+    const points = [
+      { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 100_000, eventCount: 1 },
+    ];
+
+    const result = buildMovingAverageSeries(points, 7);
+
+    expect(result).toEqual([
+      { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 100_000 },
+    ]);
+  });
+
+  it("uses a 7-day backward window and averages only past closing values", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: Array.from({ length: 10 }, (_, index) => ({
+        date: `2026-07-${String(index + 1).padStart(2, "0")}`,
+        balance: (index + 1) * 1_000,
+      })),
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-10",
+      currentBalance: 10_000,
+    });
+
+    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+
+    expect(result.length).toBe(10);
+    expect(result[0]).toEqual({
+      date: "2026-07-01",
+      timestamp: dateOnlyToTimestamp("2026-07-01"),
+      balance: 1_000,
+    });
+    expect(result[1]).toEqual({
+      date: "2026-07-02",
+      timestamp: dateOnlyToTimestamp("2026-07-02"),
+      balance: 1_500,
+    });
+    expect(result[6]).toEqual({
+      date: "2026-07-07",
+      timestamp: dateOnlyToTimestamp("2026-07-07"),
+      balance: 4_000,
+    });
+    expect(result[7]).toEqual({
+      date: "2026-07-08",
+      timestamp: dateOnlyToTimestamp("2026-07-08"),
+      balance: 5_000,
+    });
+    expect(result[9]).toEqual({
+      date: "2026-07-10",
+      timestamp: dateOnlyToTimestamp("2026-07-10"),
+      balance: 7_000,
+    });
+  });
+
+  it("uses a 30-day backward window when requested", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: Array.from({ length: 10 }, (_, index) => ({
+        date: `2026-07-${String(index + 1).padStart(2, "0")}`,
+        balance: (index + 1) * 1_000,
+      })),
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-10",
+      currentBalance: 10_000,
+    });
+
+    const result = buildMovingAverageSeries(segments.actualLineSeries, 30);
+
+    expect(result[9].balance).toBe(5_500);
+  });
+
+  it("uses the available days for the head period when the window is not yet filled", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 1_000 },
+        { date: "2026-07-02", balance: 2_000 },
+        { date: "2026-07-03", balance: 3_000 },
+      ],
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-03",
+      currentBalance: 3_000,
+    });
+
+    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+
+    expect(result.map((point) => point.balance)).toEqual([1_000, 1_500, 2_000]);
+  });
+
+  it("does not include future closing values in the average", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 100_000 },
+        { date: "2026-07-02", balance: 100_000 },
+        { date: "2026-07-03", balance: 100_000 },
+        { date: "2026-07-04", balance: 100_000 },
+        { date: "2026-07-05", balance: 100_000 },
+        { date: "2026-07-06", balance: 200_000 },
+        { date: "2026-07-07", balance: 200_000 },
+        { date: "2026-07-08", balance: 200_000 },
+        { date: "2026-07-09", balance: 200_000 },
+        { date: "2026-07-10", balance: 200_000 },
+      ],
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-10",
+      currentBalance: 200_000,
+    });
+
+    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+
+    // Day 5 (index 4) should only average the first 5 days of 100,000
+    expect(result[4].balance).toBe(100_000);
+    // Day 6 (index 5) should be (5 * 100_000 + 200_000) / 6
+    expect(result[5].balance).toBe((5 * 100_000 + 200_000) / 6);
+  });
+
+  it("preserves the step-after closing value on days without an explicit transaction", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 10_000 },
+        { date: "2026-07-05", balance: 50_000 },
+      ],
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-05",
+      currentBalance: 50_000,
+    });
+
+    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+
+    expect(result.map((point) => point.balance)).toEqual([10_000, 10_000, 10_000, 10_000, 18_000]);
+  });
+
+  it("uses the step-after closing value from the extended range endpoints", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [{ date: "2026-07-03", balance: 30_000 }],
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-05",
+      currentBalance: 30_000,
+    });
+
+    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+
+    expect(result.length).toBe(5);
+    expect(result.map((point) => point.balance)).toEqual([30_000, 30_000, 30_000, 30_000, 30_000]);
+    expect(result.map((point) => timestampToDateOnly(point.timestamp))).toEqual([
+      "2026-07-01",
+      "2026-07-02",
+      "2026-07-03",
+      "2026-07-04",
+      "2026-07-05",
+    ]);
+  });
+});
+
+describe("buildDenseChartData", () => {
+  it("returns one dense row per day in the xDomain", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 10_000 },
+        { date: "2026-07-03", balance: 30_000 },
+      ],
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-05",
+      currentBalance: 30_000,
+    });
+
+    const chartData = buildDenseChartData({
+      actualLineSeries: segments.actualLineSeries,
+      forecastLineSeries: segments.forecastLineSeries,
+      trendLineSeries: [],
+      xDomain: segments.xDomain,
+    });
+
+    expect(chartData.map((point) => point.date)).toEqual([
+      "2026-07-01",
+      "2026-07-02",
+      "2026-07-03",
+      "2026-07-04",
+      "2026-07-05",
+    ]);
+  });
+
+  it("uses step-after actual values only within the actual line range and is undefined after the actual last point", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 10_000 },
+        { date: "2026-07-05", balance: 50_000 },
+      ],
+      forecastPoints: [
+        { date: "2026-07-06", balance: 60_000 },
+        { date: "2026-07-08", balance: 80_000 },
+      ],
+      todayPoint: { date: "2026-07-04", balance: 40_000 },
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-08",
+      currentBalance: 40_000,
+    });
+
+    const chartData = buildDenseChartData({
+      actualLineSeries: segments.actualLineSeries,
+      forecastLineSeries: segments.forecastLineSeries,
+      trendLineSeries: [],
+      xDomain: segments.xDomain,
+    });
+
+    expect(chartData.map((point) => point.actualBalance)).toEqual([
+      10_000, 10_000, 10_000, 40_000, undefined, undefined, undefined, undefined,
+    ]);
+  });
+
+  it("is undefined for forecast before the forecast start and defined from the forecast start", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 10_000 },
+        { date: "2026-07-05", balance: 50_000 },
+      ],
+      forecastPoints: [
+        { date: "2026-07-06", balance: 60_000 },
+        { date: "2026-07-08", balance: 80_000 },
+      ],
+      todayPoint: { date: "2026-07-04", balance: 40_000 },
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-08",
+      currentBalance: 40_000,
+    });
+
+    const chartData = buildDenseChartData({
+      actualLineSeries: segments.actualLineSeries,
+      forecastLineSeries: segments.forecastLineSeries,
+      trendLineSeries: [],
+      xDomain: segments.xDomain,
+    });
+
+    expect(chartData.map((point) => point.forecastBalance)).toEqual([
+      undefined, undefined, undefined, 40_000, 40_000, 60_000, 60_000, 80_000,
+    ]);
+  });
+
+  it("maps the trend balance for days inside the actual range and omits it outside", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 10_000 },
+        { date: "2026-07-02", balance: 20_000 },
+        { date: "2026-07-03", balance: 30_000 },
+      ],
+      forecastPoints: [
+        { date: "2026-07-05", balance: 50_000 },
+      ],
+      todayPoint: { date: "2026-07-03", balance: 30_000 },
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-06",
+      currentBalance: 30_000,
+    });
+    const trendLineSeries = buildMovingAverageSeries(segments.actualLineSeries, 2);
+
+    const chartData = buildDenseChartData({
+      actualLineSeries: segments.actualLineSeries,
+      forecastLineSeries: segments.forecastLineSeries,
+      trendLineSeries,
+      xDomain: segments.xDomain,
+    });
+
+    expect(chartData.map((point) => point.trendBalance)).toEqual([
+      10_000, 15_000, 25_000, undefined, undefined, undefined,
+    ]);
+  });
+
+  it("contains both actual and forecast balances at the same-day boundary", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 10_000 },
+        { date: "2026-07-04", balance: 40_000 },
+      ],
+      forecastPoints: [
+        { date: "2026-07-06", balance: 60_000 },
+        { date: "2026-07-08", balance: 80_000 },
+      ],
+      todayPoint: { date: "2026-07-04", balance: 40_000 },
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-08",
+      currentBalance: 40_000,
+    });
+
+    const chartData = buildDenseChartData({
+      actualLineSeries: segments.actualLineSeries,
+      forecastLineSeries: segments.forecastLineSeries,
+      trendLineSeries: [],
+      xDomain: segments.xDomain,
+    });
+
+    const boundary = chartData.find((point) => point.date === "2026-07-04");
+    expect(boundary).toEqual({
+      date: "2026-07-04",
+      timestamp: dateOnlyToTimestamp("2026-07-04"),
+      order: 0,
+      actualBalance: 40_000,
+      actualDescription: undefined,
+      forecastBalance: 40_000,
+      forecastDescription: undefined,
+      trendBalance: undefined,
+    });
+  });
+
+  it("preserves actual and forecast descriptions only on exact days", () => {
+    const segments = buildBalanceChartSegments({
+      actualPoints: [
+        { date: "2026-07-01", balance: 10_000, description: "Salary" },
+        { date: "2026-07-04", balance: 40_000, description: "Today" },
+      ],
+      forecastPoints: [
+        { date: "2026-07-06", balance: 60_000, description: "Rent" },
+      ],
+      todayPoint: { date: "2026-07-04", balance: 40_000, description: "Today" },
+      displayStartDate: "2026-07-01",
+      displayEndDate: "2026-07-06",
+      currentBalance: 40_000,
+    });
+
+    const chartData = buildDenseChartData({
+      actualLineSeries: segments.actualLineSeries,
+      forecastLineSeries: segments.forecastLineSeries,
+      trendLineSeries: [],
+      xDomain: segments.xDomain,
+    });
+
+    const actualDay = chartData.find((point) => point.date === "2026-07-01");
+    const forecastDay = chartData.find((point) => point.date === "2026-07-06");
+    const interpolatedDay = chartData.find((point) => point.date === "2026-07-02");
+    const boundaryDay = chartData.find((point) => point.date === "2026-07-04");
+
+    expect(actualDay?.actualDescription).toBe("Salary");
+    expect(forecastDay?.forecastDescription).toBe("Rent");
+    expect(interpolatedDay?.actualDescription).toBeUndefined();
+    expect(interpolatedDay?.forecastDescription).toBeUndefined();
+    expect(boundaryDay?.actualDescription).toBe("Today");
+    expect(boundaryDay?.forecastDescription).toBe("Today");
+  });
+});

--- a/packages/frontend/src/lib/balance-chart.ts
+++ b/packages/frontend/src/lib/balance-chart.ts
@@ -256,6 +256,134 @@ export function buildNiceYAxis(
   return { domain: [niceMin, niceMax], ticks };
 }
 
+export type MovingAveragePoint = {
+  date: string;
+  timestamp: number;
+  balance: number;
+};
+
+export function buildMovingAverageSeries(
+  actualLineSeries: DailyBalanceChartPoint[],
+  windowDays: number,
+): MovingAveragePoint[] {
+  if (actualLineSeries.length === 0 || windowDays <= 0) {
+    return [];
+  }
+
+  const sorted = sortDailyPoints(actualLineSeries);
+  const startTimestamp = sorted[0].timestamp;
+  const endTimestamp = sorted[sorted.length - 1].timestamp;
+
+  if (endTimestamp < startTimestamp) {
+    return [];
+  }
+
+  const points: MovingAveragePoint[] = [];
+  const balances: number[] = [];
+
+  for (let timestamp = startTimestamp; timestamp <= endTimestamp + Number.EPSILON; timestamp += DAY_MS) {
+    const point = findLastPointBeforeOrAt(sorted, timestamp);
+    if (!point) {
+      continue;
+    }
+
+    balances.push(point.balance);
+
+    const windowLength = Math.min(windowDays, balances.length);
+    let windowSum = 0;
+    for (let index = balances.length - windowLength; index < balances.length; index += 1) {
+      windowSum += balances[index];
+    }
+
+    points.push({
+      date: timestampToDateOnly(timestamp),
+      timestamp,
+      balance: windowSum / windowLength,
+    });
+  }
+
+  return points;
+}
+
+export type ChartDataPoint = {
+  date: string;
+  timestamp: number;
+  order: number;
+  actualBalance?: number;
+  actualDescription?: string;
+  forecastBalance?: number;
+  forecastDescription?: string;
+  trendBalance?: number;
+};
+
+export function buildDenseChartData({
+  actualLineSeries,
+  forecastLineSeries,
+  trendLineSeries,
+  xDomain,
+}: {
+  actualLineSeries: DailyBalanceChartPoint[];
+  forecastLineSeries: DailyBalanceChartPoint[];
+  trendLineSeries: MovingAveragePoint[];
+  xDomain: [number, number];
+}): ChartDataPoint[] {
+  const points: ChartDataPoint[] = [];
+  const trendByTimestamp = new Map(
+    trendLineSeries.map((point) => [point.timestamp, point.balance]),
+  );
+  const actualByTimestamp = new Map(
+    actualLineSeries.map((point) => [point.timestamp, point]),
+  );
+  const forecastByTimestamp = new Map(
+    forecastLineSeries.map((point) => [point.timestamp, point]),
+  );
+
+  const actualFirst = actualLineSeries[0]?.timestamp;
+  const actualLast = actualLineSeries[actualLineSeries.length - 1]?.timestamp;
+  const forecastFirst = forecastLineSeries[0]?.timestamp;
+  const forecastLast = forecastLineSeries[forecastLineSeries.length - 1]?.timestamp;
+
+  for (
+    let timestamp = xDomain[0];
+    timestamp <= xDomain[1] + Number.EPSILON;
+    timestamp += DAY_MS
+  ) {
+    const actualInRange =
+      actualFirst !== undefined &&
+      actualLast !== undefined &&
+      timestamp >= actualFirst &&
+      timestamp <= actualLast;
+    const forecastInRange =
+      forecastFirst !== undefined &&
+      forecastLast !== undefined &&
+      timestamp >= forecastFirst &&
+      timestamp <= forecastLast;
+
+    const actualPoint = actualInRange
+      ? findLastPointBeforeOrAt(actualLineSeries, timestamp)
+      : undefined;
+    const forecastPoint = forecastInRange
+      ? findLastPointBeforeOrAt(forecastLineSeries, timestamp)
+      : undefined;
+
+    const exactActualPoint = actualByTimestamp.get(timestamp);
+    const exactForecastPoint = forecastByTimestamp.get(timestamp);
+
+    points.push({
+      date: timestampToDateOnly(timestamp),
+      timestamp,
+      order: 0,
+      actualBalance: actualPoint?.balance,
+      actualDescription: exactActualPoint?.description,
+      forecastBalance: forecastPoint?.balance,
+      forecastDescription: exactForecastPoint?.description,
+      trendBalance: trendByTimestamp.get(timestamp),
+    });
+  }
+
+  return points;
+}
+
 export function buildBalanceChartSegments({
   actualPoints,
   forecastPoints = [],

--- a/packages/frontend/src/routes/dashboard.tsx
+++ b/packages/frontend/src/routes/dashboard.tsx
@@ -162,6 +162,7 @@ type ChartSnapshot = {
   currencyCode: SupportedCurrencyCode;
   exchangeRateToJpy: number;
   disposableZero: boolean;
+  showTrend: boolean;
 };
 
 function getDefaultConfirmAccountId(event: ForecastEvent, accounts: Account[]) {
@@ -287,6 +288,7 @@ export function DashboardPage() {
   const [selectedAccountId, setSelectedAccountId] = useState<string | "total">("total");
   const [periodPreset, setPeriodPreset] = useState<DashboardPeriodPreset>(DEFAULT_DASHBOARD_PERIOD);
   const [applyOffset, setApplyOffset] = useState(true);
+  const [showTrend, setShowTrend] = useState(false);
   const [manualSelectedEvent, setManualSelectedEvent] = useState<ForecastEvent | null>(null);
   const [explainDialog, setExplainDialog] = useState<ExplainDialogState | null>(null);
   const [isQueueCollapsed, setIsQueueCollapsed] = useState(false);
@@ -450,6 +452,7 @@ export function DashboardPage() {
       currencyCode: displayCurrencyCode,
       exchangeRateToJpy: chartExchangeRateToJpy,
       disposableZero: applyOffset,
+      showTrend,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- todayChartPoint はプリミティブから毎レンダー再構築されるため依存に含めない。
   }, [
@@ -465,6 +468,7 @@ export function DashboardPage() {
     displayCurrencyCode,
     chartExchangeRateToJpy,
     applyOffset,
+    showTrend,
   ]);
 
   const accountLevelRows: AccountLevelRow[] = [
@@ -723,6 +727,17 @@ export function DashboardPage() {
             </div>
             <div className="flex flex-wrap items-center gap-3">
               <OffsetToggle checked={applyOffset} onChange={setApplyOffset} />
+              <div
+                className="flex max-w-full min-w-0 items-center gap-3 rounded-[var(--radius-s)] border border-line bg-surface-2 px-4 py-2 text-sm"
+                title="実績残高の後方移動平均線を重ねて表示します"
+              >
+                <span className="min-w-0 truncate">移動平均</span>
+                <Switch
+                  checked={showTrend}
+                  onChange={setShowTrend}
+                  aria-label="実績残高の後方移動平均線を表示"
+                />
+              </div>
               <Button variant="ghost" onClick={() => setReloadKey((value) => value + 1)}>
                 再読込
               </Button>


### PR DESCRIPTION
## 変更概要

- 残高チャートへ実績残高の後方移動平均トレンド線を追加
- 移動平均の表示切替をダッシュボードへ追加（初期状態はOFF）
- 3か月以下は7日、3か月超は30日の移動平均を使用
- 凡例とTooltipに移動平均の期間と値を表示

## 対応理由

日々の残高変動を正確に示すステップ線に加えて、中期的な増減傾向を滑らかに確認できる補助表示を提供するためです。

## 表示と計算の仕様

- 既存の実績・予測ステップ線は正確な残高を示す主系列として維持
- 移動平均は実績の日次終値だけを対象とし、予測値は含めない
- 各日は当日以前の値だけを使う後方移動平均とし、未来の値を参照しない
- 窓幅未満の先頭期間は利用可能な日数で平均
- 補助線は線形描画し、補間によるオーバーシュートを防止

## レビューで確認した回帰防止

- 実績線は今日より未来へ延長しない
- 予測線は予測開始前へ遡らない
- 実績と予測の同日境界を維持
- 取引説明はイベント当日だけ表示し、補間日に伝播させない
- 移動平均は実績系列の範囲内だけ表示
- Tooltipを実際にホバーして期間ラベルと値をE2E検証

## 検証内容

Devin CLI（SWE-1.7）が以下を実行し、すべて成功しました。

- `make lint`
- `make typecheck`
- `make test-unit`（Frontend 52件、Backend 58件、MCP 55件）
- `make build`
- `make test-e2e`（64件成功）

Closes #301
