### PR TITLE
test(e2e): 認証有効な E2E テストと auth 修正を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dev-dist
 .env.*
 coverage
 test-results
+playwright/.auth/*.json
+playwright-report
 performance-results/*
 !performance-results/.gitkeep
 packages/db/generated

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## 設計前提
 
-- **認証と信頼境界**: アプリ内に ID/PW は持たず、SPA は外部 IdP への OIDC Authorization Code + PKCE のみを使い、バックエンドは自前セッション Cookie を発行します。API および backend に内包された MCP エンドポイントは、UI で発行する API トークン（`Authorization: Bearer sui_tok_...`）で認証します。リバースプロキシの mTLS は追加の防御層として併用可能です。`SUI_AUTH_MODE=disabled` は信頼境界内限定の escape hatch です。CORS / Origin ガードは認証導入後も独立した防御層として維持します。API の CORS はデフォルトで許可オリジンなしです。開発用フロントエンドなど別オリジンからのブラウザアクセスを許可する場合のみ、`SUI_ALLOWED_ORIGINS` にカンマ区切りで Origin を指定してください。
+- **認証と信頼境界**: アプリ内に ID/PW は持たず、SPA は外部 IdP への OIDC Authorization Code + PKCE のみを使い、バックエンドは自前セッション Cookie を発行します。public client（client_secret なし）の IdP には対応していません。API および backend に内包された MCP エンドポイントは、UI で発行する API トークン（`Authorization: Bearer sui_tok_...`）で認証します。リバースプロキシの mTLS は追加の防御層として併用可能です。`SUI_AUTH_MODE=disabled` は信頼境界内限定の escape hatch です。CORS / Origin ガードは認証導入後も独立した防御層として維持します。API の CORS はデフォルトで許可オリジンなしです。開発用フロントエンドなど別オリジンからのブラウザアクセスを許可する場合のみ、`SUI_ALLOWED_ORIGINS` にカンマ区切りで Origin を指定してください。
 - **残高予測とサブスクの境界**: 残高予測は固定収支、クレジットカード請求、ローン返済から生成します。サブスクの大半はクレジットカード払いで、カード請求額の仮定値または実績額に既に含まれるため、サブスクを予測イベントへ直接統合すると二重計上になります。このアプリの本質は、クレジットカード明細ではなく「クレジットカード以外の口座残高」を管理することです。カード払いではない定額支払いを予測に入れる場合は、現時点では固定収支として登録してください。
 - **予測確定は手動**: 予定額と実際の引き落とし額が一致するとは限らないため、予定日を過ぎた予測イベントも自動確定しません。UI または MCP 経由で、金額と対象口座を人間が確認してから `POST /api/dashboard/confirm` で実取引化します。
 - **残高調整と照合**: 口座編集で `balance` を変更した場合、差分は `adjustment` 取引として記録されます。実残高の確認には照合（reconcile）フローを使い、差分を `adjustment` 取引に残した上で `lastReconciledAt` を更新します。残高履歴は調整取引を巻き戻して復元するため、過去の残高ポイントを遡及的に書き換えません。
@@ -146,7 +146,7 @@ bash scripts/seed.sh all
 | `SUI_AUTH_MODE` | バックエンドの認証モード (`enabled` / `disabled`) | `enabled` |
 | `SUI_OIDC_ISSUER` | OIDC IdP の issuer URL | （未設定） |
 | `SUI_OIDC_CLIENT_ID` | OIDC クライアント ID | （未設定） |
-| `SUI_OIDC_CLIENT_SECRET` | OIDC クライアントシークレット | （未設定） |
+| `SUI_OIDC_CLIENT_SECRET` | OIDC クライアントシークレット（public client / client_secret なしの IdP は未対応） | （未設定） |
 | `SUI_OIDC_REDIRECT_URI` | OIDC コールバック URL (`/api/auth/callback`) | （未設定） |
 | `SUI_OIDC_ALLOWED_SUBJECTS` | 許可する IdP `sub` のカンマ区切り | （未設定） |
 | `SUI_OIDC_ALLOWED_EMAILS` | 許可するメールアドレスのカンマ区切り | （未設定） |

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ bash scripts/seed.sh all
 | `SUI_OIDC_ALLOWED_SUBJECTS` | 許可する IdP `sub` のカンマ区切り | （未設定） |
 | `SUI_OIDC_ALLOWED_EMAILS` | 許可するメールアドレスのカンマ区切り | （未設定） |
 | `SUI_COOKIE_SECURE` | セッション Cookie を `Secure` に強制 (`true`/`false`) | `x-forwarded-proto` 自動判定 |
+| `SUI_FRONTEND_URL` | 認証リダイレクト先のフロントエンド URL。SPA を backend が配信する通常構成では不要（開発・テスト用） | （未設定） |
 
 ## API エンドポイント
 

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,8 @@
+import { test as setup } from "@playwright/test";
+import { authStorageState } from "../playwright.config";
+
+setup("authenticate through mock IdP", async ({ page }) => {
+  await page.goto("/api/auth/login");
+  await page.waitForURL("http://localhost:5174/");
+  await page.context().storageState({ path: authStorageState });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -9,13 +9,15 @@ test.beforeEach(async ({ page }) => {
 
 test.describe("authentication and settings", () => {
   test("issues and revokes an API token on the settings page", async ({ page }) => {
+    const tokenName = `e2e-test-${Date.now()}`;
+
     await navigateTo(page, "/settings");
 
     await expect(page.getByRole("heading", { name: "設定" })).toBeVisible();
 
     await page.getByRole("button", { name: "トークンを発行" }).click();
 
-    await page.getByLabel("用途").fill("e2e-test");
+    await page.getByLabel("用途").fill(tokenName);
     await page.getByRole("button", { name: "発行" }).click();
 
     const tokenInput = page.locator('input[readonly][class*="font-mono"]');
@@ -25,9 +27,9 @@ test.describe("authentication and settings", () => {
 
     await page.getByRole("button", { name: "閉じる" }).click();
 
-    await expect(page.getByText("e2e-test").first().locator("xpath=../..")).toContainText("読み書き");
+    await expect(page.getByText(tokenName).first().locator("xpath=../..")).toContainText("読み書き");
 
-    await page.getByText("e2e-test").first().locator("xpath=../..").getByRole("button", { name: "失効" }).click();
+    await page.getByText(tokenName).first().locator("xpath=../..").getByRole("button", { name: "失効" }).click();
 
     await expect(page.getByText("トークンはまだ発行されていません。")).toBeVisible();
   });

--- a/e2e/helpers/db-runner.ts
+++ b/e2e/helpers/db-runner.ts
@@ -8,7 +8,7 @@ import {
   createRecurringItem,
   createSubscription,
   createTransaction,
-  resetDatabase,
+  resetDatabaseForE2e,
 } from "@sui/db/testing";
 
 const TEST_DATABASE_URL = "postgresql://sui_test:sui_test@localhost:5555/sui_test";
@@ -118,7 +118,7 @@ const prisma = createPrismaClient({ databaseUrl: resolveDatabaseUrl() });
 async function run(command: DbCommand) {
   switch (command.action) {
     case "resetDatabase":
-      await resetDatabase(prisma);
+      await resetDatabaseForE2e(prisma);
       return null;
     case "seedAccount":
       return createAccount(prisma, {

--- a/e2e/helpers/mock-idp-server.ts
+++ b/e2e/helpers/mock-idp-server.ts
@@ -1,0 +1,21 @@
+import { startMockIdp } from "../../packages/backend/src/test-helpers/mock-idp";
+
+const PORT = Number(process.env.MOCK_IDP_PORT ?? "3101");
+
+async function main() {
+  const idp = await startMockIdp({ sub: "e2e-user", email: "e2e@example.com" }, PORT);
+  console.log(`Mock IdP listening on ${idp.issuerUrl}`);
+
+  const shutdown = async () => {
+    await idp.stop();
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/e2e/zzz-auth-flow.spec.ts
+++ b/e2e/zzz-auth-flow.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("logs in through the IdP", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("button", { name: "IdP でログイン" })).toBeVisible();
+
+  await page.getByRole("button", { name: "IdP でログイン" }).click();
+  await page.waitForURL("http://localhost:5174/");
+
+  await expect(page.locator("main")).toBeVisible();
+  await expect(page.getByText("総資産").first()).toBeVisible();
+});
+
+test("shows an allowlist rejection error", async ({ page }) => {
+  await page.goto("/login?auth_error=allowlist_rejected");
+  await expect(
+    page.getByText("このアカウントではログインできません。管理者に連絡してください。"),
+  ).toBeVisible();
+});

--- a/e2e/zzz-auth-flow.spec.ts
+++ b/e2e/zzz-auth-flow.spec.ts
@@ -1,3 +1,5 @@
+// `zzz-` prefix forces these tests to run near the end (workers=1, alphabetical order),
+// so login/logout specs do not invalidate the shared storageState used by earlier specs.
 import { expect, test } from "@playwright/test";
 
 test.use({ storageState: { cookies: [], origins: [] } });

--- a/e2e/zzz-auth-lifecycle.spec.ts
+++ b/e2e/zzz-auth-lifecycle.spec.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import { authStorageState } from "../playwright.config";
+
+interface StorageStateCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires: number;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: "Strict" | "Lax" | "None";
+}
+
+test.use({ storageState: authStorageState });
+
+test.beforeEach(async ({ page }) => {
+  const storage = JSON.parse(readFileSync(authStorageState, "utf8")) as { cookies: StorageStateCookie[] };
+  await page.context().clearCookies();
+  await page.context().addCookies(
+    storage.cookies.map((cookie) => ({ ...cookie, expires: -1 })),
+  );
+});
+
+test("logs out and redirects to the login screen after a 401", async ({ page }) => {
+  await page.goto("/settings");
+  await expect(page.getByRole("heading", { name: "設定" })).toBeVisible();
+
+  await page.getByRole("button", { name: "ログアウト" }).click();
+  await page.waitForURL("http://localhost:5174/");
+  await expect(page.getByRole("button", { name: "IdP でログイン" })).toBeVisible();
+
+  await page.goto("/api/auth/login");
+  await page.waitForURL("http://localhost:5174/");
+
+  await page.goto("/settings");
+  await expect(page.getByRole("heading", { name: "設定" })).toBeVisible();
+
+  await page.request.post("/api/auth/logout");
+
+  await page.getByRole("button", { name: "トークンを発行" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("用途").fill("expired-session");
+  await dialog.getByRole("button", { name: "発行" }).click();
+
+  await expect(page.getByRole("button", { name: "IdP でログイン" })).toBeVisible();
+});

--- a/e2e/zzz-auth-lifecycle.spec.ts
+++ b/e2e/zzz-auth-lifecycle.spec.ts
@@ -1,3 +1,5 @@
+// `zzz-` prefix forces this spec to run last (workers=1, alphabetical order), because
+// it logs out and invalidates the shared authenticated session in the database.
 import { readFileSync } from "node:fs";
 import { expect, test } from "@playwright/test";
 import { authStorageState } from "../playwright.config";

--- a/packages/backend/src/lib/auth.ts
+++ b/packages/backend/src/lib/auth.ts
@@ -1,4 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
+import { setCookie } from "hono/cookie";
+import type { Context } from "hono";
+import type { AuthSession } from "@sui/db";
 import { prisma } from "./db";
 
 export const SESSION_COOKIE_NAME = "sui_session";
@@ -6,7 +9,29 @@ export const SESSION_TOKEN_PREFIX = "sui_sess_";
 export const API_TOKEN_PREFIX = "sui_tok_";
 
 const SESSION_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;
+const SESSION_LIFETIME_SECONDS = 30 * 24 * 60 * 60;
 const API_TOKEN_LAST_USED_THROTTLE_MS = 60 * 1000;
+
+export function isSecureCookie(c: Context) {
+  const envValue = process.env.SUI_COOKIE_SECURE;
+  if (envValue === "true" || envValue === "1") {
+    return true;
+  }
+  if (envValue === "false" || envValue === "0") {
+    return false;
+  }
+  return c.req.header("x-forwarded-proto") === "https";
+}
+
+export function setSessionCookie(c: Context, token: string) {
+  setCookie(c, SESSION_COOKIE_NAME, token, {
+    httpOnly: true,
+    sameSite: "Lax",
+    path: "/",
+    secure: isSecureCookie(c),
+    maxAge: SESSION_LIFETIME_SECONDS,
+  });
+}
 
 export interface AuthInfo {
   kind: "session" | "token";
@@ -50,7 +75,7 @@ export async function createAuthSession(subject: string, userAgent?: string) {
   return { token, session };
 }
 
-export async function verifyAuthSession(token: string) {
+export async function verifyAuthSession(token: string): Promise<{ session: AuthSession; extended: boolean } | null> {
   const tokenHash = hashToken(token);
   const session = await prisma.authSession.findUnique({
     where: { tokenHash },
@@ -61,16 +86,17 @@ export async function verifyAuthSession(token: string) {
 
   const now = new Date();
   if (session.lastUsedAt.getTime() + API_TOKEN_LAST_USED_THROTTLE_MS <= now.getTime()) {
-    await prisma.authSession.update({
+    const updated = await prisma.authSession.update({
       where: { id: session.id },
       data: {
         lastUsedAt: now,
         expiresAt: new Date(now.getTime() + SESSION_LIFETIME_MS),
       },
     });
+    return { session: updated, extended: true };
   }
 
-  return session;
+  return { session, extended: false };
 }
 
 export async function deleteAuthSession(token: string) {

--- a/packages/backend/src/lib/auth.ts
+++ b/packages/backend/src/lib/auth.ts
@@ -51,8 +51,9 @@ export async function createAuthSession(subject: string, userAgent?: string) {
 }
 
 export async function verifyAuthSession(token: string) {
+  const tokenHash = hashToken(token);
   const session = await prisma.authSession.findUnique({
-    where: { tokenHash: hashToken(token) },
+    where: { tokenHash },
   });
   if (!session || session.expiresAt <= new Date()) {
     return null;
@@ -62,7 +63,10 @@ export async function verifyAuthSession(token: string) {
   if (session.lastUsedAt.getTime() + API_TOKEN_LAST_USED_THROTTLE_MS <= now.getTime()) {
     await prisma.authSession.update({
       where: { id: session.id },
-      data: { lastUsedAt: now },
+      data: {
+        lastUsedAt: now,
+        expiresAt: new Date(now.getTime() + SESSION_LIFETIME_MS),
+      },
     });
   }
 

--- a/packages/backend/src/mcp/index.ts
+++ b/packages/backend/src/mcp/index.ts
@@ -137,7 +137,7 @@ export function createMcpRoutes(parentApp: HonoApp, options: CreateMcpRoutesOpti
     return transport.handleRequest(c.req.raw);
   });
 
-  setInterval(() => {
+  const sweepInterval = setInterval(() => {
     const now = Date.now();
     for (const [id, session] of sessions) {
       if (now - session.lastActivityAt > MCP_SESSION_IDLE_TTL_MS) {
@@ -146,6 +146,7 @@ export function createMcpRoutes(parentApp: HonoApp, options: CreateMcpRoutesOpti
       }
     }
   }, MCP_SESSION_SWEEP_INTERVAL_MS);
+  sweepInterval.unref();
 
   return app;
 }

--- a/packages/backend/src/mcp/index.ts
+++ b/packages/backend/src/mcp/index.ts
@@ -20,6 +20,7 @@ interface McpSession {
   token: string;
   readOnly: boolean;
   closed: boolean;
+  lastActivityAt: number;
 }
 
 export interface CreateMcpRoutesOptions {
@@ -27,12 +28,27 @@ export interface CreateMcpRoutesOptions {
 }
 
 const MCP_SESSION_HEADER = "mcp-session-id";
+const MCP_SESSION_IDLE_TTL_MS = 30 * 60 * 1000;
+const MCP_SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 function extractBearerToken(authorization: string | undefined): string | null {
   if (!authorization?.toLowerCase().startsWith("bearer ")) {
     return null;
   }
   return authorization.slice(7).trim();
+}
+
+function closeMcpSession(session: McpSession) {
+  if (session.closed) {
+    return;
+  }
+  session.closed = true;
+  session.server.close().catch((error) => {
+    logger.error({ err: error }, "Failed to close MCP server during idle sweep");
+  });
+  session.transport.close().catch((error) => {
+    logger.error({ err: error }, "Failed to close MCP transport during idle sweep");
+  });
 }
 
 export function createMcpRoutes(parentApp: HonoApp, options: CreateMcpRoutesOptions = {}) {
@@ -70,6 +86,7 @@ export function createMcpRoutes(parentApp: HonoApp, options: CreateMcpRoutesOpti
       if (!session || session.token !== expectedToken) {
         return c.json({ error: "Session not found" }, 404);
       }
+      session.lastActivityAt = Date.now();
       return session.transport.handleRequest(c.req.raw);
     }
 
@@ -84,6 +101,7 @@ export function createMcpRoutes(parentApp: HonoApp, options: CreateMcpRoutesOpti
           token: auth?.token ?? "",
           readOnly: auth?.readOnly ?? false,
           closed: false,
+          lastActivityAt: Date.now(),
         };
         sessions.set(sessionId, session);
 
@@ -97,11 +115,8 @@ export function createMcpRoutes(parentApp: HonoApp, options: CreateMcpRoutesOpti
       onsessionclosed: (sessionId) => {
         const session = sessions.get(sessionId);
         sessions.delete(sessionId);
-        if (session && !session.closed) {
-          session.closed = true;
-          session.server.close().catch((error) => {
-            logger.error({ err: error }, "Failed to close MCP server");
-          });
+        if (session) {
+          closeMcpSession(session);
         }
       },
     });
@@ -111,12 +126,7 @@ export function createMcpRoutes(parentApp: HonoApp, options: CreateMcpRoutesOpti
       if (session) {
         const [sessionId, s] = session;
         sessions.delete(sessionId);
-        if (!s.closed) {
-          s.closed = true;
-          s.server.close().catch((error) => {
-            logger.error({ err: error }, "Failed to close MCP server");
-          });
-        }
+        closeMcpSession(s);
       }
     };
 
@@ -126,6 +136,16 @@ export function createMcpRoutes(parentApp: HonoApp, options: CreateMcpRoutesOpti
 
     return transport.handleRequest(c.req.raw);
   });
+
+  setInterval(() => {
+    const now = Date.now();
+    for (const [id, session] of sessions) {
+      if (now - session.lastActivityAt > MCP_SESSION_IDLE_TTL_MS) {
+        sessions.delete(id);
+        closeMcpSession(session);
+      }
+    }
+  }, MCP_SESSION_SWEEP_INTERVAL_MS);
 
   return app;
 }

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -1,6 +1,12 @@
 import type { Context, MiddlewareHandler } from "hono";
 import { getCookie } from "hono/cookie";
-import { verifyApiToken, verifyAuthSession, SESSION_COOKIE_NAME, type AuthInfo } from "../lib/auth";
+import {
+  verifyApiToken,
+  verifyAuthSession,
+  SESSION_COOKIE_NAME,
+  setSessionCookie,
+  type AuthInfo,
+} from "../lib/auth";
 
 export interface AuthMiddlewareOptions {
   authMode?: "enabled" | "disabled";
@@ -37,9 +43,13 @@ async function verifySessionAuth(c: Context): Promise<AuthInfo | null> {
     return null;
   }
 
-  const session = await verifyAuthSession(token);
-  if (!session) {
+  const result = await verifyAuthSession(token);
+  if (!result) {
     return null;
+  }
+
+  if (result.extended) {
+    setSessionCookie(c, token);
   }
 
   return { kind: "session", readOnly: false };

--- a/packages/backend/src/routes/auth.integration.test.ts
+++ b/packages/backend/src/routes/auth.integration.test.ts
@@ -303,6 +303,64 @@ describe("auth routes", () => {
     expect(after.status).toBe(401);
   });
 
+  it("refreshes the session cookie when lastUsedAt exceeds the throttle", async () => {
+    const client = buildClient();
+    const login = await client.get("/api/auth/login");
+    const location = login.headers.get("location");
+    if (!location) throw new Error("missing login redirect");
+
+    const cookies = parseSetCookies(login);
+    const callbackUrl = await followAuthorizeRedirect(location, "http://localhost/api/auth/callback");
+    const callbackResponse = await client.get(`${callbackUrl.pathname}${callbackUrl.search}`, {
+      headers: { Cookie: buildCookieHeader(cookies) },
+    });
+
+    const sessionCookies = parseSetCookies(callbackResponse);
+    const sessionToken = sessionCookies.sui_session;
+    expect(sessionToken).toBeDefined();
+
+    await testPrisma.authSession.updateMany({
+      where: { subject: "allowed-sub" },
+      data: { lastUsedAt: new Date(Date.now() - 2 * 60 * 1000) },
+    });
+
+    const response = await client.get("/api/accounts", { headers: { Cookie: `sui_session=${sessionToken}` } });
+    expect(response.status).toBe(200);
+
+    const setCookies = response.headers.getSetCookie?.() ?? [];
+    const sessionSetCookie = setCookies.find((value) => value.startsWith("sui_session="));
+    expect(sessionSetCookie).toBeDefined();
+    expect(sessionSetCookie).toContain("Max-Age=2592000");
+
+    const session = await testPrisma.authSession.findFirst({ where: { subject: "allowed-sub" } });
+    expect(session).not.toBeNull();
+    expect(session!.lastUsedAt.getTime()).toBeGreaterThan(Date.now() - 2 * 60 * 1000 + 60 * 1000);
+    expect(session!.expiresAt.getTime()).toBeGreaterThanOrEqual(Date.now() + 29 * 24 * 60 * 60 * 1000);
+  });
+
+  it("does not refresh the session cookie within the throttle window", async () => {
+    const client = buildClient();
+    const login = await client.get("/api/auth/login");
+    const location = login.headers.get("location");
+    if (!location) throw new Error("missing login redirect");
+
+    const cookies = parseSetCookies(login);
+    const callbackUrl = await followAuthorizeRedirect(location, "http://localhost/api/auth/callback");
+    const callbackResponse = await client.get(`${callbackUrl.pathname}${callbackUrl.search}`, {
+      headers: { Cookie: buildCookieHeader(cookies) },
+    });
+
+    const sessionCookies = parseSetCookies(callbackResponse);
+    const sessionToken = sessionCookies.sui_session;
+    expect(sessionToken).toBeDefined();
+
+    const response = await client.get("/api/accounts", { headers: { Cookie: `sui_session=${sessionToken}` } });
+    expect(response.status).toBe(200);
+
+    const setCookies = response.headers.getSetCookie?.() ?? [];
+    expect(setCookies.some((value) => value.startsWith("sui_session="))).toBe(false);
+  });
+
   it("respects disabled auth mode", async () => {
     vi.stubEnv("SUI_AUTH_MODE", "disabled");
     resetOidcCache();

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -7,9 +7,11 @@ import {
   createApiTokenRecord,
   createAuthSession,
   deleteAuthSession,
+  isSecureCookie,
   listApiTokens,
   revokeApiToken,
   SESSION_COOKIE_NAME,
+  setSessionCookie,
   verifyApiToken,
   verifyAuthSession,
   cleanupExpiredSessions,
@@ -18,7 +20,6 @@ import { handleRouteError } from "../lib/http";
 import { logger } from "../lib/logger";
 import { buildAuthorizationUrl, handleCallback, isOidcConfigured } from "../lib/oidc";
 
-const SESSION_LIFETIME_SECONDS = 30 * 24 * 60 * 60;
 const FLOW_COOKIE_MAX_AGE_SECONDS = 10 * 60;
 
 function getFrontendUrl() {
@@ -42,17 +43,6 @@ function serializeApiToken(token: Awaited<ReturnType<typeof listApiTokens>>[numb
   };
 }
 
-function isSecureCookie(c: Context) {
-  const envValue = process.env.SUI_COOKIE_SECURE;
-  if (envValue === "true" || envValue === "1") {
-    return true;
-  }
-  if (envValue === "false" || envValue === "0") {
-    return false;
-  }
-  return c.req.header("x-forwarded-proto") === "https";
-}
-
 function setAuthFlowCookie(c: Context, name: string, value: string) {
   setCookie(c, name, value, {
     httpOnly: true,
@@ -67,16 +57,6 @@ function clearAuthFlowCookies(c: Context) {
   for (const name of ["sui_auth_state", "sui_auth_nonce", "sui_auth_pkce"]) {
     deleteCookie(c, name, { path: "/api/auth/callback" });
   }
-}
-
-function setSessionCookie(c: Context, token: string) {
-  setCookie(c, SESSION_COOKIE_NAME, token, {
-    httpOnly: true,
-    sameSite: "Lax",
-    path: "/",
-    secure: isSecureCookie(c),
-    maxAge: SESSION_LIFETIME_SECONDS,
-  });
 }
 
 function clearSessionCookie(c: Context) {
@@ -95,8 +75,11 @@ async function isAuthenticated(c: Context) {
 
   const sessionToken = getCookie(c, SESSION_COOKIE_NAME);
   if (sessionToken) {
-    const session = await verifyAuthSession(sessionToken);
-    if (session) {
+    const result = await verifyAuthSession(sessionToken);
+    if (result) {
+      if (result.extended) {
+        setSessionCookie(c, sessionToken);
+      }
       return true;
     }
   }

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -21,6 +21,12 @@ import { buildAuthorizationUrl, handleCallback, isOidcConfigured } from "../lib/
 const SESSION_LIFETIME_SECONDS = 30 * 24 * 60 * 60;
 const FLOW_COOKIE_MAX_AGE_SECONDS = 10 * 60;
 
+function getFrontendUrl() {
+  const url = process.env.SUI_FRONTEND_URL;
+  if (!url) return "/";
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
 const createTokenSchema = z.object({
   name: z.string().min(1).max(100),
   readOnly: z.boolean().default(false),
@@ -120,7 +126,7 @@ export const authRoutes = new Hono()
       return c.redirect(url);
     } catch (error) {
       logger.warn({ err: error }, "Failed to build authorization URL");
-      return c.redirect("/?auth_error=oidc_discovery_failed");
+      return c.redirect(`${getFrontendUrl()}?auth_error=oidc_discovery_failed`);
     }
   })
   .get("/callback", async (c) => {
@@ -131,14 +137,14 @@ export const authRoutes = new Hono()
 
     if (!state || !nonce || !codeVerifier) {
       logger.warn("OIDC callback rejected: missing flow cookies");
-      return c.redirect("/?auth_error=oidc_callback_failed");
+      return c.redirect(`${getFrontendUrl()}?auth_error=oidc_callback_failed`);
     }
 
     const currentUrl = new URL(c.req.url);
     const result = await handleCallback(currentUrl, state, nonce, codeVerifier);
 
     if (!result.success) {
-      return c.redirect(`/?auth_error=${result.error}`);
+      return c.redirect(`${getFrontendUrl()}?auth_error=${result.error}`);
     }
 
     await cleanupExpiredSessions();
@@ -146,7 +152,7 @@ export const authRoutes = new Hono()
     const { token } = await createAuthSession(result.subject, userAgent);
     setSessionCookie(c, token);
     logger.info({ subject: result.subject }, "OIDC login succeeded");
-    return c.redirect("/");
+    return c.redirect(getFrontendUrl());
   })
   .post("/logout", async (c) => {
     const sessionToken = getCookie(c, SESSION_COOKIE_NAME);

--- a/packages/backend/src/test-helpers/mock-idp.ts
+++ b/packages/backend/src/test-helpers/mock-idp.ts
@@ -7,7 +7,10 @@ export interface MockIdp {
   clearLastRedirectUri: () => void;
 }
 
-export async function startMockIdp(claims: { sub: string; email?: string }): Promise<MockIdp> {
+export async function startMockIdp(
+  claims: { sub: string; email?: string },
+  port = 0,
+): Promise<MockIdp> {
   const server = new OAuth2Server();
   await server.issuer.keys.generate("RS256");
 
@@ -26,7 +29,7 @@ export async function startMockIdp(claims: { sub: string; email?: string }): Pro
     }
   });
 
-  await server.start(0, "localhost");
+  await server.start(port, "localhost");
 
   if (!server.issuer.url) {
     throw new Error("Mock IdP did not start");

--- a/packages/db/src/reset.ts
+++ b/packages/db/src/reset.ts
@@ -19,8 +19,33 @@ const TRUNCATE_TABLES_SQL = `
   RESTART IDENTITY CASCADE
 `;
 
+const TRUNCATE_DATA_TABLES_SQL = `
+  TRUNCATE TABLE
+    "transactions",
+    "credit_card_items",
+    "credit_card_billings",
+    "recurring_items",
+    "subscriptions",
+    "credit_cards",
+    "loans",
+    "accounts",
+    "audit_logs",
+    "settings"
+  RESTART IDENTITY CASCADE
+`;
+
 export async function resetDatabase(prisma: PrismaClient) {
   await prisma.$executeRawUnsafe(TRUNCATE_TABLES_SQL);
+  await prisma.setting.createMany({
+    data: Object.entries(DEFAULT_SETTINGS).map(([key, value]) => ({
+      key,
+      value,
+    })),
+  });
+}
+
+export async function resetDatabaseForE2e(prisma: PrismaClient) {
+  await prisma.$executeRawUnsafe(TRUNCATE_DATA_TABLES_SQL);
   await prisma.setting.createMany({
     data: Object.entries(DEFAULT_SETTINGS).map(([key, value]) => ({
       key,

--- a/packages/db/src/reset.ts
+++ b/packages/db/src/reset.ts
@@ -2,63 +2,56 @@ import { DEFAULT_SETTINGS } from "@sui/shared";
 
 import type { PrismaClient } from "./generated/prisma/client.mts";
 
-const TRUNCATE_TABLES_SQL = `
+const DATA_TABLES = [
+  "transactions",
+  "credit_card_items",
+  "credit_card_billings",
+  "recurring_items",
+  "subscriptions",
+  "credit_cards",
+  "loans",
+  "accounts",
+  "audit_logs",
+  "settings",
+];
+
+const AUTH_TABLES = ["auth_sessions", "api_tokens"];
+
+function buildTruncateSql(tables: string[]) {
+  const joined = tables.map((table) => `"${table}"`).join(",\n    ");
+  return `
   TRUNCATE TABLE
-    "transactions",
-    "credit_card_items",
-    "credit_card_billings",
-    "recurring_items",
-    "subscriptions",
-    "credit_cards",
-    "loans",
-    "accounts",
-    "audit_logs",
-    "auth_sessions",
-    "api_tokens",
-    "settings"
+    ${joined}
   RESTART IDENTITY CASCADE
 `;
+}
 
-const TRUNCATE_DATA_TABLES_SQL = `
-  TRUNCATE TABLE
-    "transactions",
-    "credit_card_items",
-    "credit_card_billings",
-    "recurring_items",
-    "subscriptions",
-    "credit_cards",
-    "loans",
-    "accounts",
-    "audit_logs",
-    "settings"
-  RESTART IDENTITY CASCADE
-`;
+const TRUNCATE_DATA_TABLES_SQL = buildTruncateSql(DATA_TABLES);
+const TRUNCATE_TABLES_SQL = buildTruncateSql([
+  ...DATA_TABLES.slice(0, DATA_TABLES.length - 1),
+  ...AUTH_TABLES,
+  DATA_TABLES[DATA_TABLES.length - 1],
+]);
 
-export async function resetDatabase(prisma: PrismaClient) {
-  await prisma.$executeRawUnsafe(TRUNCATE_TABLES_SQL);
+async function seedDefaultSettings(prisma: PrismaClient) {
   await prisma.setting.createMany({
     data: Object.entries(DEFAULT_SETTINGS).map(([key, value]) => ({
       key,
       value,
     })),
   });
+}
+
+export async function resetDatabase(prisma: PrismaClient) {
+  await prisma.$executeRawUnsafe(TRUNCATE_TABLES_SQL);
+  await seedDefaultSettings(prisma);
 }
 
 export async function resetDatabaseForE2e(prisma: PrismaClient) {
   await prisma.$executeRawUnsafe(TRUNCATE_DATA_TABLES_SQL);
-  await prisma.setting.createMany({
-    data: Object.entries(DEFAULT_SETTINGS).map(([key, value]) => ({
-      key,
-      value,
-    })),
-  });
+  await seedDefaultSettings(prisma);
 }
 
 export async function resetAuth(prisma: PrismaClient) {
-  await prisma.$executeRawUnsafe(`
-    TRUNCATE TABLE
-      "auth_sessions",
-      "api_tokens"
-    RESTART IDENTITY CASCADE
-  `);
+  await prisma.$executeRawUnsafe(buildTruncateSql(AUTH_TABLES));
 }

--- a/packages/db/src/testing.ts
+++ b/packages/db/src/testing.ts
@@ -1,4 +1,4 @@
-export { resetAuth, resetDatabase } from "./reset";
+export { resetAuth, resetDatabase, resetDatabaseForE2e } from "./reset";
 export {
   createAccount,
   createBilling,

--- a/packages/frontend/src/lib/auth.tsx
+++ b/packages/frontend/src/lib/auth.tsx
@@ -6,6 +6,7 @@ interface AuthState {
   configured: boolean;
   authenticated: boolean;
   loading: boolean;
+  error: boolean;
 }
 
 interface AuthContextValue extends AuthState {
@@ -20,6 +21,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     configured: false,
     authenticated: false,
     loading: true,
+    error: false,
   });
 
   useEffect(() => {
@@ -30,6 +32,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           configured: status.configured,
           authenticated: status.authenticated,
           loading: false,
+          error: false,
         });
       } catch (error) {
         const offline =
@@ -38,6 +41,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           configured: false,
           authenticated: offline,
           loading: false,
+          error: true,
         });
       }
     };

--- a/packages/frontend/src/routes/login.tsx
+++ b/packages/frontend/src/routes/login.tsx
@@ -11,12 +11,19 @@ const ERROR_MESSAGES: Record<string, string> = {
 };
 
 export function LoginPage() {
-  const { configured, loading, login } = useAuth();
+  const { configured, loading, error, login } = useAuth();
   const [searchParams] = useSearchParams();
   const authError = searchParams.get("auth_error");
   const errorMessage = authError ? (ERROR_MESSAGES[authError] ?? "認証に失敗しました。") : null;
 
   const help = useMemo(() => {
+    if (error) {
+      return (
+        <p className="mt-4 text-sm text-critical">
+          バックエンドに接続できません。ページを再読み込みするか、管理者に連絡してください。
+        </p>
+      );
+    }
     if (configured) return null;
     return (
       <div className="mt-4 text-sm text-ink-2">
@@ -30,7 +37,7 @@ export function LoginPage() {
         </ul>
       </div>
     );
-  }, [configured]);
+  }, [configured, error]);
 
   if (loading) {
     return (
@@ -52,7 +59,9 @@ export function LoginPage() {
           </p>
         ) : null}
 
-        {configured ? (
+        {error ? (
+          <p className="mt-6 text-sm text-critical">バックエンドに接続できません</p>
+        ) : configured ? (
           <Button className="mt-6 w-full" onClick={login}>
             IdP でログイン
           </Button>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "@playwright/test";
+import path from "node:path";
 
 const testDatabaseUrl = "postgresql://sui_test:sui_test@localhost:5555/sui_test";
+
+export const authStorageState = path.resolve(__dirname, "playwright/.auth/user.json");
+const mockIdpServerPath = path.resolve(__dirname, "e2e/helpers/mock-idp-server.ts");
 
 export default defineConfig({
   testDir: "e2e",
@@ -14,14 +18,31 @@ export default defineConfig({
     timezoneId: "Asia/Tokyo",
   },
   projects: [
+    { name: "setup", testMatch: /.*\.setup\.ts/ },
     {
       name: "chromium",
-      use: { browserName: "chromium" },
+      use: { browserName: "chromium", storageState: authStorageState },
+      dependencies: ["setup"],
     },
   ],
   webServer: [
     {
-      command: `SUI_AUTH_MODE=disabled DATABASE_URL=${testDatabaseUrl} PORT=3100 pnpm --filter @sui/backend dev`,
+      command: `pnpm --filter @sui/backend exec tsx ${mockIdpServerPath}`,
+      port: 3101,
+      reuseExistingServer: true,
+    },
+    {
+      command:
+        `DATABASE_URL=${testDatabaseUrl} PORT=3100 ` +
+        `SUI_AUTH_MODE=enabled ` +
+        `SUI_OIDC_ISSUER=http://localhost:3101 ` +
+        `SUI_OIDC_CLIENT_ID=sui-e2e ` +
+        `SUI_OIDC_CLIENT_SECRET=e2e-secret ` +
+        `SUI_OIDC_REDIRECT_URI=http://localhost:3100/api/auth/callback ` +
+        `SUI_OIDC_ALLOWED_SUBJECTS=e2e-user ` +
+        `SUI_COOKIE_SECURE=false ` +
+        `SUI_FRONTEND_URL=http://localhost:5174 ` +
+        `pnpm --filter @sui/backend dev`,
       port: 3100,
       reuseExistingServer: true,
     },


### PR DESCRIPTION
## 概要

認証を有効化した状態での E2E テスト基盤を整備し、関連する auth の改善を行います。

## 主な変更

- Playwright の setup プロジェクトと `storageState` を使った認証済み E2E 実行
- mock IdP を使ったログイン・allowlist 拒否・ログアウト・401 遷移の E2E spec
- E2E DB リセット時に `auth_sessions` / `api_tokens` を保持するよう調整
- セッション使用時の `lastUsedAt` / `expiresAt` スライディング延長
- スライディング延長時にブラウザ Cookie の `Max-Age` をリセット
- MCP セッション Map のアイドル TTL 定期掃除（`unref` 付き）
- `/api/auth/status` 取得失敗時の frontend 表示分岐修正
- README に public OIDC client 未対応と `SUI_FRONTEND_URL` を明記
- `reset.ts` の TRUNCATE SQL を配列から生成するリファクタ

## レビュー対応（2026-07-25）

- MCP セッション掃除 interval に `unref()` を追加
- `SUI_FRONTEND_URL` を README 環境変数表に追加
- セッション延長時に `Set-Cookie` を再設定する実装と統合テストを追加
- `zzz-` prefix ファイルに命名理由のコメントを追加

## 検証

- `make lint` / `make typecheck` / `make test-unit` 済
- `make test-integration` 159 tests 全パス
- `make test-e2e` 77 tests 全パス

Generated with [Devin](https://devin.ai)