### PR TITLE
feat(frontend): 終了した繰り返し設定をアーカイブ表示に分離する

### DIFF
--- a/e2e/subscriptions.spec.ts
+++ b/e2e/subscriptions.spec.ts
@@ -170,3 +170,39 @@ test("creates a USD subscription and displays monthly totals in JPY", async ({ p
   await expect(row).toContainText(new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(10.99));
   await expect(monthlyCard).toContainText(formatCurrency(1649));
 });
+
+test("archives an ended subscription and restores it by clearing end date", async ({ page }) => {
+  await page.clock.install({ time: new Date("2026-03-14T00:00:00.000Z") });
+  await navigateTo(page, "/subscriptions");
+
+  await page.getByRole("button", { name: "サブスクを追加" }).click();
+  await page.getByLabel("サービス名 *").first().fill("Archived Sub");
+  await page.getByLabel("金額 (JPY) *").first().fill("1000");
+  await page.getByLabel("課金開始日 *").first().fill("2026-01-05");
+  await page.getByLabel("毎月の発生日").first().fill("5");
+  await page.getByLabel("終了日").first().fill("2026-02-28");
+  await page.getByLabel("支払い元").first().fill("Visa");
+  await page.getByRole("button", { name: "追加" }).click();
+  await waitForReload(page);
+
+  const listCard = page.getByRole("heading", { name: "サブスク一覧" }).locator("../..");
+  const activeTable = listCard.locator("table").first();
+  await expect(activeTable.getByRole("row", { name: /Archived Sub/ })).toHaveCount(0);
+
+  const archivedDetails = page.locator("details").filter({
+    has: page.locator("summary", { hasText: /終了済み/ }),
+  });
+  await expect(archivedDetails).toBeVisible();
+  await archivedDetails.locator("summary").click();
+  await expect(archivedDetails.getByRole("row", { name: /Archived Sub/ })).toBeVisible();
+
+  await archivedDetails.getByRole("button", { name: "編集" }).click();
+  await page.getByRole("dialog").getByLabel("終了日").fill("");
+  await page.getByRole("button", { name: "保存" }).click();
+  await waitForReload(page);
+
+  await expect(activeTable.getByRole("row", { name: /Archived Sub/ })).toBeVisible();
+  await expect(page.locator("details").filter({
+    has: page.locator("summary", { hasText: /終了済み/ }),
+  })).toHaveCount(0);
+});

--- a/packages/frontend/src/components/ArchivedSection.tsx
+++ b/packages/frontend/src/components/ArchivedSection.tsx
@@ -1,0 +1,33 @@
+import { ChevronDown } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function ArchivedSection({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count: number;
+  children: ReactNode;
+}) {
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <div className="border-t border-line pt-4">
+      <details className="group">
+        <summary className="flex w-full cursor-pointer list-none items-center justify-between gap-2 text-sm font-medium text-ink-2 transition hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand">
+          <span>
+            {title} ({count})
+          </span>
+          <ChevronDown
+            aria-hidden="true"
+            className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
+          />
+        </summary>
+        <div className="mt-4 opacity-60">{children}</div>
+      </details>
+    </div>
+  );
+}

--- a/packages/frontend/src/routes/loans.test.ts
+++ b/packages/frontend/src/routes/loans.test.ts
@@ -33,6 +33,16 @@ describe("isEndedLoan", () => {
     const loan = buildLoan({ remainingPayments: 1 });
     expect(isEndedLoan(loan)).toBe(false);
   });
+
+  it("残り残高が 0 以下なら終了", () => {
+    const loan = buildLoan({ remainingBalance: 0, remainingPayments: 3 });
+    expect(isEndedLoan(loan)).toBe(true);
+  });
+
+  it("残り残高が 0 より大きければ現役", () => {
+    const loan = buildLoan({ remainingBalance: 1, remainingPayments: 3 });
+    expect(isEndedLoan(loan)).toBe(false);
+  });
 });
 
 describe("partitionLoans", () => {

--- a/packages/frontend/src/routes/loans.test.ts
+++ b/packages/frontend/src/routes/loans.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { Loan } from "@sui/shared";
+import { isEndedLoan, partitionLoans } from "./loans";
+
+function buildLoan(overrides: Partial<Loan> = {}): Loan {
+  return {
+    id: "11111111-1111-4111-a111-111111111111",
+    name: "Loan",
+    totalAmount: 120000,
+    startDate: "2026-01-05",
+    paymentCount: 12,
+    dateShiftPolicy: "none",
+    paymentMethod: "account_withdrawal",
+    accountId: null,
+    account: null,
+    remainingBalance: 120000,
+    remainingPayments: 12,
+    nextPaymentAmount: 10000,
+    deletedAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("isEndedLoan", () => {
+  it("残り回数が 0 なら終了", () => {
+    const loan = buildLoan({ remainingPayments: 0 });
+    expect(isEndedLoan(loan)).toBe(true);
+  });
+
+  it("残り回数が 1 以上なら現役", () => {
+    const loan = buildLoan({ remainingPayments: 1 });
+    expect(isEndedLoan(loan)).toBe(false);
+  });
+});
+
+describe("partitionLoans", () => {
+  it("現役と終了済みに分離する", () => {
+    const active = buildLoan({ id: "active", remainingPayments: 3 });
+    const ended = buildLoan({ id: "ended", remainingPayments: 0 });
+    const { active: activeLoans, archived } = partitionLoans([active, ended]);
+    expect(activeLoans).toHaveLength(1);
+    expect(activeLoans[0].id).toBe("active");
+    expect(archived).toHaveLength(1);
+    expect(archived[0].id).toBe("ended");
+  });
+});

--- a/packages/frontend/src/routes/loans.tsx
+++ b/packages/frontend/src/routes/loans.tsx
@@ -72,7 +72,7 @@ function getEffectiveTotalAmount(totalAmount: number, remainingBalance: number, 
 }
 
 export function isEndedLoan(loan: Loan): boolean {
-  return loan.remainingPayments === 0;
+  return loan.remainingPayments === 0 || loan.remainingBalance <= 0;
 }
 
 export function partitionLoans(loans: Loan[]): { active: Loan[]; archived: Loan[] } {
@@ -246,9 +246,13 @@ export function LoansPage() {
           <p className="text-sm text-ink-3">ローンが登録されていません。上部の「ローンを追加」から登録してください。</p>
         ) : (
           <>
-            {activeLoans.map((loan) => (
-              <LoanRow key={loan.id} loan={loan} accounts={accounts} onEdit={openEdit} onDelete={requestDelete} />
-            ))}
+            {activeLoans.length === 0 && archivedLoans.length > 0 ? (
+              <p className="text-sm text-ink-3">現役のローンはありません。</p>
+            ) : (
+              activeLoans.map((loan) => (
+                <LoanRow key={loan.id} loan={loan} accounts={accounts} onEdit={openEdit} onDelete={requestDelete} />
+              ))
+            )}
             <ArchivedSection title="終了済み" count={archivedLoans.length}>
               <div className="grid gap-3">
                 {archivedLoans.map((loan) => (

--- a/packages/frontend/src/routes/loans.tsx
+++ b/packages/frontend/src/routes/loans.tsx
@@ -1,6 +1,7 @@
 import type { Account, DateShiftPolicy, Loan, LoanPaymentMethod } from "@sui/shared";
 import { useEffect, useId, useRef, useState, startTransition } from "react";
 import { AccountSelect, DateShiftField } from "../components/form-fields";
+import { ArchivedSection } from "../components/ArchivedSection";
 import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { ConditionalField } from "../components/ui/conditional-field";
@@ -70,6 +71,25 @@ function getEffectiveTotalAmount(totalAmount: number, remainingBalance: number, 
   return midwayMode ? remainingBalance : totalAmount;
 }
 
+export function isEndedLoan(loan: Loan): boolean {
+  return loan.remainingPayments === 0;
+}
+
+export function partitionLoans(loans: Loan[]): { active: Loan[]; archived: Loan[] } {
+  const active: Loan[] = [];
+  const archived: Loan[] = [];
+
+  for (const loan of loans) {
+    if (isEndedLoan(loan)) {
+      archived.push(loan);
+    } else {
+      active.push(loan);
+    }
+  }
+
+  return { active, archived };
+}
+
 function describeError(error: unknown) {
   return error instanceof Error ? error.message : "不明なエラーが発生しました。";
 }
@@ -97,6 +117,7 @@ export function LoansPage() {
   );
 
   const loans = data?.loans ?? [];
+  const { active: activeLoans, archived: archivedLoans } = partitionLoans(loans);
   const accounts = data?.accounts ?? [];
   const canCreate =
     form.name.trim().length > 0 &&
@@ -224,9 +245,18 @@ export function LoansPage() {
         ) : loans.length === 0 ? (
           <p className="text-sm text-ink-3">ローンが登録されていません。上部の「ローンを追加」から登録してください。</p>
         ) : (
-          loans.map((loan) => (
-            <LoanRow key={loan.id} loan={loan} accounts={accounts} onEdit={openEdit} onDelete={requestDelete} />
-          ))
+          <>
+            {activeLoans.map((loan) => (
+              <LoanRow key={loan.id} loan={loan} accounts={accounts} onEdit={openEdit} onDelete={requestDelete} />
+            ))}
+            <ArchivedSection title="終了済み" count={archivedLoans.length}>
+              <div className="grid gap-3">
+                {archivedLoans.map((loan) => (
+                  <LoanRow key={loan.id} loan={loan} accounts={accounts} onEdit={openEdit} onDelete={requestDelete} />
+                ))}
+              </div>
+            </ArchivedSection>
+          </>
         )}
       </Card>
 

--- a/packages/frontend/src/routes/recurring.test.ts
+++ b/packages/frontend/src/routes/recurring.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { formatCurrency } from "../lib/format";
-import { getRecurringFormCurrencyCode, getRecurringItemCurrencyCode } from "./recurring";
+import {
+  getRecurringFormCurrencyCode,
+  getRecurringItemCurrencyCode,
+  isEndedRecurringItem,
+  partitionRecurringItems,
+} from "./recurring";
 
 const accounts = [
   {
@@ -57,6 +62,8 @@ function recurringItemStub(overrides: Partial<{
   name: string;
   type: "income" | "expense" | "transfer";
   amount: number;
+  endDate: string | null;
+  enabled: boolean;
   account: typeof accounts[number] | null;
   transferToAccount: typeof accounts[number] | null;
 }>) {
@@ -163,5 +170,48 @@ describe("固定収支一覧の金額表示", () => {
       account: accountStub({ id: "jpy-account" }),
     });
     expect(formatCurrency(item.amount, getRecurringItemCurrencyCode(item))).toMatch(/[¥￥]100,000/);
+  });
+});
+
+describe("isEndedRecurringItem", () => {
+  const today = "2026-03-14";
+
+  it("終了日が今日なら現役", () => {
+    const item = recurringItemStub({ endDate: "2026-03-14" });
+    expect(isEndedRecurringItem(item, today)).toBe(false);
+  });
+
+  it("終了日が昨日なら終了", () => {
+    const item = recurringItemStub({ endDate: "2026-03-13" });
+    expect(isEndedRecurringItem(item, today)).toBe(true);
+  });
+
+  it("終了日が未設定なら現役", () => {
+    const item = recurringItemStub({ endDate: null });
+    expect(isEndedRecurringItem(item, today)).toBe(false);
+  });
+
+  it("無効でも終了日未設定なら現役", () => {
+    const item = recurringItemStub({ endDate: null, enabled: false });
+    expect(isEndedRecurringItem(item, today)).toBe(false);
+  });
+
+  it("無効かつ終了日超過なら終了", () => {
+    const item = recurringItemStub({ endDate: "2026-03-13", enabled: false });
+    expect(isEndedRecurringItem(item, today)).toBe(true);
+  });
+});
+
+describe("partitionRecurringItems", () => {
+  const today = "2026-03-14";
+
+  it("現役と終了済みに分離する", () => {
+    const active = recurringItemStub({ id: "active", endDate: null });
+    const ended = recurringItemStub({ id: "ended", endDate: "2026-03-13" });
+    const { active: activeItems, archived } = partitionRecurringItems([active, ended], today);
+    expect(activeItems).toHaveLength(1);
+    expect(activeItems[0].id).toBe("active");
+    expect(archived).toHaveLength(1);
+    expect(archived[0].id).toBe("ended");
   });
 });

--- a/packages/frontend/src/routes/recurring.tsx
+++ b/packages/frontend/src/routes/recurring.tsx
@@ -2,6 +2,7 @@ import { DEFAULT_CURRENCY_CODE, formatSchedule } from "@sui/shared";
 import type { Account, DateShiftPolicy, Recurrence, RecurringItem, RecurringItemType, SupportedCurrencyCode } from "@sui/shared";
 import { useEffect, useId, useRef, useState, startTransition } from "react";
 import { ScheduleField } from "../components/ScheduleField";
+import { ArchivedSection } from "../components/ArchivedSection";
 import { AccountSelect, DateShiftField, PeriodFields } from "../components/form-fields";
 import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
@@ -18,6 +19,7 @@ import { useResource } from "../hooks/use-resource";
 import { useToast } from "../hooks/use-toast";
 import { apiFetch } from "../lib/api";
 import { formatCurrency, formatDateWithYear } from "../lib/format";
+import { getTodayDate } from "../lib/utils";
 import { Pencil, Trash2 } from "lucide-react";
 
 export type RecurringForm = {
@@ -242,6 +244,30 @@ export function getRecurringFormCurrencyCode(
   return account?.currencyCode ?? DEFAULT_CURRENCY_CODE;
 }
 
+const today = getTodayDate();
+
+export function isEndedRecurringItem(item: RecurringItem, referenceDate: string): boolean {
+  return item.endDate !== null && item.endDate < referenceDate;
+}
+
+export function partitionRecurringItems(
+  items: RecurringItem[],
+  referenceDate: string,
+): { active: RecurringItem[]; archived: RecurringItem[] } {
+  const active: RecurringItem[] = [];
+  const archived: RecurringItem[] = [];
+
+  for (const item of items) {
+    if (isEndedRecurringItem(item, referenceDate)) {
+      archived.push(item);
+    } else {
+      active.push(item);
+    }
+  }
+
+  return { active, archived };
+}
+
 function describeError(error: unknown) {
   return error instanceof Error ? error.message : "不明なエラーが発生しました。";
 }
@@ -265,6 +291,10 @@ export function RecurringPage() {
 
   const reload = () => startTransition(() => setReloadKey((value) => value + 1));
   const accounts = data?.accounts ?? [];
+  const { active: activeItems, archived: archivedItems } = partitionRecurringItems(
+    data?.items ?? [],
+    today,
+  );
   const canCreate = canSaveRecurringForm(form, accounts);
   const canSaveEdit = canSaveRecurringForm(editForm, accounts);
 
@@ -378,6 +408,29 @@ export function RecurringPage() {
     },
   ];
 
+  const renderRecurringMobileRow = (item: RecurringItem) => (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate font-medium">{item.name}</div>
+          <div className="text-xs text-ink-3">{getRecurringTypeLabel(item.type)}・{formatRecurringSchedule(item)}</div>
+        </div>
+        <div className="font-data text-base font-semibold">{formatCurrency(item.amount, getRecurringItemCurrencyCode(item))}</div>
+      </div>
+      <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
+        <span>{formatRecurringAccounts(item)}・{item.enabled ? "有効" : "無効"}</span>
+        <div className="flex gap-1">
+          <IconButton aria-label="編集" onClick={() => openEdit(item)}>
+            <Pencil aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+          <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(item)}>
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <div className="grid gap-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -399,34 +452,27 @@ export function RecurringPage() {
         {error ? (
           <ErrorBlock message={error} onRetry={reload} />
         ) : (
-          <ResponsiveTable
-            columns={columns}
-            rows={data?.items ?? []}
-            rowKey={(item) => item.id}
-            emptyMessage="固定収支が登録されていません。上部の「固定収支を追加」から登録してください。"
-            mobileRow={(item) => (
-              <>
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate font-medium">{item.name}</div>
-                    <div className="text-xs text-ink-3">{getRecurringTypeLabel(item.type)}・{formatRecurringSchedule(item)}</div>
-                  </div>
-                  <div className="font-data text-base font-semibold">{formatCurrency(item.amount, getRecurringItemCurrencyCode(item))}</div>
-                </div>
-                <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
-                  <span>{formatRecurringAccounts(item)}・{item.enabled ? "有効" : "無効"}</span>
-                  <div className="flex gap-1">
-                    <IconButton aria-label="編集" onClick={() => openEdit(item)}>
-                      <Pencil aria-hidden="true" className="h-4 w-4" />
-                    </IconButton>
-                    <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(item)}>
-                      <Trash2 aria-hidden="true" className="h-4 w-4" />
-                    </IconButton>
-                  </div>
-                </div>
-              </>
-            )}
-          />
+          <>
+            <ResponsiveTable
+              columns={columns}
+              rows={activeItems}
+              rowKey={(item) => item.id}
+              emptyMessage={
+                activeItems.length === 0 && archivedItems.length > 0
+                  ? "現役の固定収支はありません。"
+                  : "固定収支が登録されていません。上部の「固定収支を追加」から登録してください。"
+              }
+              mobileRow={renderRecurringMobileRow}
+            />
+            <ArchivedSection title="終了済み" count={archivedItems.length}>
+              <ResponsiveTable
+                columns={columns}
+                rows={archivedItems}
+                rowKey={(item) => item.id}
+                mobileRow={renderRecurringMobileRow}
+              />
+            </ArchivedSection>
+          </>
         )}
       </Card>
 

--- a/packages/frontend/src/routes/subscriptions.test.ts
+++ b/packages/frontend/src/routes/subscriptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatCurrency } from "../lib/format";
-import { getAnnualTotal, getMonthlySummary } from "./subscriptions";
+import { getAnnualTotal, getMonthlySummary, isEndedSubscription, partitionSubscriptions } from "./subscriptions";
 import type { Subscription } from "@sui/shared";
 
 function buildSubscription(overrides: Partial<Subscription> = {}): Subscription {
@@ -84,5 +84,38 @@ describe("getAnnualTotal", () => {
     });
 
     expect(getAnnualTotal([usd, jpy], 2026)).toBe(1649 * 12 + 1000 * 12);
+  });
+});
+
+describe("isEndedSubscription", () => {
+  const today = "2026-03-14";
+
+  it("終了日が今日なら現役", () => {
+    const subscription = buildSubscription({ endDate: "2026-03-14" });
+    expect(isEndedSubscription(subscription, today)).toBe(false);
+  });
+
+  it("終了日が昨日なら終了", () => {
+    const subscription = buildSubscription({ endDate: "2026-03-13" });
+    expect(isEndedSubscription(subscription, today)).toBe(true);
+  });
+
+  it("終了日が未設定なら現役", () => {
+    const subscription = buildSubscription({ endDate: null });
+    expect(isEndedSubscription(subscription, today)).toBe(false);
+  });
+});
+
+describe("partitionSubscriptions", () => {
+  const today = "2026-03-14";
+
+  it("現役と終了済みに分離する", () => {
+    const active = buildSubscription({ id: "active", endDate: null });
+    const ended = buildSubscription({ id: "ended", endDate: "2026-03-13" });
+    const { active: activeItems, archived } = partitionSubscriptions([active, ended], today);
+    expect(activeItems).toHaveLength(1);
+    expect(activeItems[0].id).toBe("active");
+    expect(archived).toHaveLength(1);
+    expect(archived[0].id).toBe("ended");
   });
 });

--- a/packages/frontend/src/routes/subscriptions.tsx
+++ b/packages/frontend/src/routes/subscriptions.tsx
@@ -9,6 +9,7 @@ import type {
 import { convertMinorUnitToJpy, formatSchedule, SUPPORTED_CURRENCY_CODES } from "@sui/shared";
 import { useEffect, useId, useRef, useState, startTransition } from "react";
 import { ScheduleField } from "../components/ScheduleField";
+import { ArchivedSection } from "../components/ArchivedSection";
 import { Button, IconButton } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { ConditionalField } from "../components/ui/conditional-field";
@@ -150,6 +151,28 @@ function formatYearMonth(yearMonth: string) {
   }).format(new Date(`${yearMonth}-01T00:00:00+09:00`));
 }
 
+export function isEndedSubscription(subscription: Subscription, referenceDate: string): boolean {
+  return subscription.endDate !== null && subscription.endDate < referenceDate;
+}
+
+export function partitionSubscriptions(
+  subscriptions: Subscription[],
+  referenceDate: string,
+): { active: Subscription[]; archived: Subscription[] } {
+  const active: Subscription[] = [];
+  const archived: Subscription[] = [];
+
+  for (const subscription of subscriptions) {
+    if (isEndedSubscription(subscription, referenceDate)) {
+      archived.push(subscription);
+    } else {
+      active.push(subscription);
+    }
+  }
+
+  return { active, archived };
+}
+
 function getPaymentSourceOptions(accounts: Account[], cards: CreditCard[]) {
   return Array.from(
     new Set([...cards.map((card) => card.name), ...accounts.map((account) => account.name)].filter(Boolean)),
@@ -182,6 +205,10 @@ export function SubscriptionsPage() {
 
   const reload = () => startTransition(() => setReloadKey((value) => value + 1));
   const subscriptions = data?.subscriptions ?? [];
+  const { active: activeSubscriptions, archived: archivedSubscriptions } = partitionSubscriptions(
+    subscriptions,
+    today,
+  );
   const paymentSources = getPaymentSourceOptions(data?.accounts ?? [], data?.cards ?? []);
   const monthlySummary = getMonthlySummary(subscriptions, yearMonth);
   const annualTotal = getAnnualTotal(subscriptions, Number(yearMonth.slice(0, 4)));
@@ -324,6 +351,29 @@ export function SubscriptionsPage() {
     },
   ];
 
+  const renderSubscriptionMobileRow = (subscription: Subscription) => (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate font-medium">{subscription.name}</div>
+          <div className="text-xs text-ink-3">{formatSubscriptionSchedule(subscription)}</div>
+        </div>
+        <div className="font-data text-base font-semibold">{formatCurrency(subscription.amount, subscription.currencyCode)}</div>
+      </div>
+      <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
+        <span>{subscription.paymentSource ?? "未設定"}</span>
+        <div className="flex gap-1">
+          <IconButton aria-label="編集" onClick={() => openEdit(subscription)}>
+            <Pencil aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+          <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(subscription)}>
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </IconButton>
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <div className="grid gap-6">
       <datalist id="subscription-payment-sources">
@@ -417,34 +467,27 @@ export function SubscriptionsPage() {
         {error ? (
           <ErrorBlock message={error} onRetry={reload} />
         ) : (
-          <ResponsiveTable
-            columns={columns}
-            rows={subscriptions}
-            rowKey={(subscription) => subscription.id}
-            emptyMessage="サブスクが登録されていません。上部の「サブスクを追加」から登録してください。"
-            mobileRow={(subscription) => (
-              <>
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate font-medium">{subscription.name}</div>
-                    <div className="text-xs text-ink-3">{formatSubscriptionSchedule(subscription)}</div>
-                  </div>
-                  <div className="font-data text-base font-semibold">{formatCurrency(subscription.amount, subscription.currencyCode)}</div>
-                </div>
-                <div className="flex items-center justify-between gap-3 text-xs text-ink-3">
-                  <span>{subscription.paymentSource ?? "未設定"}</span>
-                  <div className="flex gap-1">
-                    <IconButton aria-label="編集" onClick={() => openEdit(subscription)}>
-                      <Pencil aria-hidden="true" className="h-4 w-4" />
-                    </IconButton>
-                    <IconButton aria-label="削除" variant="danger" onClick={() => requestDelete(subscription)}>
-                      <Trash2 aria-hidden="true" className="h-4 w-4" />
-                    </IconButton>
-                  </div>
-                </div>
-              </>
-            )}
-          />
+          <>
+            <ResponsiveTable
+              columns={columns}
+              rows={activeSubscriptions}
+              rowKey={(subscription) => subscription.id}
+              emptyMessage={
+                activeSubscriptions.length === 0 && archivedSubscriptions.length > 0
+                  ? "現役のサブスクはありません。"
+                  : "サブスクが登録されていません。上部の「サブスクを追加」から登録してください。"
+              }
+              mobileRow={renderSubscriptionMobileRow}
+            />
+            <ArchivedSection title="終了済み" count={archivedSubscriptions.length}>
+              <ResponsiveTable
+                columns={columns}
+                rows={archivedSubscriptions}
+                rowKey={(subscription) => subscription.id}
+                mobileRow={renderSubscriptionMobileRow}
+              />
+            </ArchivedSection>
+          </>
         )}
       </Card>
 


### PR DESCRIPTION
## 概要

固定収支・サブスク・ローンの一覧で、終了済みの項目を「終了済み (N)」折りたたみセクションに分離します。

## 変更内容

- 固定収支・サブスクは `endDate !== null && endDate < today` で終了判定
- ローンは `remainingPayments === 0` で終了判定
- `routes/recurring.tsx` / `subscriptions.tsx` / `loans.tsx` に純粋関数として `isEnded*` / `partition*` を追加
- 3 画面の一覧下部に `<details>` ベースの `ArchivedSection` コンポーネントを追加
- 終了済み行は `opacity-60` で淡色表示し、編集・削除をそのまま利用可能
- 終了済み 0 件のときはセクション自体を表示しない
- サブスクの月合計・年間合計は既存の `getMonthlySummary` / `getAnnualTotal` のまま変更しない
- `recurring.test.ts` / `subscriptions.test.ts` に終了判定の境界テストを追加
- `loans.test.ts` を新規作成し `isEndedLoan` のテストを追加
- `e2e/subscriptions.spec.ts` に終了日が過去のサブスクを作成 → アーカイブ → 終了日をクリアして現役に戻るテストを追加

## 検証

- `make typecheck` パス
- `make lint` パス
- `make test-unit` パス（frontend tests 含む全テストパス）
- `make test-e2e` パス（78 tests passed）

Closes #368

Generated with [Devin](https://devin.ai)