### PR TITLE
feat(frontend): 移動平均を予測分にも反映する

### DIFF
--- a/packages/frontend/src/components/balance-chart.tsx
+++ b/packages/frontend/src/components/balance-chart.tsx
@@ -166,11 +166,12 @@ function BalanceTooltip({
     return null;
   }
 
+  const trendEntry = getTooltipEntry(payload, "trendBalance");
   const entries = [
     getTooltipEntry(payload, "actualBalance"),
     getTooltipEntry(payload, "forecastBalance"),
-    getTooltipEntry(payload, "trendBalance"),
-    getTooltipEntry(payload, "trendForecastBalance"),
+    trendEntry,
+    ...(trendEntry == null ? [getTooltipEntry(payload, "trendForecastBalance")] : []),
   ].filter((entry): entry is NonNullable<typeof entry> => entry != null && typeof entry.value === "number");
 
   if (entries.length === 0) {

--- a/packages/frontend/src/components/balance-chart.tsx
+++ b/packages/frontend/src/components/balance-chart.tsx
@@ -29,6 +29,7 @@ import {
   type BalanceChartInputPoint,
   type ChartDataPoint,
   type DailyBalanceChartPoint,
+  type MovingAveragePoint,
 } from "../lib/balance-chart";
 import { cn } from "../lib/utils";
 
@@ -108,7 +109,7 @@ function getMinimumForecastPoint(points: DailyBalanceChartPoint[], domain: [numb
 
 function getTooltipEntry(
   payload: TooltipContentProps["payload"],
-  dataKey: "actualBalance" | "forecastBalance" | "trendBalance",
+  dataKey: "actualBalance" | "forecastBalance" | "trendBalance" | "trendForecastBalance",
 ) {
   return payload.find((entry) => entry.dataKey === dataKey && entry.value !== null && entry.value !== undefined);
 }
@@ -129,7 +130,7 @@ function getTooltipSeriesLabel(
     return "予測";
   }
 
-  if (entry.dataKey === "trendBalance") {
+  if (entry.dataKey === "trendBalance" || entry.dataKey === "trendForecastBalance") {
     return defaultTrendLabel;
   }
 
@@ -141,7 +142,7 @@ function getTooltipSeriesLineClass(entry: TooltipContentProps["payload"][number]
     return "border-dashed border-chart-forecast";
   }
 
-  if (entry.dataKey === "trendBalance") {
+  if (entry.dataKey === "trendBalance" || entry.dataKey === "trendForecastBalance") {
     return "border-dotted border-chart-trend";
   }
 
@@ -169,6 +170,7 @@ function BalanceTooltip({
     getTooltipEntry(payload, "actualBalance"),
     getTooltipEntry(payload, "forecastBalance"),
     getTooltipEntry(payload, "trendBalance"),
+    getTooltipEntry(payload, "trendForecastBalance"),
   ].filter((entry): entry is NonNullable<typeof entry> => entry != null && typeof entry.value === "number");
 
   if (entries.length === 0) {
@@ -314,9 +316,16 @@ export function BalanceChart({
   );
   const windowDays = useMonthTicks ? 30 : 7;
   const trendLabel = windowDays === 7 ? "7日移動平均" : "30日移動平均";
-  const trendLineSeries = showTrend ? buildMovingAverageSeries(actualLineSeries, windowDays) : [];
+  const { actual: trendLineSeries, forecast: trendForecastLineSeries } = showTrend
+    ? buildMovingAverageSeries(actualLineSeries, windowDays, forecastLineSeries)
+    : { actual: [] as MovingAveragePoint[], forecast: [] as MovingAveragePoint[] };
 
-  const visibleBalances = [...actualLineSeries, ...forecastLineSeries, ...trendLineSeries]
+  const visibleBalances = [
+    ...actualLineSeries,
+    ...forecastLineSeries,
+    ...trendLineSeries,
+    ...trendForecastLineSeries,
+  ]
     .filter((point) => isInDomain(point, xDomain))
     .map((point) => point.balance);
   const { domain: chartDomain, ticks: yTicks } = buildNiceYAxis(visibleBalances, currentBalance);
@@ -336,6 +345,7 @@ export function BalanceChart({
     actualLineSeries,
     forecastLineSeries,
     trendLineSeries,
+    trendForecastLineSeries,
     xDomain,
   });
   const xTicks = buildTimeScaleTicks(timestampToDateOnly(xDomain[0]), timestampToDateOnly(xDomain[1]));
@@ -518,6 +528,22 @@ export function BalanceChart({
                 connectNulls
               />
             ) : null}
+            {trendForecastLineSeries.length > 0 ? (
+              <Line
+                type="linear"
+                dataKey="trendForecastBalance"
+                name={trendLabel}
+                stroke="var(--chart-trend)"
+                strokeWidth={1.5}
+                strokeDasharray="2 2"
+                strokeOpacity={0.5}
+                dot={false}
+                activeDot={{ r: 3 }}
+                isAnimationActive={shouldAnimate}
+                animationDuration={INITIAL_ANIMATION_MS}
+                connectNulls={false}
+              />
+            ) : null}
             {trendLineSeries.length > 0 ? (
               <Line
                 type="linear"
@@ -536,7 +562,7 @@ export function BalanceChart({
           </ComposedChart>
           <ChartLegend
             showForecast={forecastLineSeries.length > 0}
-            showTrend={trendLineSeries.length > 0}
+            showTrend={trendLineSeries.length > 0 || trendForecastLineSeries.length > 0}
             trendLabel={trendLabel}
           />
           {showTodayLine ? (

--- a/packages/frontend/src/lib/balance-chart.test.ts
+++ b/packages/frontend/src/lib/balance-chart.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("buildMovingAverageSeries", () => {
   it("returns an empty array for empty input", () => {
-    expect(buildMovingAverageSeries([], 7)).toEqual([]);
+    expect(buildMovingAverageSeries([], 7)).toEqual({ actual: [], forecast: [] });
   });
 
   it("returns an empty array when windowDays is not positive", () => {
@@ -17,8 +17,8 @@ describe("buildMovingAverageSeries", () => {
       { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 100_000, eventCount: 1 },
     ];
 
-    expect(buildMovingAverageSeries(points, 0)).toEqual([]);
-    expect(buildMovingAverageSeries(points, -1)).toEqual([]);
+    expect(buildMovingAverageSeries(points, 0)).toEqual({ actual: [], forecast: [] });
+    expect(buildMovingAverageSeries(points, -1)).toEqual({ actual: [], forecast: [] });
   });
 
   it("returns a single point for a single-day actual line", () => {
@@ -26,7 +26,7 @@ describe("buildMovingAverageSeries", () => {
       { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 100_000, eventCount: 1 },
     ];
 
-    const result = buildMovingAverageSeries(points, 7);
+    const { actual: result } = buildMovingAverageSeries(points, 7);
 
     expect(result).toEqual([
       { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 100_000 },
@@ -44,7 +44,7 @@ describe("buildMovingAverageSeries", () => {
       currentBalance: 10_000,
     });
 
-    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+    const { actual: result } = buildMovingAverageSeries(segments.actualLineSeries, 7);
 
     expect(result.length).toBe(10);
     expect(result[0]).toEqual({
@@ -85,7 +85,7 @@ describe("buildMovingAverageSeries", () => {
       currentBalance: 10_000,
     });
 
-    const result = buildMovingAverageSeries(segments.actualLineSeries, 30);
+    const { actual: result } = buildMovingAverageSeries(segments.actualLineSeries, 30);
 
     expect(result[9].balance).toBe(5_500);
   });
@@ -102,7 +102,7 @@ describe("buildMovingAverageSeries", () => {
       currentBalance: 3_000,
     });
 
-    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+    const { actual: result } = buildMovingAverageSeries(segments.actualLineSeries, 7);
 
     expect(result.map((point) => point.balance)).toEqual([1_000, 1_500, 2_000]);
   });
@@ -126,7 +126,7 @@ describe("buildMovingAverageSeries", () => {
       currentBalance: 200_000,
     });
 
-    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+    const { actual: result } = buildMovingAverageSeries(segments.actualLineSeries, 7);
 
     // Day 5 (index 4) should only average the first 5 days of 100,000
     expect(result[4].balance).toBe(100_000);
@@ -145,7 +145,7 @@ describe("buildMovingAverageSeries", () => {
       currentBalance: 50_000,
     });
 
-    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+    const { actual: result } = buildMovingAverageSeries(segments.actualLineSeries, 7);
 
     expect(result.map((point) => point.balance)).toEqual([10_000, 10_000, 10_000, 10_000, 18_000]);
   });
@@ -158,7 +158,7 @@ describe("buildMovingAverageSeries", () => {
       currentBalance: 30_000,
     });
 
-    const result = buildMovingAverageSeries(segments.actualLineSeries, 7);
+    const { actual: result } = buildMovingAverageSeries(segments.actualLineSeries, 7);
 
     expect(result.length).toBe(5);
     expect(result.map((point) => point.balance)).toEqual([30_000, 30_000, 30_000, 30_000, 30_000]);
@@ -169,6 +169,71 @@ describe("buildMovingAverageSeries", () => {
       "2026-07-04",
       "2026-07-05",
     ]);
+  });
+
+  it("returns the same result for actual-only input when forecast is omitted", () => {
+    const actual = [
+      { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 10_000, eventCount: 1 },
+      { date: "2026-07-02", timestamp: dateOnlyToTimestamp("2026-07-02"), balance: 20_000, eventCount: 1 },
+      { date: "2026-07-03", timestamp: dateOnlyToTimestamp("2026-07-03"), balance: 30_000, eventCount: 1 },
+    ];
+
+    const result = buildMovingAverageSeries(actual, 7);
+
+    expect(result.actual.map((point) => point.balance)).toEqual([10_000, 15_000, 20_000]);
+    expect(result.forecast).toEqual([]);
+  });
+
+  it("extends the moving average into the forecast window using a cumulative window", () => {
+    const actual = [
+      { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 10_000, eventCount: 1 },
+      { date: "2026-07-02", timestamp: dateOnlyToTimestamp("2026-07-02"), balance: 20_000, eventCount: 1 },
+      { date: "2026-07-03", timestamp: dateOnlyToTimestamp("2026-07-03"), balance: 30_000, eventCount: 1 },
+    ];
+    const forecast = [
+      { date: "2026-07-04", timestamp: dateOnlyToTimestamp("2026-07-04"), balance: 20_000, eventCount: 1 },
+      { date: "2026-07-05", timestamp: dateOnlyToTimestamp("2026-07-05"), balance: 50_000, eventCount: 1 },
+      { date: "2026-07-06", timestamp: dateOnlyToTimestamp("2026-07-06"), balance: 80_000, eventCount: 1 },
+    ];
+
+    const { actual: actualTrend, forecast: forecastTrend } = buildMovingAverageSeries(actual, 7, forecast);
+
+    expect(actualTrend.map((point) => point.balance)).toEqual([10_000, 15_000, 20_000]);
+    expect(forecastTrend.map((point) => point.balance)).toEqual([20_000, 20_000, 26_000, 35_000]);
+  });
+
+  it("duplicates the boundary moving average at the head of the forecast series", () => {
+    const actual = [
+      { date: "2026-07-01", timestamp: dateOnlyToTimestamp("2026-07-01"), balance: 10_000, eventCount: 1 },
+      { date: "2026-07-02", timestamp: dateOnlyToTimestamp("2026-07-02"), balance: 20_000, eventCount: 1 },
+      { date: "2026-07-03", timestamp: dateOnlyToTimestamp("2026-07-03"), balance: 30_000, eventCount: 1 },
+    ];
+    const forecast = [
+      { date: "2026-07-04", timestamp: dateOnlyToTimestamp("2026-07-04"), balance: 20_000, eventCount: 1 },
+      { date: "2026-07-05", timestamp: dateOnlyToTimestamp("2026-07-05"), balance: 50_000, eventCount: 1 },
+    ];
+
+    const { actual: actualTrend, forecast: forecastTrend } = buildMovingAverageSeries(actual, 7, forecast);
+
+    const lastActual = actualTrend[actualTrend.length - 1];
+    const firstForecast = forecastTrend[0];
+
+    expect(lastActual).toEqual(firstForecast);
+    expect(lastActual?.timestamp).toBe(dateOnlyToTimestamp("2026-07-03"));
+    expect(lastActual?.balance).toBe(20_000);
+  });
+
+  it("does not crash when the actual series is empty and only forecast is given", () => {
+    const forecast = [
+      { date: "2026-07-04", timestamp: dateOnlyToTimestamp("2026-07-04"), balance: 20_000, eventCount: 1 },
+      { date: "2026-07-05", timestamp: dateOnlyToTimestamp("2026-07-05"), balance: 50_000, eventCount: 1 },
+      { date: "2026-07-06", timestamp: dateOnlyToTimestamp("2026-07-06"), balance: 80_000, eventCount: 1 },
+    ];
+
+    const result = buildMovingAverageSeries([], 7, forecast);
+
+    expect(result.actual).toEqual([]);
+    expect(result.forecast.map((point) => point.balance)).toEqual([20_000, 35_000, 50_000]);
   });
 });
 
@@ -271,7 +336,7 @@ describe("buildDenseChartData", () => {
       displayEndDate: "2026-07-06",
       currentBalance: 30_000,
     });
-    const trendLineSeries = buildMovingAverageSeries(segments.actualLineSeries, 2);
+    const { actual: trendLineSeries } = buildMovingAverageSeries(segments.actualLineSeries, 2);
 
     const chartData = buildDenseChartData({
       actualLineSeries: segments.actualLineSeries,
@@ -318,6 +383,7 @@ describe("buildDenseChartData", () => {
       forecastBalance: 40_000,
       forecastDescription: undefined,
       trendBalance: undefined,
+      trendForecastBalance: undefined,
     });
   });
 

--- a/packages/frontend/src/lib/balance-chart.ts
+++ b/packages/frontend/src/lib/balance-chart.ts
@@ -342,7 +342,8 @@ export function buildMovingAverageSeries(
     }
   }
 
-  if (forecast.length > 0 && actual.length > 0 && forecast[0].timestamp !== actual[actual.length - 1].timestamp) {
+  // 実績末尾の移動平均値を予測系列の先頭に複製し、境界で線が途切れないようにする。
+  if (forecast.length > 0 && actual.length > 0) {
     forecast.unshift({ ...actual[actual.length - 1] });
   }
 

--- a/packages/frontend/src/lib/balance-chart.ts
+++ b/packages/frontend/src/lib/balance-chart.ts
@@ -262,27 +262,52 @@ export type MovingAveragePoint = {
   balance: number;
 };
 
+export type MovingAverageSeries = {
+  actual: MovingAveragePoint[];
+  forecast: MovingAveragePoint[];
+};
+
 export function buildMovingAverageSeries(
   actualLineSeries: DailyBalanceChartPoint[],
   windowDays: number,
-): MovingAveragePoint[] {
-  if (actualLineSeries.length === 0 || windowDays <= 0) {
-    return [];
+  forecastLineSeries: DailyBalanceChartPoint[] = [],
+): MovingAverageSeries {
+  if ((actualLineSeries.length === 0 && forecastLineSeries.length === 0) || windowDays <= 0) {
+    return { actual: [], forecast: [] };
   }
 
-  const sorted = sortDailyPoints(actualLineSeries);
-  const startTimestamp = sorted[0].timestamp;
-  const endTimestamp = sorted[sorted.length - 1].timestamp;
+  const sortedActual = sortDailyPoints(actualLineSeries);
+  const sortedForecast = sortDailyPoints(forecastLineSeries);
+
+  const startTimestamp = Math.min(
+    sortedActual[0]?.timestamp ?? Infinity,
+    sortedForecast[0]?.timestamp ?? Infinity,
+  );
+  const actualLastTimestamp = sortedActual[sortedActual.length - 1]?.timestamp;
+  const forecastLastTimestamp = sortedForecast[sortedForecast.length - 1]?.timestamp;
+  const endTimestamp = Math.max(
+    actualLastTimestamp ?? -Infinity,
+    forecastLastTimestamp ?? -Infinity,
+  );
 
   if (endTimestamp < startTimestamp) {
-    return [];
+    return { actual: [], forecast: [] };
   }
 
   const points: MovingAveragePoint[] = [];
   const balances: number[] = [];
 
   for (let timestamp = startTimestamp; timestamp <= endTimestamp + Number.EPSILON; timestamp += DAY_MS) {
-    const point = findLastPointBeforeOrAt(sorted, timestamp);
+    let point: DailyBalanceChartPoint | undefined;
+
+    if (sortedActual.length > 0 && actualLastTimestamp !== undefined && timestamp <= actualLastTimestamp + Number.EPSILON) {
+      point = findLastPointBeforeOrAt(sortedActual, timestamp);
+    }
+
+    if (!point && sortedForecast.length > 0) {
+      point = findLastPointBeforeOrAt(sortedForecast, timestamp);
+    }
+
     if (!point) {
       continue;
     }
@@ -302,7 +327,26 @@ export function buildMovingAverageSeries(
     });
   }
 
-  return points;
+  if (actualLastTimestamp === undefined) {
+    return { actual: [], forecast: points };
+  }
+
+  const actual: MovingAveragePoint[] = [];
+  const forecast: MovingAveragePoint[] = [];
+
+  for (const point of points) {
+    if (point.timestamp <= actualLastTimestamp + Number.EPSILON) {
+      actual.push(point);
+    } else {
+      forecast.push(point);
+    }
+  }
+
+  if (forecast.length > 0 && actual.length > 0 && forecast[0].timestamp !== actual[actual.length - 1].timestamp) {
+    forecast.unshift({ ...actual[actual.length - 1] });
+  }
+
+  return { actual, forecast };
 }
 
 export type ChartDataPoint = {
@@ -314,22 +358,28 @@ export type ChartDataPoint = {
   forecastBalance?: number;
   forecastDescription?: string;
   trendBalance?: number;
+  trendForecastBalance?: number;
 };
 
 export function buildDenseChartData({
   actualLineSeries,
   forecastLineSeries,
   trendLineSeries,
+  trendForecastLineSeries = [],
   xDomain,
 }: {
   actualLineSeries: DailyBalanceChartPoint[];
   forecastLineSeries: DailyBalanceChartPoint[];
   trendLineSeries: MovingAveragePoint[];
+  trendForecastLineSeries?: MovingAveragePoint[];
   xDomain: [number, number];
 }): ChartDataPoint[] {
   const points: ChartDataPoint[] = [];
   const trendByTimestamp = new Map(
     trendLineSeries.map((point) => [point.timestamp, point.balance]),
+  );
+  const trendForecastByTimestamp = new Map(
+    trendForecastLineSeries.map((point) => [point.timestamp, point.balance]),
   );
   const actualByTimestamp = new Map(
     actualLineSeries.map((point) => [point.timestamp, point]),
@@ -378,6 +428,7 @@ export function buildDenseChartData({
       forecastBalance: forecastPoint?.balance,
       forecastDescription: exactForecastPoint?.description,
       trendBalance: trendByTimestamp.get(timestamp),
+      trendForecastBalance: trendForecastByTimestamp.get(timestamp),
     });
   }
 


### PR DESCRIPTION
## 概要

ダッシュボードの残高チャートで、移動平均（トレンド）線が実績区間のみで描画されており、今日以降の予測期間のトレンドが読めなかった問題を修正します。

## 変更内容

- `packages/frontend/src/lib/balance-chart.ts`:
  - `buildMovingAverageSeries` のシグネチャを拡張し、オプションで `forecastLineSeries` を受け取れるようにする
  - 実績と予測を連続した 1 系列として日次サンプリングし、移動平均を計算
  - 戻り値を `{ actual, forecast }` に分け、実績末尾の移動平均値を `forecast` の先頭に複製して境界で線が途切れないようにする
  - `buildDenseChartData` に `trendForecastLineSeries` / `trendForecastBalance` を追加
- `packages/frontend/src/components/balance-chart.tsx`:
  - `buildMovingAverageSeries` の返り値を `trendLineSeries` / `trendForecastLineSeries` に展開
  - `trendForecastBalance` の `<Line>` を追加（同色・点線・`strokeOpacity=0.5`）
  - ツールチップと Y 軸ドメイン計算に予測トレンド系列を含める
- `packages/frontend/src/lib/balance-chart.test.ts`:
  - 既存テストを新しい戻り値に対応
  - 実績＋予測の累積窓、境界点複製、予測のみ、実績のみ互換のテストを追加

## 受け入れ基準

- [x] 移動平均トグル ON で、トレンド線が今日を越えて予測期間末尾まで描画される
- [x] 今日の境界で線が途切れたり段差ができたりしない
- [x] 予測系列がないチャート（取引履歴ページなど）の表示が変わらない
- [x] 7日窓 / 30日窓の切り替えで動作する

## 検証

- `make typecheck` パス
- `make lint` パス
- `make test-unit` パス（frontend tests 19 passed を含む全テストパス）

Closes #369

Generated with [Devin](https://devin.ai)