### PR TITLE
MCPの口座一覧にaccount UUIDを追加

### DIFF
--- a/packages/backend/src/mcp/__tests__/format.test.ts
+++ b/packages/backend/src/mcp/__tests__/format.test.ts
@@ -317,6 +317,31 @@ describe("formatters", () => {
     expect(destinationText).not.toMatch(rawJsonKeyPattern);
   });
 
+  it("formats accounts with id on the same line and preserves empty state", () => {
+    const account = {
+      id: "account-1",
+      name: "Main",
+      balance: 123456,
+      balanceOffset: 1000,
+      lastReconciledAt: null,
+      currencyCode: "JPY" as const,
+      exchangeRateToJpy: 1,
+      exchangeRateUpdatedAt: "2026-03-01T00:00:00.000Z",
+      sortOrder: 1,
+      deletedAt: null,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    };
+
+    const text = formatAccountsText([account] as AccountsResponse);
+
+    expect(text).toContain("口座一覧: 1件");
+    expect(text).toContain("Main [id: account-1]: 残高 ￥123,456 / オフセット ￥1,000 / 並び順 1");
+    expect(text).not.toMatch(rawJsonKeyPattern);
+
+    expect(formatAccountsText([])).toBe("口座一覧: 0件\n  ありません");
+  });
+
   it("formats list-style API responses without raw JSON", () => {
     const account = {
       id: "account-1",

--- a/packages/backend/src/mcp/__tests__/server.test.ts
+++ b/packages/backend/src/mcp/__tests__/server.test.ts
@@ -1170,6 +1170,61 @@ describe("MCP server", () => {
     });
   });
 
+  it("lists accounts with id on the same line and structured content", async () => {
+    const result = await client.callTool({
+      name: "list_accounts",
+      arguments: {},
+    });
+
+    const text = getToolText(result);
+    expect(text).toContain("口座一覧: 1件");
+    expect(text).toContain("Main [id: 11111111-1111-4111-a111-111111111111]:");
+
+    const structured = getStructuredContent(result);
+    expect(structured).toMatchObject({
+      accounts: [{ id: "11111111-1111-4111-a111-111111111111", name: "Main" }],
+    });
+  });
+
+  it("list_accounts keeps empty state and returns empty structured accounts", async () => {
+    addRoute("GET", "/api/accounts", {
+      body: [],
+    });
+
+    const result = await client.callTool({
+      name: "list_accounts",
+      arguments: {},
+    });
+
+    expect(getToolText(result)).toBe("口座一覧: 0件\n  ありません");
+    expect(getStructuredContent(result)).toMatchObject({ accounts: [] });
+  });
+
+  it("exposes list_accounts output and account id parameter descriptions", async () => {
+    const tools = await client.listTools();
+
+    const listTool = tools.tools.find((tool) => tool.name === "list_accounts");
+    expect(listTool?.description).toContain("ID");
+
+    const updateTool = tools.tools.find((tool) => tool.name === "update_account");
+    const updateSchema = updateTool?.inputSchema as
+      | { properties?: { id?: { description?: string } } }
+      | undefined;
+    expect(updateSchema?.properties?.id?.description).toContain("list_accounts");
+
+    const reconcileTool = tools.tools.find((tool) => tool.name === "reconcile_account");
+    const reconcileSchema = reconcileTool?.inputSchema as
+      | { properties?: { accountId?: { description?: string } } }
+      | undefined;
+    expect(reconcileSchema?.properties?.accountId?.description).toContain("list_accounts");
+
+    const deleteTool = tools.tools.find((tool) => tool.name === "delete_account");
+    const deleteSchema = deleteTool?.inputSchema as
+      | { properties?: { id?: { description?: string } } }
+      | undefined;
+    expect(deleteSchema?.properties?.id?.description).toContain("list_accounts");
+  });
+
   it("lists recent changes from audit logs", async () => {
     const result = await client.callTool({
       name: "list_recent_changes",

--- a/packages/backend/src/mcp/format.ts
+++ b/packages/backend/src/mcp/format.ts
@@ -320,7 +320,7 @@ export function formatAccountsText(accounts: AccountsResponse) {
   return [
     `口座一覧: ${accounts.length}件`,
     ...accounts.map((account) =>
-      `  ${account.name}: 残高 ${formatCurrency(account.balance, account.currencyCode)} / オフセット ${formatCurrency(account.balanceOffset, account.currencyCode)} / 並び順 ${account.sortOrder}`
+      `  ${account.name} [id: ${account.id}]: 残高 ${formatCurrency(account.balance, account.currencyCode)} / オフセット ${formatCurrency(account.balanceOffset, account.currencyCode)} / 並び順 ${account.sortOrder}`
     ),
   ].join("\n");
 }

--- a/packages/backend/src/mcp/helpers.ts
+++ b/packages/backend/src/mcp/helpers.ts
@@ -26,10 +26,19 @@ export const createToolAnnotations = { destructiveHint: false, idempotentHint: f
 export const updateToolAnnotations = { destructiveHint: false, idempotentHint: false };
 export const deleteToolAnnotations = { destructiveHint: true, idempotentHint: false };
 
-export function textContent(text: string) {
-  return {
+export function textContent(text: string, structuredContent?: Record<string, unknown>) {
+  const result: {
+    content: Array<{ type: "text"; text: string }>;
+    structuredContent?: Record<string, unknown>;
+  } = {
     content: [{ type: "text" as const, text }],
   };
+
+  if (structuredContent) {
+    result.structuredContent = structuredContent;
+  }
+
+  return result;
 }
 
 export function formatDeletePreview(label: string, id: string, summary: string | null) {

--- a/packages/backend/src/mcp/tools/accounts.ts
+++ b/packages/backend/src/mcp/tools/accounts.ts
@@ -35,9 +35,9 @@ const accountPayload = {
 };
 
 export function registerAccountTools(server: McpServer, apiClient: SuiApiClient) {
-  server.tool("list_accounts", "口座一覧を取得する", {}, readOnlyToolAnnotations, async () => {
+  server.tool("list_accounts", "口座名、ID、残高等を取得する", {}, readOnlyToolAnnotations, async () => {
     const data = await apiClient.get<AccountsResponse>("/api/accounts");
-    return textContent(formatAccountsText(data));
+    return textContent(formatAccountsText(data), { accounts: data });
   });
 
   server.tool("create_account", "口座を作成する", accountPayload, createToolAnnotations, async (args) => {
@@ -49,7 +49,7 @@ export function registerAccountTools(server: McpServer, apiClient: SuiApiClient)
     "update_account",
     "口座を更新する。balance を変更した差分は調整取引として記録される",
     {
-      id: uuidSchema.describe("口座 ID"),
+      id: uuidSchema.describe("口座 ID。list_accounts で確認できる"),
       ...accountPayload,
     },
     updateToolAnnotations,
@@ -63,7 +63,7 @@ export function registerAccountTools(server: McpServer, apiClient: SuiApiClient)
     "reconcile_account",
     "口座の実残高を入力して照合する。差分は adjustment 取引として記録され、残高履歴を遡及的に書き換えない",
     {
-      accountId: uuidSchema.describe("口座 ID"),
+      accountId: uuidSchema.describe("口座 ID。list_accounts で確認できる"),
       actualBalance: moneySchema.describe("実残高（通貨の最小単位）"),
     },
     updateToolAnnotations,
@@ -84,7 +84,7 @@ export function registerAccountTools(server: McpServer, apiClient: SuiApiClient)
     "delete_account",
     "口座を削除する。confirm が true でない場合は API の DELETE を呼ばず、対象口座の要約と再実行案内だけを返す。confirm: true の場合のみ削除を実行する",
     {
-      id: uuidSchema.describe("口座 ID"),
+      id: uuidSchema.describe("口座 ID。list_accounts で確認できる"),
       confirm: confirmDeleteSchema,
     },
     deleteToolAnnotations,


### PR DESCRIPTION
Closes #423

## 変更内容

- MCP の `list_accounts` テキスト出力へ口座 UUID を追加
- structured content でも口座 ID を安定して返すよう整備
- formatter と MCP server の回帰テストを追加

## 目的

MCP クライアントが同名口座を表示名だけで識別せず、後続ツールへ正しい account UUID を渡せるようにします。

## 検証

- `make lint`
- `make typecheck`
- `make test-unit`（246 tests passed）
- `make test-integration`（186 tests passed）
