### PR TITLE
固定収支の外貨入力・表示に対応

### DIFF
--- a/e2e/recurring.spec.ts
+++ b/e2e/recurring.spec.ts
@@ -22,7 +22,7 @@ test("creates an income recurring item", async ({ page }) => {
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("Salary");
   await page.getByRole("radio", { name: "収入" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("300000");
+  await page.getByLabel("金額 (JPY)").first().fill("300000");
   await page.getByLabel("毎月の発生日").first().fill("25");
   await page.getByLabel("振り込み先口座 *").selectOption(account.id);
   await page.getByRole("button", { name: "追加" }).click();
@@ -39,7 +39,7 @@ test("creates an expense recurring item with a period", async ({ page }) => {
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("Rent");
   await page.getByRole("radio", { name: "支出" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("80000");
+  await page.getByLabel("金額 (JPY)").first().fill("80000");
   await page.getByLabel("毎月の発生日").first().fill("27");
   await page.getByLabel("開始日").first().fill("2026-03-01");
   await page.getByLabel("終了日").first().fill("2026-12-31");
@@ -66,7 +66,7 @@ test("edits a recurring item", async ({ page }) => {
 
   const row = page.getByRole("row", { name: /Subscription/ });
   await row.getByRole("button", { name: "編集" }).click();
-  await page.getByLabel("金額 (円)").last().fill("2500");
+  await page.getByLabel("金額 (JPY)").last().fill("2500");
   await page.getByRole("button", { name: "保存" }).click();
   await waitForReload(page);
 
@@ -81,7 +81,7 @@ test("keeps recurring item date shift policy through create and edit", async ({ 
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("Shifted Rent");
   await page.getByRole("radio", { name: "支出" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("80000");
+  await page.getByLabel("金額 (JPY)").first().fill("80000");
   await page.getByLabel("毎月の発生日").first().fill("31");
   await page.getByLabel("土日祝の扱い").first().selectOption("next");
   await page.getByLabel("引き落とし口座 *").selectOption(account.id);
@@ -92,7 +92,7 @@ test("keeps recurring item date shift policy through create and edit", async ({ 
   await row.getByRole("button", { name: "編集" }).click();
   await expect(page.getByLabel("土日祝の扱い").last()).toHaveValue("next");
 
-  await page.getByLabel("金額 (円)").last().fill("81000");
+  await page.getByLabel("金額 (JPY)").last().fill("81000");
   await page.getByRole("button", { name: "保存" }).click();
   await waitForReload(page);
 
@@ -129,7 +129,7 @@ test("creates and edits a weekly recurring item", async ({ page }) => {
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("Lunch");
   await page.getByRole("radio", { name: "支出" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("1000");
+  await page.getByLabel("金額 (JPY)").first().fill("1000");
   await page.getByRole("radio", { name: "毎週" }).first().click();
   await page.getByLabel("曜日").first().selectOption("5");
   await page.getByLabel("引き落とし口座 *").selectOption(account.id);
@@ -155,7 +155,7 @@ test("creates a transfer with only a destination account and edits it", async ({
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("External In");
   await page.getByRole("radio", { name: "振替" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("10000");
+  await page.getByLabel("金額 (JPY)").first().fill("10000");
   await page.getByLabel("毎月の発生日").first().fill("10");
   await page.getByLabel("送金元口座").first().selectOption("");
   await page.getByLabel("振替先口座").first().selectOption(account.id);
@@ -182,7 +182,7 @@ test("creates a transfer with only a source account and disables save when both 
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("External Out");
   await page.getByRole("radio", { name: "振替" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("5000");
+  await page.getByLabel("金額 (JPY)").first().fill("5000");
   await page.getByLabel("毎月の発生日").first().fill("20");
   await page.getByLabel("送金元口座").first().selectOption(account.id);
   await page.getByLabel("振替先口座").first().selectOption("");
@@ -194,8 +194,61 @@ test("creates a transfer with only a source account and disables save when both 
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("No Accounts");
   await page.getByRole("radio", { name: "振替" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("1000");
+  await page.getByLabel("金額 (JPY)").first().fill("1000");
   await page.getByLabel("毎月の発生日").first().fill("15");
   await page.getByLabel("送金元口座").first().selectOption("");
   await expect(page.getByRole("button", { name: "追加" })).toBeDisabled();
+});
+
+test("creates a USD recurring item and displays the amount in USD", async ({ page }) => {
+  const usdAccount = await seedAccount({
+    name: "USD Account",
+    currencyCode: "USD",
+    exchangeRateToJpy: 150,
+  });
+
+  await navigateTo(page, "/recurring");
+
+  await page.getByRole("button", { name: "固定収支を追加" }).click();
+  await page.getByLabel("カテゴリ名 *").first().fill("USD Rent");
+  await page.getByRole("radio", { name: "支出" }).first().click();
+  await page.getByLabel("引き落とし口座 *").selectOption(usdAccount.id);
+  await page.getByLabel("金額 (USD)").first().fill("1000.00");
+  await page.getByLabel("毎月の発生日").first().fill("25");
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  const row = page.getByRole("row", { name: /USD Rent/ });
+  await expect(row).toContainText("支出");
+  await expect(row).toContainText(new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(1000));
+});
+
+test("creates a USD destination-only transfer and displays the source as unset", async ({ page }) => {
+  const usdAccount = await seedAccount({
+    name: "USD Account",
+    currencyCode: "USD",
+    exchangeRateToJpy: 150,
+  });
+
+  await navigateTo(page, "/recurring");
+
+  await page.getByRole("button", { name: "固定収支を追加" }).click();
+  await page.getByLabel("カテゴリ名 *").first().fill("USD External In");
+  await page.getByRole("radio", { name: "振替" }).first().click();
+  await page.getByLabel("送金元口座").first().selectOption("");
+  await page.getByLabel("振替先口座").first().selectOption(usdAccount.id);
+  await page.getByLabel("金額 (USD)").first().fill("500.00");
+  await page.getByLabel("毎月の発生日").first().fill("10");
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  const row = page.getByRole("row", { name: /USD External In/ });
+  await expect(row).toContainText("未設定 → USD Account");
+  await expect(row).toContainText(new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(500));
 });

--- a/e2e/scenarios/forecast-flow.spec.ts
+++ b/e2e/scenarios/forecast-flow.spec.ts
@@ -25,7 +25,7 @@ test("reflects newly created accounts and recurring items on the dashboard forec
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("給料");
   await page.getByRole("radio", { name: "収入" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("250000");
+  await page.getByLabel("金額 (JPY)").first().fill("250000");
   await page.getByLabel("毎月の発生日").first().fill(String(forecastDayOfMonth));
   await page.getByLabel("振り込み先口座 *").selectOption({ label: "メイン口座" });
   await page.getByRole("button", { name: "追加" }).click();
@@ -36,7 +36,7 @@ test("reflects newly created accounts and recurring items on the dashboard forec
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("家賃");
   await page.getByRole("radio", { name: "支出" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("80000");
+  await page.getByLabel("金額 (JPY)").first().fill("80000");
   await page.getByLabel("毎月の発生日").first().fill(String(forecastDayOfMonth));
   await page.getByLabel("引き落とし口座 *").selectOption({ label: "メイン口座" });
   await page.getByRole("button", { name: "追加" }).click();
@@ -78,7 +78,7 @@ test("reflects recurring transfers in account forecasts and confirms them as tra
   await page.getByRole("button", { name: "固定収支を追加" }).click();
   await page.getByLabel("カテゴリ名 *").first().fill("資金移動");
   await page.getByRole("radio", { name: "振替" }).first().click();
-  await page.getByLabel("金額 (円)").first().fill("100000");
+  await page.getByLabel("金額 (JPY)").first().fill("100000");
   await page.getByLabel("毎月の発生日").first().fill(String(dayOfMonth));
   await page.getByLabel("開始日").first().fill(eventDate);
   await page.getByLabel("終了日").first().fill(eventDate);

--- a/packages/backend/src/routes/dashboard.integration.test.ts
+++ b/packages/backend/src/routes/dashboard.integration.test.ts
@@ -1395,4 +1395,194 @@ describe("dashboard routes", () => {
       ]),
     );
   });
+
+  it("confirms a USD recurring expense and returns currency, amountJpy, and updated balance", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const usdAccount = await createAccount(testPrisma, {
+      name: "USD Wallet",
+      balance: 100000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 1,
+    });
+    const recurring = await createRecurringItem(testPrisma, {
+      name: "USD Rent",
+      type: "expense",
+      amount: 25000,
+      dayOfMonth: 20,
+      accountId: usdAccount.id,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/dashboard/confirm", {
+      forecastEventId: `recurring:${recurring.id}:2026-03`,
+      amount: 25000,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await parseJson<{
+      amount: number;
+      amountJpy: number;
+      currencyCode: string;
+      accountName: string | null;
+    }>(response);
+    expect(body.amount).toBe(25000);
+    expect(body.amountJpy).toBe(37500);
+    expect(body.currencyCode).toBe("USD");
+    expect(body.accountName).toBe("USD Wallet");
+
+    const updatedAccount = await testPrisma.account.findUniqueOrThrow({
+      where: { id: usdAccount.id },
+    });
+    expect(updatedAccount.balance).toBe(75000);
+  });
+
+  it("confirms a USD source-only transfer and updates source balance in raw currency", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const usdAccount = await createAccount(testPrisma, {
+      name: "USD Source",
+      balance: 100000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 1,
+    });
+    const transfer = await createRecurringItem(testPrisma, {
+      name: "External Out",
+      type: "transfer",
+      amount: 25000,
+      dayOfMonth: 20,
+      accountId: usdAccount.id,
+      transferToAccountId: null,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/dashboard/confirm", {
+      forecastEventId: `recurring:${transfer.id}:2026-03`,
+      amount: 25000,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await parseJson<{
+      amount: number;
+      amountJpy: number;
+      currencyCode: string;
+      accountId: string | null;
+      transferToAccountId: string | null;
+    }>(response);
+    expect(body.amount).toBe(25000);
+    expect(body.amountJpy).toBe(37500);
+    expect(body.currencyCode).toBe("USD");
+    expect(body.accountId).toBe(usdAccount.id);
+    expect(body.transferToAccountId).toBeNull();
+
+    const updatedAccount = await testPrisma.account.findUniqueOrThrow({
+      where: { id: usdAccount.id },
+    });
+    expect(updatedAccount.balance).toBe(75000);
+  });
+
+  it("confirms a USD destination-only transfer and updates destination balance in raw currency", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const usdAccount = await createAccount(testPrisma, {
+      name: "USD Destination",
+      balance: 100000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 1,
+    });
+    const transfer = await createRecurringItem(testPrisma, {
+      name: "External In",
+      type: "transfer",
+      amount: 25000,
+      dayOfMonth: 20,
+      accountId: null,
+      transferToAccountId: usdAccount.id,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/dashboard/confirm", {
+      forecastEventId: `recurring:${transfer.id}:2026-03`,
+      amount: 25000,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await parseJson<{
+      amount: number;
+      amountJpy: number;
+      currencyCode: string;
+      accountId: string | null;
+      transferToAccountId: string | null;
+    }>(response);
+    expect(body.amount).toBe(25000);
+    expect(body.amountJpy).toBe(37500);
+    expect(body.currencyCode).toBe("USD");
+    expect(body.accountId).toBeNull();
+    expect(body.transferToAccountId).toBe(usdAccount.id);
+
+    const updatedAccount = await testPrisma.account.findUniqueOrThrow({
+      where: { id: usdAccount.id },
+    });
+    expect(updatedAccount.balance).toBe(125000);
+  });
+
+  it("confirms a USD two-sided transfer and updates both accounts in raw currency", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T00:00:00.000Z"));
+
+    const usdSource = await createAccount(testPrisma, {
+      name: "USD Source",
+      balance: 100000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 1,
+    });
+    const usdDestination = await createAccount(testPrisma, {
+      name: "USD Destination",
+      balance: 50000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 2,
+    });
+    const transfer = await createRecurringItem(testPrisma, {
+      name: "USD Move",
+      type: "transfer",
+      amount: 25000,
+      dayOfMonth: 20,
+      accountId: usdSource.id,
+      transferToAccountId: usdDestination.id,
+      sortOrder: 1,
+    });
+
+    const response = await client.post("/api/dashboard/confirm", {
+      forecastEventId: `recurring:${transfer.id}:2026-03`,
+      amount: 25000,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await parseJson<{
+      amount: number;
+      amountJpy: number;
+      currencyCode: string;
+      accountId: string | null;
+      transferToAccountId: string | null;
+    }>(response);
+    expect(body.amount).toBe(25000);
+    expect(body.amountJpy).toBe(37500);
+    expect(body.currencyCode).toBe("USD");
+    expect(body.accountId).toBe(usdSource.id);
+    expect(body.transferToAccountId).toBe(usdDestination.id);
+
+    const [updatedSource, updatedDestination] = await Promise.all([
+      testPrisma.account.findUniqueOrThrow({ where: { id: usdSource.id } }),
+      testPrisma.account.findUniqueOrThrow({ where: { id: usdDestination.id } }),
+    ]);
+    expect(updatedSource.balance).toBe(75000);
+    expect(updatedDestination.balance).toBe(75000);
+  });
 });

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -6,10 +6,10 @@ import type {
   DashboardSimulationResponse,
   ForecastEvent,
 } from "@sui/shared";
-import { DEFAULT_SETTINGS } from "@sui/shared";
+import { DEFAULT_CURRENCY_CODE, DEFAULT_SETTINGS } from "@sui/shared";
 import { z } from "zod";
 import { prisma } from "../lib/db";
-import { normalizeCurrencyCode } from "../lib/currency";
+import { normalizeCurrencyCode, toJpy } from "../lib/currency";
 import { addMonthsToYearMonth, getCurrentYearMonth, getJstToday } from "../lib/dates";
 import { BadRequestError, ConflictError, handleRouteError, notFound } from "../lib/http";
 import { positiveInt32Schema } from "../lib/validation";
@@ -120,6 +120,25 @@ function createEmptySourceTotals(): DashboardExplainSourceTotals {
     creditCardJpy: 0,
     loanJpy: 0,
     transferJpy: 0,
+  };
+}
+
+function buildTransactionResponse(
+  transaction: Awaited<ReturnType<typeof prisma.transaction.create>>,
+  currencyAccount: { currencyCode: string; exchangeRateToJpy: number } | null,
+  accountName: string | null,
+  transferToAccount: { name: string; currencyCode: string } | null,
+) {
+  const currencyCode = currencyAccount ? normalizeCurrencyCode(currencyAccount.currencyCode) : DEFAULT_CURRENCY_CODE;
+  const amountJpy = currencyAccount ? toJpy(transaction.amount, currencyAccount) : transaction.amount;
+
+  return {
+    ...transaction,
+    currencyCode,
+    amountJpy,
+    accountName,
+    transferToAccountName: transferToAccount?.name ?? null,
+    transferToAccountCurrencyCode: transferToAccount ? normalizeCurrencyCode(transferToAccount.currencyCode) : null,
   };
 }
 
@@ -373,7 +392,7 @@ export const dashboardRoutes = new Hono()
           return c.json({ error: "transfer accounts must be different" }, 400);
         }
 
-        const transaction = await prisma.$transaction(async (tx) => {
+        const { sourceAccount, destinationAccount, transaction } = await prisma.$transaction(async (tx) => {
           let sourceAccount = null;
           let destinationAccount = null;
 
@@ -418,7 +437,7 @@ export const dashboardRoutes = new Hono()
             });
           }
 
-          return tx.transaction.create({
+          const transaction = await tx.transaction.create({
             data: {
               accountId: sourceAccount?.id ?? null,
               transferToAccountId: destinationAccount?.id ?? null,
@@ -429,9 +448,19 @@ export const dashboardRoutes = new Hono()
               amount: body.amount,
             },
           });
+
+          return { sourceAccount, destinationAccount, transaction };
         });
 
-        return c.json(transaction, 201);
+        return c.json(
+          buildTransactionResponse(
+            transaction,
+            sourceAccount ?? destinationAccount,
+            sourceAccount?.name ?? null,
+            destinationAccount,
+          ),
+          201,
+        );
       }
 
       const resolvedAccountId = body.accountId ?? event.accountId ?? undefined;
@@ -439,7 +468,7 @@ export const dashboardRoutes = new Hono()
         return c.json({ error: "Account is required for this forecast event" }, 400);
       }
 
-      const transaction = await prisma.$transaction(async (tx) => {
+      const { account, transaction } = await prisma.$transaction(async (tx) => {
         const account = await tx.account.findFirst({
           where: { id: resolvedAccountId, deletedAt: null },
         });
@@ -461,7 +490,7 @@ export const dashboardRoutes = new Hono()
           },
         });
 
-        return tx.transaction.create({
+        const transaction = await tx.transaction.create({
           data: {
             accountId: account.id,
             forecastEventId: event.id,
@@ -471,9 +500,11 @@ export const dashboardRoutes = new Hono()
             amount: body.amount,
           },
         });
+
+        return { account, transaction };
       });
 
-      return c.json(transaction, 201);
+      return c.json(buildTransactionResponse(transaction, account, account.name, null), 201);
     } catch (error) {
       if (isPrismaUniqueConstraintError(error)) {
         return handleRouteError(c, new ConflictError("Forecast event already confirmed"));

--- a/packages/backend/src/services/forecast-core.test.ts
+++ b/packages/backend/src/services/forecast-core.test.ts
@@ -1095,4 +1095,278 @@ describe("buildDashboardCore", () => {
     );
     expect(ids).toHaveLength(9);
   });
+
+  it("handles USD transfer source-only as external outflow in raw currency and JPY", () => {
+    const usd = account({
+      id: "usd",
+      name: "USD",
+      balance: 100000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 1,
+    });
+    const transfer = recurringItem({
+      id: "usd-source-only-transfer",
+      name: "External Out",
+      type: "transfer" as RecurringItemType,
+      amount: 50000,
+      dayOfMonth: 10,
+      account: usd,
+      accountId: usd.id,
+      transferToAccount: null,
+      transferToAccountId: null,
+    });
+
+    const result = buildDashboard({
+      accounts: [usd],
+      recurringItems: [transfer],
+      today: "2026-03-01",
+      forecastMonths: 1,
+    });
+
+    expect(result.totalBalance).toBe(150000);
+    expect(result.minBalance).toBe(75000);
+    expect(result.forecast).toEqual([
+      expect.objectContaining({
+        id: "recurring:usd-source-only-transfer:2026-03",
+        type: "transfer",
+        amount: 50000,
+        amountJpy: 75000,
+        balance: 75000,
+        currencyCode: "USD",
+        accountId: usd.id,
+        transferToAccountId: null,
+      }),
+    ]);
+    expect(result.accountForecasts).toEqual([
+      expect.objectContaining({
+        accountId: usd.id,
+        currentBalance: 100000,
+        currentBalanceJpy: 150000,
+        minBalance: 50000,
+        minBalanceJpy: 75000,
+        events: [
+          expect.objectContaining({
+            id: "recurring:usd-source-only-transfer:2026-03",
+            amount: 50000,
+            amountJpy: 75000,
+            balance: 50000,
+            balanceJpy: 75000,
+            currencyCode: "USD",
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("handles USD transfer destination-only as external inflow in raw currency and JPY", () => {
+    const usd = account({
+      id: "usd",
+      name: "USD",
+      balance: 100000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 1,
+    });
+    const transfer = recurringItem({
+      id: "usd-destination-only-transfer",
+      name: "External In",
+      type: "transfer" as RecurringItemType,
+      amount: 50000,
+      dayOfMonth: 10,
+      account: null,
+      accountId: null,
+      transferToAccount: usd,
+      transferToAccountId: usd.id,
+    });
+
+    const result = buildDashboard({
+      accounts: [usd],
+      recurringItems: [transfer],
+      today: "2026-03-01",
+      forecastMonths: 1,
+    });
+
+    expect(result.totalBalance).toBe(150000);
+    expect(result.minBalance).toBe(150000);
+    expect(result.forecast).toEqual([
+      expect.objectContaining({
+        id: "recurring:usd-destination-only-transfer:2026-03",
+        type: "transfer",
+        amount: 50000,
+        amountJpy: 75000,
+        balance: 225000,
+        currencyCode: "USD",
+        accountId: null,
+        transferToAccountId: usd.id,
+      }),
+    ]);
+    expect(result.accountForecasts).toEqual([
+      expect.objectContaining({
+        accountId: usd.id,
+        currentBalance: 100000,
+        currentBalanceJpy: 150000,
+        minBalance: 100000,
+        minBalanceJpy: 150000,
+        events: [
+          expect.objectContaining({
+            id: "recurring:usd-destination-only-transfer:2026-03",
+            amount: 50000,
+            amountJpy: 75000,
+            balance: 150000,
+            balanceJpy: 225000,
+            currencyCode: "USD",
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("handles USD two-sided transfer as neutral total and currency-matched account balances", () => {
+    const usdSource = account({
+      id: "usd-source",
+      name: "USD Source",
+      balance: 100000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 1,
+    });
+    const usdDestination = account({
+      id: "usd-destination",
+      name: "USD Destination",
+      balance: 50000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 2,
+    });
+    const transfer = recurringItem({
+      id: "usd-two-sided-transfer",
+      name: "USD Move",
+      type: "transfer" as RecurringItemType,
+      amount: 30000,
+      dayOfMonth: 10,
+      account: usdSource,
+      accountId: usdSource.id,
+      transferToAccount: usdDestination,
+      transferToAccountId: usdDestination.id,
+    });
+
+    const result = buildDashboard({
+      accounts: [usdSource, usdDestination],
+      recurringItems: [transfer],
+      today: "2026-03-01",
+      forecastMonths: 1,
+    });
+
+    expect(result.totalBalance).toBe(225000);
+    expect(result.minBalance).toBe(225000);
+    expect(result.forecast).toEqual([
+      expect.objectContaining({
+        id: "recurring:usd-two-sided-transfer:2026-03",
+        type: "transfer",
+        amount: 30000,
+        amountJpy: 45000,
+        balance: 225000,
+        currencyCode: "USD",
+        accountId: usdSource.id,
+        transferToAccountId: usdDestination.id,
+      }),
+    ]);
+    expect(result.accountForecasts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: usdSource.id,
+          currentBalance: 100000,
+          currentBalanceJpy: 150000,
+          minBalance: 70000,
+          minBalanceJpy: 105000,
+          events: [
+            expect.objectContaining({
+              id: "recurring:usd-two-sided-transfer:2026-03",
+              amount: 30000,
+              amountJpy: 45000,
+              balance: 70000,
+              balanceJpy: 105000,
+              currencyCode: "USD",
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          accountId: usdDestination.id,
+          currentBalance: 50000,
+          currentBalanceJpy: 75000,
+          minBalance: 50000,
+          minBalanceJpy: 75000,
+          events: [
+            expect.objectContaining({
+              id: "recurring:usd-two-sided-transfer:2026-03",
+              amount: 30000,
+              amountJpy: 45000,
+              balance: 80000,
+              balanceJpy: 120000,
+              currencyCode: "USD",
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("handles USD normal recurring expense with amount and amountJpy separated", () => {
+    const usd = account({
+      id: "usd",
+      name: "USD",
+      balance: 100000,
+      currencyCode: "USD",
+      exchangeRateToJpy: 150,
+      sortOrder: 1,
+    });
+    const expense = recurringItem({
+      id: "usd-normal-expense",
+      name: "USD Rent",
+      amount: 25000,
+      dayOfMonth: 10,
+      account: usd,
+      accountId: usd.id,
+    });
+
+    const result = buildDashboard({
+      accounts: [usd],
+      recurringItems: [expense],
+      today: "2026-03-01",
+      forecastMonths: 1,
+    });
+
+    expect(result.totalBalance).toBe(150000);
+    expect(result.minBalance).toBe(112500);
+    expect(result.forecast).toEqual([
+      expect.objectContaining({
+        id: "recurring:usd-normal-expense:2026-03",
+        amount: 25000,
+        amountJpy: 37500,
+        balance: 112500,
+        balanceJpy: 112500,
+        currencyCode: "USD",
+      }),
+    ]);
+    expect(result.accountForecasts).toEqual([
+      expect.objectContaining({
+        accountId: usd.id,
+        currentBalance: 100000,
+        currentBalanceJpy: 150000,
+        minBalance: 75000,
+        minBalanceJpy: 112500,
+        events: [
+          expect.objectContaining({
+            id: "recurring:usd-normal-expense:2026-03",
+            amount: 25000,
+            amountJpy: 37500,
+            balance: 75000,
+            balanceJpy: 112500,
+            currencyCode: "USD",
+          }),
+        ],
+      }),
+    ]);
+  });
 });

--- a/packages/frontend/src/routes/recurring.test.ts
+++ b/packages/frontend/src/routes/recurring.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { formatCurrency } from "../lib/format";
+import { getRecurringFormCurrencyCode, getRecurringItemCurrencyCode } from "./recurring";
+
+const accounts = [
+  {
+    id: "jpy-account",
+    name: "JPY Main",
+    balance: 100000,
+    balanceOffset: 0,
+    lastReconciledAt: null,
+    currencyCode: "JPY" as const,
+    exchangeRateToJpy: 1,
+    exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+    sortOrder: 0,
+    deletedAt: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+  },
+  {
+    id: "usd-account",
+    name: "USD Wallet",
+    balance: 100000,
+    balanceOffset: 0,
+    lastReconciledAt: null,
+    currencyCode: "USD" as const,
+    exchangeRateToJpy: 150,
+    exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+    sortOrder: 1,
+    deletedAt: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+  },
+  {
+    id: "eur-account",
+    name: "EUR Wallet",
+    balance: 50000,
+    balanceOffset: 0,
+    lastReconciledAt: null,
+    currencyCode: "EUR" as const,
+    exchangeRateToJpy: 160,
+    exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+    sortOrder: 2,
+    deletedAt: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+  },
+];
+
+function accountStub(overrides: Partial<(typeof accounts)[number]>) {
+  const base = accounts.find((a) => a.id === overrides.id) ?? accounts[0];
+  return { ...base, ...overrides };
+}
+
+function recurringItemStub(overrides: Partial<{
+  id: string;
+  name: string;
+  type: "income" | "expense" | "transfer";
+  amount: number;
+  account: typeof accounts[number] | null;
+  transferToAccount: typeof accounts[number] | null;
+}>) {
+  return {
+    id: "recurring-1",
+    name: "Recurring",
+    type: "expense" as const,
+    amount: 1000,
+    recurrence: "monthly" as const,
+    dayOfMonth: 1,
+    dayOfWeek: null,
+    startDate: null,
+    endDate: null,
+    dateShiftPolicy: "none" as const,
+    enabled: true,
+    sortOrder: 0,
+    deletedAt: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    accountId: overrides.account?.id ?? null,
+    account: overrides.account ?? null,
+    transferToAccountId: overrides.transferToAccount?.id ?? null,
+    transferToAccount: overrides.transferToAccount ?? null,
+    ...overrides,
+  };
+}
+
+describe("getRecurringItemCurrencyCode", () => {
+  it("通常収支は account の通貨を使う", () => {
+    const item = recurringItemStub({ type: "expense", account: accountStub({ id: "usd-account" }) });
+    expect(getRecurringItemCurrencyCode(item)).toBe("USD");
+  });
+
+  it("振替は送金元口座の通貨を優先する", () => {
+    const item = recurringItemStub({
+      type: "transfer",
+      account: accountStub({ id: "usd-account" }),
+      transferToAccount: accountStub({ id: "eur-account" }),
+    });
+    expect(getRecurringItemCurrencyCode(item)).toBe("USD");
+  });
+
+  it("送金元のみの振替は送金元口座の通貨", () => {
+    const item = recurringItemStub({
+      type: "transfer",
+      account: accountStub({ id: "usd-account" }),
+      transferToAccount: null,
+    });
+    expect(getRecurringItemCurrencyCode(item)).toBe("USD");
+  });
+
+  it("送金先のみの振替は振替先口座の通貨", () => {
+    const item = recurringItemStub({
+      type: "transfer",
+      account: null,
+      transferToAccount: accountStub({ id: "eur-account" }),
+    });
+    expect(getRecurringItemCurrencyCode(item)).toBe("EUR");
+  });
+
+  it("口座なしのデータは JPY fallback", () => {
+    const item = recurringItemStub({ type: "expense", account: null });
+    expect(getRecurringItemCurrencyCode(item)).toBe("JPY");
+  });
+});
+
+describe("getRecurringFormCurrencyCode", () => {
+  it("通常収支は選択 accountId の通貨", () => {
+    const form = { type: "expense" as const, accountId: "usd-account", transferToAccountId: "" };
+    expect(getRecurringFormCurrencyCode(form, accounts)).toBe("USD");
+  });
+
+  it("振替は送金元口座の通貨を優先する", () => {
+    const form = { type: "transfer" as const, accountId: "usd-account", transferToAccountId: "eur-account" };
+    expect(getRecurringFormCurrencyCode(form, accounts)).toBe("USD");
+  });
+
+  it("送金元なしの振替は振替先口座の通貨", () => {
+    const form = { type: "transfer" as const, accountId: "", transferToAccountId: "eur-account" };
+    expect(getRecurringFormCurrencyCode(form, accounts)).toBe("EUR");
+  });
+
+  it("両方なしの初期状態は JPY fallback", () => {
+    const form = { type: "transfer" as const, accountId: "", transferToAccountId: "" };
+    expect(getRecurringFormCurrencyCode(form, accounts)).toBe("JPY");
+  });
+});
+
+describe("固定収支一覧の金額表示", () => {
+  it("USD 通常固定収支は $ 表示", () => {
+    const item = recurringItemStub({
+      type: "expense",
+      amount: 100000,
+      account: accountStub({ id: "usd-account" }),
+    });
+    expect(formatCurrency(item.amount, getRecurringItemCurrencyCode(item))).toBe("$1,000.00");
+  });
+
+  it("JPY 通常固定収支は ¥ 表示", () => {
+    const item = recurringItemStub({
+      type: "income",
+      amount: 100000,
+      account: accountStub({ id: "jpy-account" }),
+    });
+    expect(formatCurrency(item.amount, getRecurringItemCurrencyCode(item))).toMatch(/[¥￥]100,000/);
+  });
+});

--- a/packages/frontend/src/routes/recurring.tsx
+++ b/packages/frontend/src/routes/recurring.tsx
@@ -1,4 +1,5 @@
-import type { Account, DateShiftPolicy, Recurrence, RecurringItem, RecurringItemType } from "@sui/shared";
+import { DEFAULT_CURRENCY_CODE } from "@sui/shared";
+import type { Account, DateShiftPolicy, Recurrence, RecurringItem, RecurringItemType, SupportedCurrencyCode } from "@sui/shared";
 import { useEffect, useId, useRef, useState, startTransition } from "react";
 import { AccountSelect, DateShiftField, DayOfMonthField, DayOfWeekField, PeriodFields } from "../components/form-fields";
 import { Button, IconButton } from "../components/ui/button";
@@ -18,7 +19,7 @@ import { apiFetch } from "../lib/api";
 import { formatCurrency, formatDateWithYear, formatDayOfWeek } from "../lib/format";
 import { Pencil, Trash2 } from "lucide-react";
 
-type RecurringForm = {
+export type RecurringForm = {
   name: string;
   type: RecurringItemType;
   amount: number;
@@ -211,6 +212,32 @@ function formatRecurringAccounts(item: RecurringItem) {
   return `${sourceName} → ${item.transferToAccount?.name ?? "未設定"}`;
 }
 
+export function getRecurringItemCurrencyCode(item: RecurringItem): SupportedCurrencyCode {
+  if (item.type === "transfer") {
+    return item.account?.currencyCode ?? item.transferToAccount?.currencyCode ?? DEFAULT_CURRENCY_CODE;
+  }
+
+  return item.account?.currencyCode ?? DEFAULT_CURRENCY_CODE;
+}
+
+export function getRecurringFormCurrencyCode(
+  form: Pick<RecurringForm, "type" | "accountId" | "transferToAccountId">,
+  accounts: Account[],
+): SupportedCurrencyCode {
+  if (form.type === "transfer") {
+    const sourceAccount = accounts.find((account) => account.id === form.accountId);
+    if (sourceAccount) {
+      return sourceAccount.currencyCode;
+    }
+
+    const destinationAccount = accounts.find((account) => account.id === form.transferToAccountId);
+    return destinationAccount?.currencyCode ?? DEFAULT_CURRENCY_CODE;
+  }
+
+  const account = accounts.find((account) => account.id === form.accountId);
+  return account?.currencyCode ?? DEFAULT_CURRENCY_CODE;
+}
+
 function describeError(error: unknown) {
   return error instanceof Error ? error.message : "不明なエラーが発生しました。";
 }
@@ -324,7 +351,7 @@ export function RecurringPage() {
   const columns: ResponsiveTableColumn<RecurringItem>[] = [
     { key: "name", header: "カテゴリ", render: (item) => item.name },
     { key: "type", header: "種別", render: (item) => getRecurringTypeLabel(item.type) },
-    { key: "amount", header: "金額", align: "right", mono: true, render: (item) => formatCurrency(item.amount) },
+    { key: "amount", header: "金額", align: "right", mono: true, render: (item) => formatCurrency(item.amount, getRecurringItemCurrencyCode(item)) },
     { key: "schedule", header: "周期", render: (item) => formatRecurringSchedule(item) },
     { key: "period", header: "期間", render: (item) => formatPeriod(item.startDate, item.endDate) },
     { key: "account", header: "対象口座", render: (item) => formatRecurringAccounts(item) },
@@ -379,7 +406,7 @@ export function RecurringPage() {
                     <div className="truncate font-medium">{item.name}</div>
                     <div className="text-xs text-ink-3">{getRecurringTypeLabel(item.type)}・{formatRecurringSchedule(item)}</div>
                   </div>
-                  <div className="font-data text-base font-semibold">{formatCurrency(item.amount)}</div>
+                  <div className="font-data text-base font-semibold">{formatCurrency(item.amount, getRecurringItemCurrencyCode(item))}</div>
                 </div>
                 <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
                   <span>{formatRecurringAccounts(item)}・{item.enabled ? "有効" : "無効"}</span>
@@ -458,6 +485,7 @@ function RecurringEditModal({
   actionLabel?: string;
 }) {
   const transferDestinationAccounts = getTransferDestinationAccounts(accounts, form.accountId);
+  const currencyCode = getRecurringFormCurrencyCode(form, accounts);
   const nameId = useId();
   const amountId = useId();
   const dateShiftId = useId();
@@ -495,8 +523,8 @@ function RecurringEditModal({
         />
       </FormField>
 
-      <FormField label="金額 (円)" htmlFor={amountId} required>
-        <MoneyInput id={amountId} currencyCode="JPY" value={form.amount} onChange={(value) => onChange({ ...form, amount: value })} />
+      <FormField label={`金額 (${currencyCode})`} htmlFor={amountId} required>
+        <MoneyInput id={amountId} currencyCode={currencyCode} value={form.amount} onChange={(value) => onChange({ ...form, amount: value })} />
       </FormField>
 
       <FormField label="周期" htmlFor="recurring-recurrence">

--- a/packages/mcp/src/__tests__/format.test.ts
+++ b/packages/mcp/src/__tests__/format.test.ts
@@ -17,6 +17,7 @@ import {
   formatRecurringItemsText,
   formatSubscriptionsText,
   formatTransactionsText,
+  getRecurringCurrencyCode,
 } from "../format";
 import { describe, expect, it } from "vitest";
 
@@ -200,6 +201,71 @@ describe("formatters", () => {
     expect(subscriptionText).toContain("毎週 日曜日");
     expect(recurringText).not.toMatch(rawJsonKeyPattern);
     expect(subscriptionText).not.toMatch(rawJsonKeyPattern);
+  });
+
+  it("formats recurring items in the currency of the source or destination account", () => {
+    const usdAccount = {
+      id: "account-usd",
+      name: "USD Wallet",
+      balance: 12345,
+      balanceOffset: 0,
+      lastReconciledAt: null,
+      currencyCode: "USD" as const,
+      exchangeRateToJpy: 150,
+      exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+      sortOrder: 1,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    };
+    const usdSourceOnly = {
+      id: "recurring-usd-out",
+      name: "USD External Out",
+      type: "transfer",
+      amount: 123456,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      dateShiftPolicy: "none",
+      accountId: usdAccount.id,
+      account: usdAccount,
+      transferToAccountId: null,
+      transferToAccount: null,
+      enabled: true,
+      sortOrder: 1,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    } as const;
+    const usdDestinationOnly = {
+      id: "recurring-usd-in",
+      name: "USD External In",
+      type: "transfer",
+      amount: 123456,
+      dayOfMonth: 10,
+      startDate: null,
+      endDate: null,
+      dateShiftPolicy: "none",
+      accountId: null,
+      account: null,
+      transferToAccountId: usdAccount.id,
+      transferToAccount: usdAccount,
+      enabled: true,
+      sortOrder: 1,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    } as const;
+
+    const sourceText = formatRecurringItemsText([usdSourceOnly] as RecurringItemsResponse);
+    const destinationText = formatRecurringItemsText([usdDestinationOnly] as RecurringItemsResponse);
+
+    expect(sourceText).toContain("$1,234.56");
+    expect(destinationText).toContain("$1,234.56");
+    expect(getRecurringCurrencyCode(usdSourceOnly as RecurringItemsResponse[number])).toBe("USD");
+    expect(getRecurringCurrencyCode(usdDestinationOnly as RecurringItemsResponse[number])).toBe("USD");
+    expect(sourceText).not.toMatch(rawJsonKeyPattern);
+    expect(destinationText).not.toMatch(rawJsonKeyPattern);
   });
 
   it("formats list-style API responses without raw JSON", () => {

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -1690,6 +1690,96 @@ describe("MCP server", () => {
     });
   });
 
+  it("lists recurring items in the account currency", async () => {
+    addRoute("GET", "/api/recurring-items", {
+      body: [{
+        id: "recurring-usd-1",
+        name: "USD Rent",
+        type: "expense",
+        amount: 123456,
+        dayOfMonth: 10,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "none",
+        accountId: "account-usd",
+        account: {
+          id: "account-usd",
+          name: "USD Wallet",
+          balance: 12345,
+          balanceOffset: 0,
+          lastReconciledAt: null,
+          currencyCode: "USD",
+          exchangeRateToJpy: 150,
+          exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+          sortOrder: 1,
+          deletedAt: null,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+        transferToAccountId: null,
+        transferToAccount: null,
+        enabled: true,
+        sortOrder: 1,
+        deletedAt: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }],
+    });
+
+    const result = await client.callTool({ name: "list_recurring_items", arguments: {} });
+
+    expect(getToolText(result)).toContain("USD Rent");
+    expect(getToolText(result)).toContain("$1,234.56");
+  });
+
+  it("shows delete preview for USD recurring items in the account currency", async () => {
+    addRoute("GET", "/api/recurring-items", {
+      body: [{
+        id: "99999999-9999-4999-8999-999999999999",
+        name: "USD External Out",
+        type: "transfer",
+        amount: 123456,
+        dayOfMonth: 10,
+        startDate: null,
+        endDate: null,
+        dateShiftPolicy: "none",
+        accountId: "account-usd",
+        account: {
+          id: "account-usd",
+          name: "USD Wallet",
+          balance: 12345,
+          balanceOffset: 0,
+          lastReconciledAt: null,
+          currencyCode: "USD",
+          exchangeRateToJpy: 150,
+          exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+          sortOrder: 1,
+          deletedAt: null,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+        transferToAccountId: null,
+        transferToAccount: null,
+        enabled: true,
+        sortOrder: 1,
+        deletedAt: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }],
+    });
+    addRoute("DELETE", "/api/recurring-items/99999999-9999-4999-8999-999999999999", {
+      status: 204,
+    });
+
+    const result = await client.callTool({
+      name: "delete_recurring_item",
+      arguments: { id: "99999999-9999-4999-8999-999999999999" },
+    });
+
+    expect(getToolText(result)).toContain("USD External Out");
+    expect(getToolText(result)).toContain("$1,234.56");
+  });
+
   it("formats transfer forecast labels in dashboard tools", async () => {
     const transferEvent = {
       id: "transfer-event",
@@ -1839,6 +1929,57 @@ describe("MCP server", () => {
       overdueCount: 0,
       events: [],
     });
+  });
+
+  it("confirms a USD forecast event and formats minor unit to major with JPY equivalent", async () => {
+    addRoute("POST", "/api/dashboard/confirm", {
+      status: 201,
+      body: {
+        id: "tx-usd-1",
+        description: "USD Rent",
+        amount: 25000,
+        amountJpy: 37500,
+        currencyCode: "USD",
+      },
+    });
+
+    const result = await client.callTool({
+      name: "confirm_forecast",
+      arguments: {
+        forecastEventId: "recurring:usd-rent:2026-03",
+        amount: 25000,
+      },
+    });
+
+    const text = getToolText(result);
+    expect(text).toContain("USD Rent");
+    expect(text).toContain("250.00");
+    expect(text).toContain("37,500");
+  });
+
+  it("confirms a JPY forecast event and preserves integer formatting", async () => {
+    addRoute("POST", "/api/dashboard/confirm", {
+      status: 201,
+      body: {
+        id: "tx-jpy-1",
+        description: "Salary",
+        amount: 10000,
+        amountJpy: 10000,
+        currencyCode: "JPY",
+      },
+    });
+
+    const result = await client.callTool({
+      name: "confirm_forecast",
+      arguments: {
+        forecastEventId: "recurring:salary:2026-03",
+        amount: 10000,
+      },
+    });
+
+    const text = getToolText(result);
+    expect(text).toContain("Salary");
+    expect(text).toContain("10,000");
   });
 
   it("forwards transaction list filters to the REST API", async () => {

--- a/packages/mcp/src/format.ts
+++ b/packages/mcp/src/format.ts
@@ -13,7 +13,7 @@ import type {
   Transaction,
   TransactionsResponse,
 } from "@sui/shared";
-import { DEFAULT_SETTINGS } from "@sui/shared";
+import { DEFAULT_CURRENCY_CODE, DEFAULT_SETTINGS, getCurrencyMinorUnits, toMajorCurrencyUnit } from "@sui/shared";
 
 const currencyFormatter = new Intl.NumberFormat("ja-JP", {
   style: "currency",
@@ -27,20 +27,25 @@ const SUBSCRIPTION_FORECAST_NOTE =
 const MANUAL_CONFIRM_NOTE =
   "予定日超過イベントも自動確定しません。実際の金額と口座を確認してから confirm_forecast で手動確定してください。";
 
-function formatCurrency(amount: number | null | undefined, currencyCode?: SupportedCurrencyCode | null) {
+export function formatCurrency(amount: number | null | undefined, currencyCode?: SupportedCurrencyCode | null) {
   if (typeof amount !== "number") {
     return "未設定";
   }
 
-  if (!currencyCode || currencyCode === "JPY") {
-    return currencyFormatter.format(amount);
+  const code = currencyCode ?? "JPY";
+  const major = toMajorCurrencyUnit(amount, code);
+
+  if (code === "JPY") {
+    return currencyFormatter.format(major);
   }
 
+  const minorUnits = getCurrencyMinorUnits(code);
   return new Intl.NumberFormat("ja-JP", {
     style: "currency",
-    currency: currencyCode,
-    maximumFractionDigits: 2,
-  }).format(amount);
+    currency: code,
+    minimumFractionDigits: minorUnits,
+    maximumFractionDigits: minorUnits,
+  }).format(major);
 }
 
 function formatForecastEventType(type: "income" | "expense" | "transfer") {
@@ -127,7 +132,7 @@ function formatAccountForecast(item: AccountForecast) {
     : item.warningLevel === "yellow"
       ? " ⚠️ 可処分残高不足"
       : "";
-  return `  ${item.accountName}: ${formatCurrency(item.currentBalance)} -> 最小 ${formatCurrency(item.minBalance)}（${item.minBalanceDate}）${warning}`;
+  return `  ${item.accountName}: ${formatCurrency(item.currentBalance, item.currencyCode)} -> 最小 ${formatCurrency(item.minBalance, item.currencyCode)}（${item.minBalanceDate}）${warning}`;
 }
 
 export function formatJson(data: unknown) {
@@ -150,12 +155,12 @@ export function formatDashboardText(data: DashboardResponse, today: string) {
 
   if (data.nextIncome) {
     lines.push(
-      `直近の収入: ${data.nextIncome.description} ${formatCurrency(data.nextIncome.amount)}（${data.nextIncome.date}）[id: ${data.nextIncome.id}]`,
+      `直近の収入: ${data.nextIncome.description} ${formatCurrency(data.nextIncome.amount, data.nextIncome.currencyCode)}（${data.nextIncome.date}）[id: ${data.nextIncome.id}]`,
     );
   }
   if (data.nextExpense) {
     lines.push(
-      `直近の支出: ${data.nextExpense.description} ${formatCurrency(data.nextExpense.amount)}（${data.nextExpense.date}）[id: ${data.nextExpense.id}]`,
+      `直近の支出: ${data.nextExpense.description} ${formatCurrency(data.nextExpense.amount, data.nextExpense.currencyCode)}（${data.nextExpense.date}）[id: ${data.nextExpense.id}]`,
     );
   }
 
@@ -169,7 +174,7 @@ export function formatDashboardText(data: DashboardResponse, today: string) {
     for (const event of overdueForecast) {
       const typeLabel = formatForecastEventType(event.type);
       lines.push(
-        `  [${event.id}] ${event.date} ${typeLabel}: ${event.description} ${formatCurrency(event.amount)}`,
+        `  [${event.id}] ${event.date} ${typeLabel}: ${event.description} ${formatCurrency(event.amount, event.currencyCode)}`,
       );
     }
   } else {
@@ -182,7 +187,7 @@ export function formatDashboardText(data: DashboardResponse, today: string) {
     for (const event of todayEvents) {
       const typeLabel = formatForecastEventType(event.type);
       lines.push(
-        `  [${event.id}] ${typeLabel}: ${event.description} ${formatCurrency(event.amount)}`,
+        `  [${event.id}] ${typeLabel}: ${event.description} ${formatCurrency(event.amount, event.currencyCode)}`,
       );
     }
   } else {
@@ -245,14 +250,14 @@ export function formatForecastSummary(data: DashboardResponse, forecastMonths?: 
 
   lines.push("", "【直近のイベント】");
   if (data.nextIncome) {
-    lines.push(`  収入: ${data.nextIncome.description} ${formatCurrency(data.nextIncome.amount)}（${data.nextIncome.date}）`);
+    lines.push(`  収入: ${data.nextIncome.description} ${formatCurrency(data.nextIncome.amount, data.nextIncome.currencyCode)}（${data.nextIncome.date}）`);
   }
   if (data.nextExpense) {
-    lines.push(`  支出: ${data.nextExpense.description} ${formatCurrency(data.nextExpense.amount)}（${data.nextExpense.date}）`);
+    lines.push(`  支出: ${data.nextExpense.description} ${formatCurrency(data.nextExpense.amount, data.nextExpense.currencyCode)}（${data.nextExpense.date}）`);
   }
   const nextTransfer = data.forecast.find((event) => event.type === "transfer");
   if (nextTransfer) {
-    lines.push(`  振替: ${nextTransfer.description} ${formatCurrency(nextTransfer.amount)}（${nextTransfer.date}）`);
+    lines.push(`  振替: ${nextTransfer.description} ${formatCurrency(nextTransfer.amount, nextTransfer.currencyCode)}（${nextTransfer.date}）`);
   }
   if (!data.nextIncome && !data.nextExpense && !nextTransfer) {
     lines.push("  直近のイベントはありません");
@@ -329,6 +334,18 @@ export function formatAccountsText(accounts: AccountsResponse) {
   ].join("\n");
 }
 
+export function getRecurringCurrencyCode(item: RecurringItemsResponse[number]): SupportedCurrencyCode {
+  if (item.type === "transfer") {
+    return item.account?.currencyCode ?? item.transferToAccount?.currencyCode ?? DEFAULT_CURRENCY_CODE;
+  }
+
+  return item.account?.currencyCode ?? DEFAULT_CURRENCY_CODE;
+}
+
+export function formatRecurringItemAmount(item: RecurringItemsResponse[number]) {
+  return formatCurrency(item.amount, getRecurringCurrencyCode(item));
+}
+
 export function formatRecurringItemsText(items: RecurringItemsResponse) {
   if (items.length === 0) {
     return formatEmptyList("固定収支一覧");
@@ -340,7 +357,7 @@ export function formatRecurringItemsText(items: RecurringItemsResponse) {
       const transfer = item.type === "transfer"
         ? formatTransferSuffix(item.transferToAccount, item.transferToAccountId)
         : "";
-      return `  ${item.name}: ${formatForecastEventType(item.type)} ${formatCurrency(item.amount)} / ${formatRecurringSchedule(item)} / ${formatEnabled(item.enabled)} / 口座 ${formatAccountName(item.account, item.accountId)}${transfer} / 期間 ${item.startDate ?? "指定なし"}〜${item.endDate ?? "継続"} / 日付調整 ${formatDateShiftPolicy(item.dateShiftPolicy)}`;
+      return `  ${item.name}: ${formatForecastEventType(item.type)} ${formatRecurringItemAmount(item)} / ${formatRecurringSchedule(item)} / ${formatEnabled(item.enabled)} / 口座 ${formatAccountName(item.account, item.accountId)}${transfer} / 期間 ${item.startDate ?? "指定なし"}〜${item.endDate ?? "継続"} / 日付調整 ${formatDateShiftPolicy(item.dateShiftPolicy)}`;
     }),
   ].join("\n");
 }
@@ -353,7 +370,7 @@ export function formatCreditCardsText(cards: CreditCardsResponse) {
   return [
     `クレジットカード一覧: ${cards.length}件`,
     ...cards.map((card) =>
-      `  ${card.name}: 引落日 ${card.settlementDay ?? "未設定"} / 仮定請求額 ${formatCurrency(card.assumptionAmount)} / 引落口座 ${formatAccountName(card.account, card.accountId)} / 日付調整 ${formatDateShiftPolicy(card.dateShiftPolicy)}`
+      `  ${card.name}: 引落日 ${card.settlementDay ?? "未設定"} / 仮定請求額 ${formatCurrency(card.assumptionAmount, card.account?.currencyCode)} / 引落口座 ${formatAccountName(card.account, card.accountId)} / 日付調整 ${formatDateShiftPolicy(card.dateShiftPolicy)}`
     ),
   ].join("\n");
 }
@@ -384,7 +401,7 @@ export function formatLoansText(loans: LoansResponse) {
   return [
     `ローン一覧: ${loans.length}件`,
     ...loans.map((loan) =>
-      `  ${loan.name}: 総額 ${formatCurrency(loan.totalAmount)} / 残高 ${formatCurrency(loan.remainingBalance)} / 次回 ${formatCurrency(loan.nextPaymentAmount)} / 残 ${loan.remainingPayments}/${loan.paymentCount}回 / 開始 ${loan.startDate} / 支払 ${loan.paymentMethod} / 口座 ${formatAccountName(loan.account, loan.accountId)} / 日付調整 ${formatDateShiftPolicy(loan.dateShiftPolicy)}`
+      `  ${loan.name}: 総額 ${formatCurrency(loan.totalAmount, loan.account?.currencyCode)} / 残高 ${formatCurrency(loan.remainingBalance, loan.account?.currencyCode)} / 次回 ${formatCurrency(loan.nextPaymentAmount, loan.account?.currencyCode)} / 残 ${loan.remainingPayments}/${loan.paymentCount}回 / 開始 ${loan.startDate} / 支払 ${loan.paymentMethod} / 口座 ${formatAccountName(loan.account, loan.accountId)} / 日付調整 ${formatDateShiftPolicy(loan.dateShiftPolicy)}`
     ),
   ].join("\n");
 }
@@ -449,7 +466,7 @@ export function formatBalanceHistory(data: BalanceHistoryResponse) {
   }
 
   const lines = data.points.map((point) =>
-    `${point.date}: ${formatCurrency(point.balance)}  ${point.description}`,
+    `${point.date}: ${formatCurrency(point.balance, point.currencyCode)}  ${point.description}`,
   );
   const first = data.points[0];
   const last = data.points[data.points.length - 1];
@@ -458,7 +475,7 @@ export function formatBalanceHistory(data: BalanceHistoryResponse) {
 
   return [
     `残高推移 (${first.date} 〜 ${last.date})`,
-    `期間中の変動: ${sign}${formatCurrency(diff)}`,
+    `期間中の変動: ${sign}${formatCurrency(diff, last.currencyCode)}`,
     "",
     ...lines,
   ].join("\n");

--- a/packages/mcp/src/tools/dashboard.ts
+++ b/packages/mcp/src/tools/dashboard.ts
@@ -7,10 +7,11 @@ import type {
   DashboardResponse,
   DashboardSimulationPayload,
   DashboardSimulationResponse,
+  SupportedCurrencyCode,
   Transaction,
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
-import { formatDashboardText } from "../format";
+import { formatCurrency, formatDashboardText } from "../format";
 import {
   booleanFlagSchema,
   dateSchema,
@@ -109,14 +110,25 @@ function formatSignedJpy(amount: number) {
 }
 
 function formatReviewAmount(event: z.infer<typeof reviewOverdueEventSchema>) {
-  const amount = event.amount.toLocaleString("ja-JP");
-  const amountJpy = event.amountJpy.toLocaleString("ja-JP");
+  const amount = formatCurrency(event.amount, event.currencyCode);
+  const amountJpy = formatCurrency(event.amountJpy, "JPY");
 
   if (event.currencyCode === "JPY") {
-    return `¥${amount}`;
+    return amount;
   }
 
-  return `${event.currencyCode} ${amount}（¥${amountJpy}）`;
+  return `${amount}（${amountJpy}）`;
+}
+
+function formatConfirmedAmount(amount: number, amountJpy: number, currencyCode: SupportedCurrencyCode) {
+  const formatted = formatCurrency(amount, currencyCode);
+  const formattedJpy = formatCurrency(amountJpy, "JPY");
+
+  if (currencyCode === "JPY") {
+    return formatted;
+  }
+
+  return `${formatted}（${formattedJpy}）`;
 }
 
 function formatReviewEventType(type: z.infer<typeof reviewOverdueEventSchema>["type"]) {
@@ -400,13 +412,13 @@ export function registerDashboardTools(server: McpServer, apiClient: SuiApiClien
     "実際の金額と口座を人間が確認した予測イベントを、手動で実取引として確定する。予定額と実績額は一致しないことがあるため、自動確定目的では使わない",
     {
       forecastEventId: z.string().min(1).describe("手動確認済みの予測イベント ID"),
-      amount: positiveMoneySchema.describe("実績確認後の確定金額（円単位）"),
+      amount: positiveMoneySchema.describe("実績確認後の確定金額（選択口座通貨建て）"),
       accountId: uuidSchema.optional().describe("実績確認後の口座 ID（イベント設定口座から変更する場合のみ指定）"),
     },
     updateToolAnnotations,
     async (args) => {
       const result = await apiClient.post<Transaction>("/api/dashboard/confirm", args as ConfirmForecastPayload);
-      return textContent(`手動確認済みの予測を確定しました: ${result.description} ¥${result.amount.toLocaleString("ja-JP")}`);
+      return textContent(`手動確認済みの予測を確定しました: ${result.description} ${formatConfirmedAmount(result.amount, result.amountJpy, result.currencyCode)}`);
     },
   );
 }

--- a/packages/mcp/src/tools/recurring-items.ts
+++ b/packages/mcp/src/tools/recurring-items.ts
@@ -6,7 +6,7 @@ import type {
   UpdateRecurringItemPayload,
 } from "@sui/shared";
 import type { SuiApiClient } from "../api-client";
-import { formatRecurringItemsText, formatRecurringSchedule } from "../format";
+import { formatRecurringItemAmount, formatRecurringItemsText, formatRecurringSchedule } from "../format";
 import {
   confirmDeleteSchema,
   createToolAnnotations,
@@ -25,7 +25,7 @@ import { z } from "zod";
 const recurringPayload = {
   name: z.string().min(1).max(100).describe("固定収支名"),
   type: z.enum(["income", "expense", "transfer"]).describe("種別。transfer は定期振替"),
-  amount: nonNegativeMoneySchema.describe("金額"),
+  amount: nonNegativeMoneySchema.describe("金額（選択口座通貨建て）"),
   recurrence: z.enum(["monthly", "weekly"]).optional().describe("繰り返し種別。monthly または weekly。省略時は monthly"),
   dayOfMonth: z.number().int().min(1).max(31).nullable().optional().describe("毎月の対象日（1-31）。monthly の場合のみ指定（weekly では null または未指定）"),
   dayOfWeek: z.number().int().min(0).max(6).nullable().optional().describe("曜日（0=日曜、6=土曜）。weekly の場合のみ指定（monthly では null または未指定）"),
@@ -51,7 +51,7 @@ export function registerRecurringItemTools(server: McpServer, apiClient: SuiApiC
     createToolAnnotations,
     async (args) => {
       const item = await apiClient.post<RecurringItem>("/api/recurring-items", args as CreateRecurringItemPayload);
-      return textContent(`固定収支を作成しました: ${item.name} ¥${item.amount.toLocaleString("ja-JP")}`);
+      return textContent(`固定収支を作成しました: ${item.name} ${formatRecurringItemAmount(item)}`);
     },
   );
 
@@ -68,7 +68,7 @@ export function registerRecurringItemTools(server: McpServer, apiClient: SuiApiC
         `/api/recurring-items/${id}`,
         payload as UpdateRecurringItemPayload,
       );
-      return textContent(`固定収支を更新しました: ${item.name} ¥${item.amount.toLocaleString("ja-JP")}`);
+      return textContent(`固定収支を更新しました: ${item.name} ${formatRecurringItemAmount(item)}`);
     },
   );
 
@@ -87,7 +87,7 @@ export function registerRecurringItemTools(server: McpServer, apiClient: SuiApiC
         return textContent(formatDeletePreview(
           "固定収支",
           id,
-          item ? `${item.name} ${item.type} ¥${item.amount.toLocaleString("ja-JP")}（${formatRecurringSchedule(item)}）` : null,
+          item ? `${item.name} ${item.type} ${formatRecurringItemAmount(item)}（${formatRecurringSchedule(item)}）` : null,
         ));
       }
 


### PR DESCRIPTION
## 概要

固定収支の金額入力・表示・予測確定を、選択口座の通貨に対応させます。

## 変更内容

- 通常の固定収支は対象口座の通貨を使用
- 振替は送金元口座、送金元なしの場合は振替先口座の通貨を使用
- 固定収支フォームのラベルと通貨記号を口座選択へ即時同期
- 一覧の金額をJPY、USDなど実際の口座通貨で表示
- USD固定収支の予測額・JPY換算・口座残高を検証
- USDの通常収支、片側振替、両側振替の手動確定に対応
- MCPの固定収支表示・削除プレビュー・予測確定結果を外貨対応
- MCPの通貨フォーマットを共通化し、minor unitを正しくmajor unitへ変換

## テスト

SWE-1.7 がMakefile経由で以下を実行し、すべて成功しました。

- `make lint`
- `make typecheck`
- `make test-unit`
- `make test-integration`
- `make build`
- `make test-e2e`（71 passed）

## レビュー結果

初回レビューではMCPのUSD確定結果がminor unitのまま表示される問題をNOGOとして差し戻しました。共通通貨フォーマッタによる修正と回帰テストを確認し、GOと判断しました。
