### PR TITLE
テスト用Composeネットワークを分離

### DIFF
--- a/compose_db.yaml
+++ b/compose_db.yaml
@@ -10,3 +10,7 @@ services:
       TZ: Asia/Tokyo
     tmpfs:
       - /var/lib/postgresql
+
+networks:
+  default:
+    name: sui-test

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -21,6 +21,11 @@ pnpm dev
 フロントエンドは 5173、バックエンドは 3000 で立つ。
 開発サーバーは `/api` へのリクエストをバックエンドにプロキシする。
 
+## テスト用 DB
+
+テスト用 DB は `compose_db.yaml` で起動し、`sui-test` という専用 Docker network に接続する。
+これにより、ローカル動作確認用 `compose.yaml` の `db` / `app` とネットワークが分離され、`make test-db-up` / `make test-db-down` や `make test-integration` / `make test-e2e` の停止処理がローカル環境に干渉しない。
+
 # シードデータ
 
 `scripts/seed.sh` はフェーズごとに投入する。


### PR DESCRIPTION
Closes #425

## 変更内容

- テスト用 Docker Compose に外部名 `sui-test` の専用 network を定義
- 開発ドキュメントにテストネットワークの分離方針を追記

## 目的

worktree ごとに Compose の project 名が変わっても、テストDBが意図した専用ネットワークを使い、本番・開発用ネットワークへ誤接続しないようにします。

## 検証

- `make lint`
- `make test-integration`（186 tests passed）
- 実行時に `sui-test` network の作成・削除を確認
