### PR TITLE
docs: OIDC リダイレクト URI と OTLP エンドポイントの設定値を明記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ bash scripts/seed.sh all      # phase1 から順に全部
 | `PORT` | バックエンドのポート | `3000` |
 | `SUI_AUTH_MODE` | 認証モード（`enabled` / `disabled`） | `enabled` |
 | `SUI_OIDC_ISSUER` ほか `SUI_OIDC_*` | OIDC の issuer、クライアント、許可する利用者 | 未設定 |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | トレースの送信先。未設定ならトレース計装を起動しない | 未設定 |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | トレースの送信先。`http://collector:4318` のようにパスなしのベース URL で書く。未設定ならトレース計装を起動しない | 未設定 |
 
 全項目は [設定と環境変数](docs/operations/configuration.md) にあります。
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -21,6 +21,11 @@ timestamp: 2026-07-26T00:00:00+09:00
 未設定なら計装ごと動かない。
 `OTEL_SERVICE_NAME` の既定は `sui-backend` である。
 
+設定するのはどちらか一方でよい。
+アプリ側はこの二つを起動の可否にしか使っておらず、送信先の解決は引数なしで生成した `OTLPTraceExporter` に委ねている。
+SDK は `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` を優先し、こちらはそのまま、`OTEL_EXPORTER_OTLP_ENDPOINT` には `/v1/traces` を追記して使う。
+前者にはパスまで、後者にはパスなしのベース URL を書く（[設定と環境変数](../operations/configuration.md)）。
+
 自動計装として入れているのは Prisma だけで、HTTP 側は `/api/*` のミドルウェアで自前にスパンを張っている。
 ESM で読み込むと HTTP の自動計装が効かなかったためである。
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -88,5 +88,12 @@ timestamp: 2026-07-26T00:00:00+09:00
 `SUI_OIDC_ISSUER`、`SUI_OIDC_CLIENT_ID`、`SUI_OIDC_REDIRECT_URI` と、許可する `sub` かメールアドレスのいずれかが要る。
 一つでも欠けると未構成として扱われ、ログインできない（[設定と環境変数](../operations/configuration.md)）。
 
+`SUI_OIDC_REDIRECT_URI` は `https://sui.example.com/api/auth/callback` のような絶対 URL で書く。
+パスの `/api/auth/callback` は固定で、前に付けるのは公開している URL のスキームとホストである。
+同じ値を IdP 側にもリダイレクト URI として登録する。
+
+`SUI_OIDC_CLIENT_SECRET` は confidential client のときだけ設定する。
+シークレットを持たない public client では PKCE だけで完結するため、設定しなくてよい。
+
 MCP クライアントから使う場合は、「設定」で API トークンを発行する。
 読み取り専用のトークンも発行できる。

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -54,9 +54,21 @@ IdP で認証できる利用者が素通りする状態を既定にしないた�
 
 | 変数名 | 説明 | 既定 |
 |--------|------|------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP の送信先。未設定なら計装を起動しない | 未設定 |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | トレース専用の送信先。設定時はこちらを優先 | 未設定 |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP のベース URL。`http://collector:4318` のようにパスなしで書き、`/v1/traces` は付けない | 未設定 |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | トレース専用の送信先。`http://collector:4318/v1/traces` のようにパスまで含めて書く | 未設定 |
 | `OTEL_SERVICE_NAME` | サービス名 | `sui-backend` |
+
+この二つは**どちらか一方だけ**を設定する。
+両方が設定されている場合は `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` が使われ、`OTEL_EXPORTER_OTLP_ENDPOINT` は読まれない。
+どちらも未設定なら計装そのものを起動しない。
+
+二つの違いは、パスを補完するかどうかである。
+`OTEL_EXPORTER_OTLP_ENDPOINT` は SDK が末尾に `/v1/traces` を追記するため、ベース URL を書く。
+ここにパスまで書くと送信先が `http://collector:4318/v1/traces/v1/traces` になり、送信は失敗する。
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` は補完せずそのまま使うため、`/v1/traces` を自分で書く。
+
+コレクタが標準のパスで受けるなら `OTEL_EXPORTER_OTLP_ENDPOINT` だけでよい。
+トレースを別の送信先や非標準のパスへ送るときに `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` を使う。
 
 # 関連
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -24,7 +24,7 @@ timestamp: 2026-07-26T00:00:00+09:00
 | `SUI_OIDC_ISSUER` | IdP の issuer URL | 未設定 |
 | `SUI_OIDC_CLIENT_ID` | クライアント ID | 未設定 |
 | `SUI_OIDC_CLIENT_SECRET` | クライアントシークレット。confidential client のときだけ設定する | 未設定 |
-| `SUI_OIDC_REDIRECT_URI` | コールバック URL（`/api/auth/callback`） | 未設定 |
+| `SUI_OIDC_REDIRECT_URI` | コールバック URL。`https://sui.example.com/api/auth/callback` のようにスキームとホストを含む絶対 URL で書き、IdP に登録した値と完全に一致させる | 未設定 |
 | `SUI_OIDC_ALLOWED_SUBJECTS` | 許可する `sub` のカンマ区切り | 未設定 |
 | `SUI_OIDC_ALLOWED_EMAILS` | 許可するメールアドレスのカンマ区切り | 未設定 |
 | `SUI_COOKIE_SECURE` | セッション Cookie に `Secure` を強制する | `x-forwarded-proto` で自動判定 |
@@ -35,6 +35,10 @@ timestamp: 2026-07-26T00:00:00+09:00
 どちらも空だと OIDC 設定そのものが未構成として扱われ、ログインできない。
 IdP で認証できる利用者が素通りする状態を既定にしないための扱いである。
 `SUI_OIDC_ISSUER`、`SUI_OIDC_CLIENT_ID`、`SUI_OIDC_REDIRECT_URI` も同様に、欠けていれば未構成になる。
+
+`SUI_OIDC_REDIRECT_URI` のパス部分は `/api/auth/callback` で固定である。
+ここにパスだけを書くと、未構成にはならずログインの開始までは通り、コールバックの検証だけが失敗する。
+公開している URL のスキームとホストを必ず前に付ける。
 
 `SUI_AUTH_MODE=disabled` の意味は [認証と信頼境界](../architecture/authentication.md) を参照。
 

--- a/packages/frontend/src/routes/login.tsx
+++ b/packages/frontend/src/routes/login.tsx
@@ -27,14 +27,14 @@ export function LoginPage() {
     if (configured) return null;
     return (
       <div className="mt-4 text-sm text-ink-2">
-        <p>バックエンドに OIDC 設定が未完了です。</p>
+        <p>バックエンドに OIDC 設定が未完了です。次の環境変数がすべて要ります。</p>
         <ul className="mt-2 list-disc pl-5">
           <li>SUI_OIDC_ISSUER</li>
           <li>SUI_OIDC_CLIENT_ID</li>
-          <li>SUI_OIDC_CLIENT_SECRET</li>
-          <li>SUI_OIDC_REDIRECT_URI</li>
+          <li>SUI_OIDC_REDIRECT_URI（例: https://sui.example.com/api/auth/callback）</li>
           <li>SUI_OIDC_ALLOWED_SUBJECTS または SUI_OIDC_ALLOWED_EMAILS</li>
         </ul>
+        <p className="mt-2">SUI_OIDC_CLIENT_SECRET は confidential client のときだけ設定します。</p>
       </div>
     );
   }, [configured, error]);


### PR DESCRIPTION
設定値の形が読み取れず、設定しても動かない・不要なものを設定してしまう箇所を二つ直す。どちらもドキュメントと画面表示のみで、挙動は変えていない。

## 1. `SUI_OIDC_REDIRECT_URI`

説明が「コールバック URL（`/api/auth/callback`）」となっており、パスだけを設定する値のように読めた。実際には絶対 URL が要る。

- `packages/backend/src/lib/oidc.ts:99` — authorize URL の `redirect_uri` にそのまま載るため、IdP に登録した値と文字列一致する必要がある
- `packages/backend/src/lib/oidc.ts:142` — コールバック検証で `new URL(oidc.redirectUri)` に渡すため、パスだけだと `Invalid URL` になる

パスだけを設定しても未構成にはならないので、ログインの開始までは通り、コールバックだけが `oidc_callback_failed` で失敗する。気づきにくい詰まり方をする。

あわせて、ログイン画面の未構成リストから `SUI_OIDC_CLIENT_SECRET` をリスト外に降ろした。`oidc.ts:29` の必須判定に入っておらず、public client では不要なため。

## 2. `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`

表に二つ並んでいるだけで、両方要るようにも読めた。実際は一方だけでよい。

`packages/backend/src/otel.ts` はこの二つを起動の可否にしか使っておらず、送信先の解決は引数なしで生成した `OTLPTraceExporter` に委ねている。SDK 側（`otlp-exporter-base` の `otlp-node-http-env-configuration.js:111`）は `getSpecificUrlFromEnv(...) ?? getNonSpecificUrlFromEnv(...)` で、TRACES 側が取れれば ENDPOINT 側は読まない。

二つの違いはパスの補完にある。

- `OTEL_EXPORTER_OTLP_ENDPOINT` — SDK が末尾に `/v1/traces` を追記する。ベース URL を書く
- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` — 補完せずそのまま使う。パスまで書く

前者にパスまで書くと送信先が `http://collector:4318/v1/traces/v1/traces` になり、送信が失敗する。

## 変更ファイル

- `docs/operations/configuration.md` — 両方の表の説明と、それぞれの補足
- `docs/guides/getting-started.md` — リダイレクト URI の例、IdP 側への登録、`SUI_OIDC_CLIENT_SECRET` が confidential client 専用である旨
- `docs/architecture/observability.md` — 一方だけでよい理由と優先順位
- `README.md` — `OTEL_EXPORTER_OTLP_ENDPOINT` がパスなしのベース URL であること
- `packages/frontend/src/routes/login.tsx` — 未構成時のリストの整理と例の併記

🤖 Generated with [Claude Code](https://claude.com/claude-code)