### PR TITLE
固定収支の振替設定を取引管理と統一

### DIFF
--- a/e2e/helpers/db-runner.ts
+++ b/e2e/helpers/db-runner.ts
@@ -35,7 +35,7 @@ type DbCommand =
       dayOfMonth?: number;
       startDate?: string | null;
       endDate?: string | null;
-      accountId: string;
+      accountId?: string | null;
       transferToAccountId?: string | null;
       enabled?: boolean;
       sortOrder?: number;

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -37,7 +37,7 @@ type DbCommand =
       dayOfMonth?: number;
       startDate?: string | null;
       endDate?: string | null;
-      accountId: string;
+      accountId?: string | null;
       transferToAccountId?: string | null;
       enabled?: boolean;
       sortOrder?: number;
@@ -269,7 +269,7 @@ export async function seedRecurringItem(overrides: {
   dayOfMonth?: number;
   startDate?: Date | null;
   endDate?: Date | null;
-  accountId: string;
+  accountId?: string | null;
   transferToAccountId?: string | null;
   enabled?: boolean;
   sortOrder?: number;

--- a/e2e/recurring.spec.ts
+++ b/e2e/recurring.spec.ts
@@ -146,3 +146,56 @@ test("creates and edits a weekly recurring item", async ({ page }) => {
 
   await expect(page.getByRole("row", { name: /Lunch/ })).toContainText("毎週 土曜日");
 });
+
+test("creates a transfer with only a destination account and edits it", async ({ page }) => {
+  const account = await seedAccount({ name: "Main Account" });
+
+  await navigateTo(page, "/recurring");
+
+  await page.getByRole("button", { name: "固定収支を追加" }).click();
+  await page.getByLabel("カテゴリ名 *").first().fill("External In");
+  await page.getByRole("radio", { name: "振替" }).first().click();
+  await page.getByLabel("金額 (円)").first().fill("10000");
+  await page.getByLabel("毎月の発生日").first().fill("10");
+  await page.getByLabel("送金元口座").first().selectOption("");
+  await page.getByLabel("振替先口座").first().selectOption(account.id);
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  const row = page.getByRole("row", { name: /External In/ });
+  await expect(row).toContainText("未設定 → Main Account");
+
+  await row.getByRole("button", { name: "編集" }).click();
+  await page.getByLabel("送金元口座").last().selectOption(account.id);
+  await page.getByLabel("振替先口座").last().selectOption("");
+  await page.getByRole("button", { name: "保存" }).click();
+  await waitForReload(page);
+
+  await expect(page.getByRole("row", { name: /External In/ })).toContainText("Main Account → 未設定");
+});
+
+test("creates a transfer with only a source account and disables save when both accounts are empty", async ({ page }) => {
+  const account = await seedAccount({ name: "Main Account" });
+
+  await navigateTo(page, "/recurring");
+
+  await page.getByRole("button", { name: "固定収支を追加" }).click();
+  await page.getByLabel("カテゴリ名 *").first().fill("External Out");
+  await page.getByRole("radio", { name: "振替" }).first().click();
+  await page.getByLabel("金額 (円)").first().fill("5000");
+  await page.getByLabel("毎月の発生日").first().fill("20");
+  await page.getByLabel("送金元口座").first().selectOption(account.id);
+  await page.getByLabel("振替先口座").first().selectOption("");
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  await expect(page.getByRole("row", { name: /External Out/ })).toContainText("Main Account → 未設定");
+
+  await page.getByRole("button", { name: "固定収支を追加" }).click();
+  await page.getByLabel("カテゴリ名 *").first().fill("No Accounts");
+  await page.getByRole("radio", { name: "振替" }).first().click();
+  await page.getByLabel("金額 (円)").first().fill("1000");
+  await page.getByLabel("毎月の発生日").first().fill("15");
+  await page.getByLabel("送金元口座").first().selectOption("");
+  await expect(page.getByRole("button", { name: "追加" })).toBeDisabled();
+});

--- a/e2e/scenarios/forecast-flow.spec.ts
+++ b/e2e/scenarios/forecast-flow.spec.ts
@@ -82,8 +82,8 @@ test("reflects recurring transfers in account forecasts and confirms them as tra
   await page.getByLabel("毎月の発生日").first().fill(String(dayOfMonth));
   await page.getByLabel("開始日").first().fill(eventDate);
   await page.getByLabel("終了日").first().fill(eventDate);
-  await page.getByLabel("振替元口座 *").selectOption({ label: "給与口座" });
-  await page.getByLabel("振替先口座 *").selectOption({ label: "引落口座" });
+  await page.getByLabel("送金元口座").selectOption({ label: "給与口座" });
+  await page.getByLabel("振替先口座").selectOption({ label: "引落口座" });
   await page.getByRole("button", { name: "追加" }).click();
   await waitForReload(page);
 

--- a/packages/backend/src/routes/dashboard.integration.test.ts
+++ b/packages/backend/src/routes/dashboard.integration.test.ts
@@ -271,6 +271,142 @@ describe("dashboard routes", () => {
     expect(afterConfirm.forecast.map((event) => event.id)).not.toContain(forecastEventId);
   });
 
+  it("confirms source-only transfer forecast events by decrementing the source account", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const source = await createAccount(testPrisma, {
+      name: "Source",
+      balance: 100000,
+      sortOrder: 1,
+    });
+    const transfer = await createRecurringItem(testPrisma, {
+      name: "External Out",
+      type: "transfer",
+      amount: 30000,
+      dayOfMonth: 20,
+      accountId: source.id,
+      transferToAccountId: null,
+      sortOrder: 1,
+    });
+    const forecastEventId = `recurring:${transfer.id}:2026-03`;
+
+    const dashboard = await parseJson<{ totalBalance: number; forecast: Array<{ balance: number }> }>(
+      await client.get("/api/dashboard"),
+    );
+    expect(dashboard.totalBalance).toBe(100000);
+    expect(dashboard.forecast).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          balance: 70000,
+        }),
+      ]),
+    );
+
+    const confirm = await client.post("/api/dashboard/confirm", {
+      forecastEventId,
+      amount: 30000,
+    });
+
+    expect(confirm.status).toBe(201);
+
+    const savedTransaction = await testPrisma.transaction.findFirstOrThrow({
+      where: { forecastEventId },
+    });
+    expect(savedTransaction).toMatchObject({
+      accountId: source.id,
+      transferToAccountId: null,
+      type: "transfer",
+      amount: 30000,
+    });
+
+    const savedSource = await testPrisma.account.findUniqueOrThrow({ where: { id: source.id } });
+    expect(savedSource.balance).toBe(70000);
+  });
+
+  it("confirms destination-only transfer forecast events by incrementing the destination account", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const destination = await createAccount(testPrisma, {
+      name: "Destination",
+      balance: 10000,
+      sortOrder: 1,
+    });
+    const transfer = await createRecurringItem(testPrisma, {
+      name: "External In",
+      type: "transfer",
+      amount: 30000,
+      dayOfMonth: 20,
+      accountId: null,
+      transferToAccountId: destination.id,
+      sortOrder: 1,
+    });
+    const forecastEventId = `recurring:${transfer.id}:2026-03`;
+
+    const dashboard = await parseJson<{ totalBalance: number; forecast: Array<{ balance: number }> }>(
+      await client.get("/api/dashboard"),
+    );
+    expect(dashboard.totalBalance).toBe(10000);
+    expect(dashboard.forecast).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          balance: 40000,
+        }),
+      ]),
+    );
+
+    const confirm = await client.post("/api/dashboard/confirm", {
+      forecastEventId,
+      amount: 30000,
+    });
+
+    expect(confirm.status).toBe(201);
+
+    const savedTransaction = await testPrisma.transaction.findFirstOrThrow({
+      where: { forecastEventId },
+    });
+    expect(savedTransaction).toMatchObject({
+      accountId: null,
+      transferToAccountId: destination.id,
+      type: "transfer",
+      amount: 30000,
+    });
+
+    const savedDestination = await testPrisma.account.findUniqueOrThrow({ where: { id: destination.id } });
+    expect(savedDestination.balance).toBe(40000);
+  });
+
+  it("rejects confirming a transfer forecast event with both accounts missing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const transfer = await testPrisma.recurringItem.create({
+      data: {
+        name: "No Accounts",
+        type: "transfer",
+        amount: 10000,
+        recurrence: "monthly",
+        dayOfMonth: 20,
+        accountId: null,
+        transferToAccountId: null,
+        enabled: true,
+        sortOrder: 1,
+      },
+    });
+    const forecastEventId = `recurring:${transfer.id}:2026-03`;
+
+    const confirm = await client.post("/api/dashboard/confirm", {
+      forecastEventId,
+      amount: 10000,
+    });
+
+    expect(confirm.status).toBe(400);
+    expect(await parseJson(confirm)).toEqual({
+      error: "Transfer forecast event requires source or destination account",
+    });
+  });
+
   it("applies dateShiftPolicy to recurring items and credit cards without shifting manual card settlement dates", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-01T00:00:00.000Z"));

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -83,15 +83,30 @@ function getEventContributionJpy(event: ForecastEvent, accountId: string | null)
     return -event.amountJpy;
   }
 
-  if (!accountId) {
+  if (accountId) {
+    if (event.accountId === accountId) {
+      return -event.amountJpy;
+    }
+
+    if (event.transferToAccountId === accountId) {
+      return event.amountJpy;
+    }
+
     return 0;
   }
 
-  if (event.accountId === accountId) {
+  const hasSource = event.accountId != null;
+  const hasDestination = event.transferToAccountId != null;
+
+  if (hasSource && hasDestination) {
+    return 0;
+  }
+
+  if (hasSource) {
     return -event.amountJpy;
   }
 
-  if (event.transferToAccountId === accountId) {
+  if (hasDestination) {
     return event.amountJpy;
   }
 
@@ -347,47 +362,66 @@ export const dashboardRoutes = new Hono()
       }
 
       if (event.type === "transfer") {
-        if (!event.accountId || !event.transferToAccountId) {
-          return c.json({ error: "Transfer forecast event requires source and destination accounts" }, 400);
-        }
-        if (event.accountId === event.transferToAccountId) {
-          return c.json({ error: "transfer accounts must be different" }, 400);
-        }
         const sourceAccountId = event.accountId;
         const destinationAccountId = event.transferToAccountId;
 
-        const transaction = await prisma.$transaction(async (tx) => {
-          const [sourceAccount, destinationAccount] = await Promise.all([
-            tx.account.findFirst({ where: { id: sourceAccountId, deletedAt: null } }),
-            tx.account.findFirst({ where: { id: destinationAccountId, deletedAt: null } }),
-          ]);
+        if (!sourceAccountId && !destinationAccountId) {
+          return c.json({ error: "Transfer forecast event requires source or destination account" }, 400);
+        }
 
-          if (!sourceAccount) {
-            throw new BadRequestError("Source account not found");
+        if (sourceAccountId && destinationAccountId && sourceAccountId === destinationAccountId) {
+          return c.json({ error: "transfer accounts must be different" }, 400);
+        }
+
+        const transaction = await prisma.$transaction(async (tx) => {
+          let sourceAccount = null;
+          let destinationAccount = null;
+
+          if (sourceAccountId) {
+            sourceAccount = await tx.account.findFirst({
+              where: { id: sourceAccountId, deletedAt: null },
+            });
+            if (!sourceAccount) {
+              throw new BadRequestError("Source account not found");
+            }
           }
-          if (!destinationAccount) {
-            throw new BadRequestError("Destination account not found");
+
+          if (destinationAccountId) {
+            destinationAccount = await tx.account.findFirst({
+              where: { id: destinationAccountId, deletedAt: null },
+            });
+            if (!destinationAccount) {
+              throw new BadRequestError("Destination account not found");
+            }
           }
+
           if (
+            sourceAccount &&
+            destinationAccount &&
             normalizeCurrencyCode(sourceAccount.currencyCode) !==
-            normalizeCurrencyCode(destinationAccount.currencyCode)
+              normalizeCurrencyCode(destinationAccount.currencyCode)
           ) {
             throw new BadRequestError("Cross-currency transfers are not supported");
           }
 
-          await tx.account.update({
-            where: { id: sourceAccount.id },
-            data: { balance: { decrement: body.amount } },
-          });
-          await tx.account.update({
-            where: { id: destinationAccount.id },
-            data: { balance: { increment: body.amount } },
-          });
+          if (sourceAccount) {
+            await tx.account.update({
+              where: { id: sourceAccount.id },
+              data: { balance: { decrement: body.amount } },
+            });
+          }
+
+          if (destinationAccount) {
+            await tx.account.update({
+              where: { id: destinationAccount.id },
+              data: { balance: { increment: body.amount } },
+            });
+          }
 
           return tx.transaction.create({
             data: {
-              accountId: sourceAccount.id,
-              transferToAccountId: destinationAccount.id,
+              accountId: sourceAccount?.id ?? null,
+              transferToAccountId: destinationAccount?.id ?? null,
               forecastEventId: event.id,
               date: new Date(`${event.date}T00:00:00.000Z`),
               type: "transfer",

--- a/packages/backend/src/routes/data-transfer.integration.test.ts
+++ b/packages/backend/src/routes/data-transfer.integration.test.ts
@@ -75,6 +75,24 @@ async function seedBackupDataset() {
     sortOrder: 2,
   });
   await createRecurringItem(testPrisma, {
+    name: "External out",
+    type: "transfer",
+    amount: 10000,
+    dayOfMonth: 2,
+    accountId: main.id,
+    transferToAccountId: null,
+    sortOrder: 4,
+  });
+  await createRecurringItem(testPrisma, {
+    name: "External in",
+    type: "transfer",
+    amount: 20000,
+    dayOfMonth: 3,
+    accountId: null,
+    transferToAccountId: savings.id,
+    sortOrder: 5,
+  });
+  await createRecurringItem(testPrisma, {
     name: "Deleted recurring",
     type: "expense",
     amount: 1000,

--- a/packages/backend/src/routes/recurring-items.integration.test.ts
+++ b/packages/backend/src/routes/recurring-items.integration.test.ts
@@ -165,6 +165,82 @@ describe("recurring items routes", () => {
     });
   });
 
+  it("allows one-sided transfer recurring items and rejects both accounts missing", async () => {
+    const source = await createAccount(testPrisma, { name: "Source" });
+    const destination = await createAccount(testPrisma, { name: "Destination" });
+
+    const sourceOnly = await client.post("/api/recurring-items", {
+      name: "External Out",
+      type: "transfer",
+      amount: 10000,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      accountId: source.id,
+      transferToAccountId: null,
+      enabled: true,
+      sortOrder: 1,
+    });
+
+    const destinationOnly = await client.post("/api/recurring-items", {
+      name: "External In",
+      type: "transfer",
+      amount: 10000,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      accountId: null,
+      transferToAccountId: destination.id,
+      enabled: true,
+      sortOrder: 2,
+    });
+
+    const bothNull = await client.post("/api/recurring-items", {
+      name: "No Accounts",
+      type: "transfer",
+      amount: 10000,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      accountId: null,
+      transferToAccountId: null,
+      enabled: true,
+      sortOrder: 3,
+    });
+
+    expect(sourceOnly.status).toBe(201);
+    const sourceOnlyBody = await parseJson<{ accountId: string | null; transferToAccountId: string | null }>(sourceOnly);
+    expect(sourceOnlyBody.accountId).toBe(source.id);
+    expect(sourceOnlyBody.transferToAccountId).toBeNull();
+
+    expect(destinationOnly.status).toBe(201);
+    const destinationOnlyBody = await parseJson<{ accountId: string | null; transferToAccountId: string | null }>(destinationOnly);
+    expect(destinationOnlyBody.accountId).toBeNull();
+    expect(destinationOnlyBody.transferToAccountId).toBe(destination.id);
+
+    expect(bothNull.status).toBe(400);
+    expect(await parseJson(bothNull)).toEqual({
+      error: "accountId or transferToAccountId is required for transfer",
+    });
+  });
+
+  it("rejects non-transfer recurring items without accountId", async () => {
+    const missingAccount = await client.post("/api/recurring-items", {
+      name: "Missing Account",
+      type: "expense",
+      amount: 1000,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      accountId: null,
+      enabled: true,
+      sortOrder: 1,
+    });
+
+    expect(missingAccount.status).toBe(400);
+    expect(await parseJson(missingAccount)).toEqual({ error: "accountId is required" });
+  });
+
   it("round-trips dateShiftPolicy and preserves it when omitted on update", async () => {
     const account = await createAccount(testPrisma, { name: "Main" });
 

--- a/packages/backend/src/routes/recurring-items.ts
+++ b/packages/backend/src/routes/recurring-items.ts
@@ -18,7 +18,7 @@ const basePayloadSchema = z.object({
   dayOfWeek: z.number().int().min(0).max(6).nullable().optional(),
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
-  accountId: z.string().uuid(),
+  accountId: z.string().uuid().nullish(),
   transferToAccountId: z.string().uuid().nullish(),
   enabled: z.boolean(),
   sortOrder: int32Schema(),
@@ -124,8 +124,8 @@ function buildRecurringItemData(
     dayOfWeek,
     startDate: body.startDate ? fromDateOnlyString(body.startDate) : null,
     endDate: body.endDate ? fromDateOnlyString(body.endDate) : null,
-    accountId: body.accountId,
-    transferToAccountId: body.type === "transfer" ? body.transferToAccountId : null,
+    accountId: body.accountId ?? null,
+    transferToAccountId: body.type === "transfer" ? (body.transferToAccountId ?? null) : null,
     enabled: body.enabled,
     sortOrder: body.sortOrder,
     ...(body.dateShiftPolicy !== undefined ? { dateShiftPolicy: body.dateShiftPolicy } : {}),
@@ -142,32 +142,62 @@ async function validateRecurringPayload(body: RecurringPayload, existing?: Recur
     if (body.transferToAccountId) {
       return "transferToAccountId is only allowed for transfer";
     }
+    if (!body.accountId) {
+      return "accountId is required";
+    }
+    const account = await prisma.account.findFirst({ where: { id: body.accountId, deletedAt: null } });
+    if (!account) {
+      return "Account not found";
+    }
     return null;
   }
 
-  if (!body.transferToAccountId) {
-    return "transferToAccountId is required for transfer";
+  if (!body.accountId && !body.transferToAccountId) {
+    return "accountId or transferToAccountId is required for transfer";
   }
 
-  if (body.accountId === body.transferToAccountId) {
+  if (body.accountId && body.accountId === body.transferToAccountId) {
     return "transfer accounts must be different";
   }
 
-  const [sourceAccount, destinationAccount] = await Promise.all([
-    prisma.account.findFirst({ where: { id: body.accountId, deletedAt: null } }),
-    prisma.account.findFirst({ where: { id: body.transferToAccountId, deletedAt: null } }),
-  ]);
-  if (!sourceAccount) {
-    return "Source account not found";
+  if (body.accountId && body.transferToAccountId) {
+    const [sourceAccount, destinationAccount] = await Promise.all([
+      prisma.account.findFirst({ where: { id: body.accountId, deletedAt: null } }),
+      prisma.account.findFirst({ where: { id: body.transferToAccountId, deletedAt: null } }),
+    ]);
+    if (!sourceAccount) {
+      return "Source account not found";
+    }
+    if (!destinationAccount) {
+      return "Destination account not found";
+    }
+    if (
+      normalizeCurrencyCode(sourceAccount.currencyCode) !==
+      normalizeCurrencyCode(destinationAccount.currencyCode)
+    ) {
+      throw new BadRequestError("Cross-currency transfers are not supported");
+    }
+
+    return null;
   }
-  if (!destinationAccount) {
-    return "Destination account not found";
+
+  if (body.accountId) {
+    const sourceAccount = await prisma.account.findFirst({
+      where: { id: body.accountId, deletedAt: null },
+    });
+    if (!sourceAccount) {
+      return "Source account not found";
+    }
+    return null;
   }
-  if (
-    normalizeCurrencyCode(sourceAccount.currencyCode) !==
-    normalizeCurrencyCode(destinationAccount.currencyCode)
-  ) {
-    throw new BadRequestError("Cross-currency transfers are not supported");
+
+  if (body.transferToAccountId) {
+    const destinationAccount = await prisma.account.findFirst({
+      where: { id: body.transferToAccountId, deletedAt: null },
+    });
+    if (!destinationAccount) {
+      return "Destination account not found";
+    }
   }
 
   return null;

--- a/packages/backend/src/services/forecast-core.test.ts
+++ b/packages/backend/src/services/forecast-core.test.ts
@@ -465,6 +465,144 @@ describe("buildDashboardCore", () => {
     );
   });
 
+  it("treats source-only transfers as external outflows", () => {
+    const source = account({ id: "source", name: "Source", balance: 500, sortOrder: 1 });
+    const transfer = recurringItem({
+      id: "source-only-transfer",
+      name: "External Out",
+      type: "transfer" as RecurringItemType,
+      amount: 200,
+      dayOfMonth: 10,
+      account: source,
+      accountId: source.id,
+      transferToAccount: null,
+      transferToAccountId: null,
+    });
+
+    const result = buildDashboard({
+      accounts: [source],
+      recurringItems: [transfer],
+      today: "2026-03-01",
+      forecastMonths: 1,
+    });
+
+    expect(result.totalBalance).toBe(500);
+    expect(result.minBalance).toBe(300);
+    expect(result.forecast).toEqual([
+      expect.objectContaining({
+        id: "recurring:source-only-transfer:2026-03",
+        type: "transfer",
+        balance: 300,
+        accountId: source.id,
+        transferToAccountId: null,
+      }),
+    ]);
+    expect(result.accountForecasts).toEqual([
+      expect.objectContaining({
+        accountId: source.id,
+        minBalance: 300,
+        events: [
+          expect.objectContaining({
+            id: "recurring:source-only-transfer:2026-03",
+            balance: 300,
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("treats destination-only transfers as external inflows", () => {
+    const destination = account({ id: "destination", name: "Destination", balance: 100, sortOrder: 1 });
+    const transfer = recurringItem({
+      id: "destination-only-transfer",
+      name: "External In",
+      type: "transfer" as RecurringItemType,
+      amount: 200,
+      dayOfMonth: 10,
+      account: null,
+      accountId: null,
+      transferToAccount: destination,
+      transferToAccountId: destination.id,
+    });
+
+    const result = buildDashboard({
+      accounts: [destination],
+      recurringItems: [transfer],
+      today: "2026-03-01",
+      forecastMonths: 1,
+    });
+
+    expect(result.totalBalance).toBe(100);
+    expect(result.minBalance).toBe(100);
+    expect(result.forecast).toEqual([
+      expect.objectContaining({
+        id: "recurring:destination-only-transfer:2026-03",
+        type: "transfer",
+        balance: 300,
+        accountId: null,
+        transferToAccountId: destination.id,
+      }),
+    ]);
+    expect(result.accountForecasts).toEqual([
+      expect.objectContaining({
+        accountId: destination.id,
+        minBalance: 100,
+        events: [
+          expect.objectContaining({
+            id: "recurring:destination-only-transfer:2026-03",
+            balance: 300,
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("handles one-sided transfer overdue forecast events", () => {
+    const source = account({ id: "source", name: "Source", balance: 500, sortOrder: 1 });
+    const destination = account({ id: "destination", name: "Destination", balance: 100, sortOrder: 2 });
+    const sourceOnly = recurringItem({
+      id: "overdue-source-only",
+      name: "Overdue Out",
+      type: "transfer" as RecurringItemType,
+      amount: 50,
+      dayOfMonth: 10,
+      account: source,
+      accountId: source.id,
+      transferToAccount: null,
+      transferToAccountId: null,
+    });
+    const destinationOnly = recurringItem({
+      id: "overdue-destination-only",
+      name: "Overdue In",
+      type: "transfer" as RecurringItemType,
+      amount: 30,
+      dayOfMonth: 15,
+      account: null,
+      accountId: null,
+      transferToAccount: destination,
+      transferToAccountId: destination.id,
+    });
+
+    const result = buildDashboard({
+      accounts: [source, destination],
+      recurringItems: [sourceOnly, destinationOnly],
+      today: "2026-03-20",
+      forecastMonths: 1,
+    });
+
+    expect(result.overdueForecast).toEqual([
+      expect.objectContaining({
+        id: "recurring:overdue-source-only:2026-03",
+        balance: 550,
+      }),
+      expect.objectContaining({
+        id: "recurring:overdue-destination-only:2026-03",
+        balance: 580,
+      }),
+    ]);
+    expect(result.forecast).toHaveLength(0);
+  });
+
   it("excludes recurring transfer forecast events that already have confirmed transactions", () => {
     const source = account({ id: "source", name: "Source", balance: 500, sortOrder: 1 });
     const destination = account({ id: "destination", name: "Destination", balance: 100, sortOrder: 2 });

--- a/packages/backend/src/services/forecast-core.ts
+++ b/packages/backend/src/services/forecast-core.ts
@@ -114,13 +114,31 @@ export function sortEvents(events: RawForecastEvent[]) {
   });
 }
 
-export function applyEvent(balance: number, event: Pick<RawForecastEvent, "type" | "amount">) {
+export function applyEvent(
+  balance: number,
+  event: Pick<RawForecastEvent, "type" | "amount" | "accountId" | "transferToAccountId">,
+) {
   if (event.type === "income") {
     return balance + event.amount;
   }
 
   if (event.type === "expense") {
     return balance - event.amount;
+  }
+
+  const hasSource = event.accountId != null;
+  const hasDestination = event.transferToAccountId != null;
+
+  if (hasSource && hasDestination) {
+    return balance;
+  }
+
+  if (hasSource) {
+    return balance - event.amount;
+  }
+
+  if (hasDestination) {
+    return balance + event.amount;
   }
 
   return balance;
@@ -249,7 +267,7 @@ export function buildDashboardCore({
           isAssumption: false,
           description: item.name,
           amount: item.amount,
-          ...getAccountCurrency(item.account),
+          ...getAccountCurrency(item.account ?? item.transferToAccount),
           accountId: item.accountId,
           transferToAccountId: item.transferToAccountId,
           sourcePriority: 10,
@@ -360,7 +378,12 @@ export function buildDashboardCore({
   for (const event of pastEvents) {
     const amountJpy = getEventAmountJpy(event);
     const currencyCode = event.currencyCode ?? DEFAULT_CURRENCY_CODE;
-    runningOverdueBalance = applyEvent(runningOverdueBalance, { type: event.type, amount: amountJpy });
+    runningOverdueBalance = applyEvent(runningOverdueBalance, {
+      type: event.type,
+      amount: amountJpy,
+      accountId: event.accountId,
+      transferToAccountId: event.transferToAccountId,
+    });
     overdueForecast.push({
       id: event.id,
       date: event.date,
@@ -452,7 +475,12 @@ export function buildDashboardCore({
   for (const event of futureEvents) {
     const amountJpy = getEventAmountJpy(event);
     const currencyCode = event.currencyCode ?? DEFAULT_CURRENCY_CODE;
-    runningTotalBalance = applyEvent(runningTotalBalance, { type: event.type, amount: amountJpy });
+    runningTotalBalance = applyEvent(runningTotalBalance, {
+      type: event.type,
+      amount: amountJpy,
+      accountId: event.accountId,
+      transferToAccountId: event.transferToAccountId,
+    });
     minBalance = Math.min(minBalance, runningTotalBalance);
 
     forecast.push({

--- a/packages/backend/src/services/forecast.test.ts
+++ b/packages/backend/src/services/forecast.test.ts
@@ -92,8 +92,14 @@ describe("sortEvents", () => {
 
 describe("applyEvent", () => {
   it("adds income, subtracts expense, and keeps transfer neutral", () => {
-    expect(applyEvent(1000, { type: "income", amount: 300 })).toBe(1300);
-    expect(applyEvent(1000, { type: "expense", amount: 300 })).toBe(700);
-    expect(applyEvent(1000, { type: "transfer", amount: 300 })).toBe(1000);
+    expect(applyEvent(1000, { type: "income", amount: 300, accountId: null, transferToAccountId: null })).toBe(1300);
+    expect(applyEvent(1000, { type: "expense", amount: 300, accountId: null, transferToAccountId: null })).toBe(700);
+    expect(applyEvent(1000, { type: "transfer", amount: 300, accountId: null, transferToAccountId: null })).toBe(1000);
+  });
+
+  it("treats one-sided transfers as external inflow or outflow", () => {
+    expect(applyEvent(1000, { type: "transfer", amount: 300, accountId: "source", transferToAccountId: null })).toBe(700);
+    expect(applyEvent(1000, { type: "transfer", amount: 300, accountId: null, transferToAccountId: "destination" })).toBe(1300);
+    expect(applyEvent(1000, { type: "transfer", amount: 300, accountId: "source", transferToAccountId: "destination" })).toBe(1000);
   });
 });

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -32,7 +32,7 @@ export async function createRecurringItem(
     startDate?: Date | null;
     endDate?: Date | null;
     dateShiftPolicy?: "none" | "previous" | "next";
-    accountId: string;
+    accountId?: string | null;
     transferToAccountId?: string | null;
     enabled?: boolean;
     sortOrder?: number;

--- a/packages/frontend/src/routes/recurring.tsx
+++ b/packages/frontend/src/routes/recurring.tsx
@@ -103,7 +103,7 @@ function getAccountLabel(type: RecurringItemType) {
   }
 
   if (type === "transfer") {
-    return "振替元口座";
+    return "送金元口座";
   }
 
   return "引き落とし口座";
@@ -119,7 +119,7 @@ function formatRecurringSchedule(item: RecurringItem) {
 function getTransferDestinationAccounts(accounts: Account[], sourceAccountId: string) {
   const sourceAccount = accounts.find((account) => account.id === sourceAccountId);
   if (!sourceAccount) {
-    return [];
+    return accounts;
   }
 
   return accounts.filter(
@@ -129,6 +129,10 @@ function getTransferDestinationAccounts(accounts: Account[], sourceAccountId: st
 
 function isTransferDestinationValid(form: RecurringForm, accounts: Account[]) {
   if (form.type !== "transfer") {
+    return true;
+  }
+
+  if (form.transferToAccountId === "") {
     return true;
   }
 
@@ -145,15 +149,21 @@ function normalizeTransferToAccountId(form: RecurringForm, accounts: Account[]) 
   return isTransferDestinationValid(form, accounts) ? form.transferToAccountId : "";
 }
 
+function hasTransferAccount(form: RecurringForm) {
+  return form.accountId !== "" || form.transferToAccountId !== "";
+}
+
 function canSaveRecurringForm(form: RecurringForm, accounts: Account[]) {
   const dayValid = form.recurrence === "monthly"
     ? form.dayOfMonth !== null && form.dayOfMonth >= 1 && form.dayOfMonth <= 31
     : form.dayOfWeek !== null && form.dayOfWeek >= 0 && form.dayOfWeek <= 6;
 
+  const hasAccount = form.type === "transfer" ? hasTransferAccount(form) : form.accountId !== "";
+
   return (
     form.name.trim().length > 0 &&
     dayValid &&
-    form.accountId !== "" &&
+    hasAccount &&
     isPeriodValid(form.startDate, form.endDate) &&
     isTransferDestinationValid(form, accounts)
   );
@@ -162,7 +172,11 @@ function canSaveRecurringForm(form: RecurringForm, accounts: Account[]) {
 function getMissingFields(form: RecurringForm, accounts: Account[]) {
   const missing: string[] = [];
   if (form.name.trim().length === 0) missing.push("カテゴリ名");
-  if (form.accountId === "") missing.push("口座");
+  if (form.type === "transfer") {
+    if (!hasTransferAccount(form)) missing.push("口座");
+  } else if (form.accountId === "") {
+    missing.push("口座");
+  }
   if (form.type === "transfer" && !isTransferDestinationValid(form, accounts)) missing.push("振替先口座");
   if (form.recurrence === "monthly" && (form.dayOfMonth === null || form.dayOfMonth < 1 || form.dayOfMonth > 31)) missing.push("毎月の発生日");
   if (form.recurrence === "weekly" && (form.dayOfWeek === null || form.dayOfWeek < 0 || form.dayOfWeek > 6)) missing.push("曜日");
@@ -181,8 +195,8 @@ function toRecurringPayload(form: RecurringForm) {
     startDate: form.startDate,
     endDate: form.endDate,
     dateShiftPolicy: form.dateShiftPolicy,
-    accountId: form.accountId,
-    transferToAccountId: form.type === "transfer" ? form.transferToAccountId : null,
+    accountId: form.accountId || null,
+    transferToAccountId: form.type === "transfer" ? form.transferToAccountId || null : null,
     enabled: form.enabled,
     sortOrder: form.sortOrder,
   };
@@ -514,6 +528,8 @@ function RecurringEditModal({
         label={getAccountLabel(form.type)}
         accounts={accounts}
         value={form.accountId}
+        required={form.type !== "transfer"}
+        placeholder={form.type === "transfer" ? "送金元口座なし" : "対象口座を選択"}
         onChange={(accountId) => {
           const nextForm = { ...form, accountId };
           onChange({ ...nextForm, transferToAccountId: normalizeTransferToAccountId(nextForm, accounts) });
@@ -526,8 +542,9 @@ function RecurringEditModal({
           label="振替先口座"
           accounts={transferDestinationAccounts}
           value={form.transferToAccountId}
+          required={false}
+          placeholder="振替先口座なし"
           onChange={(accountId) => onChange({ ...form, transferToAccountId: accountId })}
-          disabled={form.accountId === ""}
         />
       ) : null}
 

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -1335,6 +1335,67 @@ describe("MCP server", () => {
     });
   });
 
+  it("forwards one-sided recurring transfer payloads", async () => {
+    addRoute("POST", "/api/recurring-items", {
+      status: 201,
+      body: {
+        id: "recurring-transfer-source-only",
+        name: "External Out",
+        type: "transfer",
+        amount: 10000,
+        dayOfMonth: 10,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "none",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        transferToAccountId: null,
+        enabled: true,
+        sortOrder: 5,
+      },
+    });
+
+    const result = await client.callTool({
+      name: "create_recurring_item",
+      arguments: {
+        name: "External Out",
+        type: "transfer",
+        amount: 10000,
+        dayOfMonth: 10,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "none",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        transferToAccountId: null,
+        enabled: true,
+        sortOrder: 5,
+      },
+    });
+
+    expect(getToolText(result)).toContain("External Out");
+
+    const requests = (globalThis as typeof globalThis & {
+      __mcpRequests?: Array<{ method: string; path: string; body?: unknown }>;
+    }).__mcpRequests ?? [];
+
+    expect(requests).toContainEqual({
+      method: "POST",
+      path: "/api/recurring-items",
+      body: {
+        name: "External Out",
+        type: "transfer",
+        amount: 10000,
+        dayOfMonth: 10,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "none",
+        accountId: "11111111-1111-4111-a111-111111111111",
+        transferToAccountId: null,
+        enabled: true,
+        sortOrder: 5,
+      },
+    });
+  });
+
   it("forwards weekly recurring item and subscription payloads", async () => {
     addRoute("POST", "/api/recurring-items", {
       status: 201,

--- a/packages/mcp/src/tools/recurring-items.ts
+++ b/packages/mcp/src/tools/recurring-items.ts
@@ -32,8 +32,8 @@ const recurringPayload = {
   startDate: dateSchema.nullable().describe("開始日"),
   endDate: dateSchema.nullable().describe("終了日"),
   dateShiftPolicy: dateShiftPolicySchema.optional().describe("土日祝の扱い"),
-  accountId: uuidSchema.describe("口座 ID。振替では振替元口座"),
-  transferToAccountId: uuidSchema.optional().describe("振替先口座 ID。type が transfer の場合に指定。振替は口座別予測に反映され、合計残高には中立"),
+  accountId: uuidSchema.optional().nullable().describe("口座 ID。振替では送金元口座。type が transfer の場合は null または省略で送金元なし"),
+  transferToAccountId: uuidSchema.optional().nullable().describe("振替先口座 ID。type が transfer の場合に指定。null または省略で振替先なし"),
   enabled: z.boolean().describe("有効フラグ"),
   sortOrder: z.number().int().describe("表示順"),
 };

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -141,7 +141,7 @@ export interface CreateRecurringItemPayload {
   startDate: string | null;
   endDate: string | null;
   dateShiftPolicy?: DateShiftPolicy;
-  accountId: string;
+  accountId?: string | null;
   transferToAccountId?: string | null;
   enabled: boolean;
   sortOrder: number;


### PR DESCRIPTION
## 概要

固定収支の振替設定を、取引管理と同じ片側任意の口座指定へ揃えます。

## 変更内容

- 送金元・振替先のどちらか片側だけを指定した固定収支を許可
- 両方未設定は拒否し、両側指定時は同一口座・異通貨間の振替を拒否
- 送金元未設定でも振替先を選択できるようUIを変更
- 送金元・振替先に「なし」の選択肢を追加
- 片側振替を総残高・口座別残高・期限超過予測へ正しい符号で反映
- 予測の手動確定を片側振替に対応
- Shared型、MCP、データ移行、E2Eヘルパーを整合

## テスト

SWE-1.7 が Makefile 経由で以下を実行し、すべて成功しました。

- `make lint`
- `make typecheck`
- `make test-unit`（backend 75、mcp 59、frontend 52）
- `make test-integration`（132 passed）
- `make build`
- `make test-e2e`（69 passed）

## レビュー結果

API制約、予測残高の符号、手動確定時の口座更新、UI操作、MCP・データ互換性を確認し、GOと判断しました。
