### PR TITLE
監査ログを確認できるWeb UIを追加

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -77,6 +77,14 @@ pino の `mixin` で、有効なスパンがあるときだけ `trace_id`、`spa
 
 `audit_logs` は `GET /api/export` のエクスポート対象外である。
 
+## 確認方法
+
+監査ログは以下の 3 経路から読める。
+
+- **Web UI**: 認証済みのブラウザで `/audit-logs` からページネーション付きで閲覧する。
+- **HTTP API**: `GET /api/audit-logs?page=&limit=` で取得する（`limit` の既定は 50、最大 100）。
+- **MCP**: `list_recent_changes` ツールで直近の変更を一覧する（[MCP エンドポイント](./mcp-endpoint.md)）。
+
 # 関連
 
 - [認証と信頼境界](./authentication.md)

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "./components/ui/toast";
 import { useToast } from "./hooks/use-toast";
 import { useAuth } from "./lib/auth";
 import { AccountsPage } from "./routes/accounts";
+import { AuditLogsPage } from "./routes/audit-logs";
 import { CreditCardsPage } from "./routes/credit-cards";
 import { DataManagementPage } from "./routes/data-management";
 import { DashboardPage } from "./routes/dashboard";
@@ -52,6 +53,7 @@ export function App() {
           <Route path="/splits" element={<SplitsPage />} />
           <Route path="/data" element={<DataManagementPage />} />
           <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/audit-logs" element={<AuditLogsPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </AppLayout>

--- a/packages/frontend/src/components/layout.tsx
+++ b/packages/frontend/src/components/layout.tsx
@@ -7,6 +7,7 @@ import { apiFetch } from "../lib/api";
 import { cn } from "../lib/utils";
 import {
   BarChart3,
+  FileText,
   Landmark,
   LayoutGrid,
   ListChecks,
@@ -43,6 +44,7 @@ const navGroups: NavGroup[] = [
     items: [
       { to: "/data", label: "データ管理", icon: Settings },
       { to: "/settings", label: "設定", icon: Settings },
+      { to: "/audit-logs", label: "監査ログ", icon: FileText },
     ],
     muted: true,
   },

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -151,6 +151,28 @@ export function formatDate(value: string) {
   }).format(new Date(`${value}T00:00:00+09:00`));
 }
 
+export function formatDateTime(value: string | null | undefined): string {
+  if (value == null) {
+    return "-";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("ja-JP", {
+    timeZone: JAPAN_TIME_ZONE,
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
 export function formatDateWithYear(value: string) {
   return new Intl.DateTimeFormat("ja-JP", {
     timeZone: JAPAN_TIME_ZONE,

--- a/packages/frontend/src/routes/audit-logs.test.tsx
+++ b/packages/frontend/src/routes/audit-logs.test.tsx
@@ -1,0 +1,322 @@
+import type { AuditLogEntry, AuditLogsResponse } from "@sui/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AppLayout } from "../components/layout";
+import { AuditLogsPage } from "./audit-logs";
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function mockFetchWith(handler: (url: string) => Promise<unknown>) {
+  globalThis.fetch = vi.fn().mockImplementation((url: string) => handler(url));
+}
+
+function createAuditLogEntry(overrides: Partial<AuditLogEntry> = {}): AuditLogEntry {
+  return {
+    id: "11111111-1111-4111-a111-111111111111",
+    createdAt: "2026-07-01T09:00:00.000Z",
+    method: "POST",
+    path: "/api/accounts",
+    status: 201,
+    clientSource: "web",
+    requestId: "req-1",
+    authKind: "session",
+    subject: "user-1",
+    sessionId: "sess-1",
+    apiTokenId: null,
+    authMode: "enabled",
+    ...overrides,
+  };
+}
+
+function createResponse(page: number, total: number, items: AuditLogEntry[]): AuditLogsResponse {
+  return { page, limit: 50, total, items };
+}
+
+function createPagedResponse(page: number, total = 51): AuditLogsResponse {
+  if (page === 1) {
+    return createResponse(
+      1,
+      total,
+      Array.from({ length: 50 }, (_, index) =>
+        createAuditLogEntry({
+          id: `log-${index}`,
+          createdAt: `2026-07-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+        }),
+      ),
+    );
+  }
+
+  if (page === 2) {
+    return createResponse(
+      2,
+      total,
+      [createAuditLogEntry({ id: `log-50`, createdAt: "2026-08-20T00:00:00.000Z" })],
+    );
+  }
+
+  return createResponse(page, total, []);
+}
+
+function extractPage(url: string) {
+  const match = url.match(/page=(\d+)/);
+  return match ? Number(match[1]) : 1;
+}
+
+function renderWithRouter(children: React.ReactNode, initialEntries: string[] = ["/audit-logs"]) {
+  return render(<MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>);
+}
+
+beforeEach(() => {
+  // ResponsiveTable の desktop 表示を保つ。
+  // テスト環境では window.matchMedia が存在しないため、デフォルトで desktop になる。
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).matchMedia;
+});
+
+describe("AuditLogsPage", () => {
+  it("ページパラメータを URL から読み取り、page=2 を API に送る", async () => {
+    mockFetchWith((url) =>
+      url.startsWith("/api/audit-logs")
+        ? Promise.resolve(jsonResponse(createPagedResponse(extractPage(url))))
+        : Promise.resolve(jsonResponse({ error: "not found" }, 404)),
+    );
+
+    renderWithRouter(<AuditLogsPage />, ["/audit-logs?page=2"]);
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/audit-logs?page=2&limit=50",
+        expect.any(Object),
+      );
+    });
+
+    expect(screen.getByText("2 / 2 ページ")).toBeVisible();
+  });
+
+  it("ステータス・メソッド・パス・認証情報を表示し、null 項目は - とする", async () => {
+    mockFetchWith(() =>
+      Promise.resolve(
+        jsonResponse(
+          createResponse(1, 1, [
+            createAuditLogEntry({
+              requestId: null,
+              sessionId: null,
+              apiTokenId: null,
+              authKind: null,
+              authMode: null,
+              subject: null,
+            }),
+          ]),
+        ),
+      ),
+    );
+
+    renderWithRouter(<AuditLogsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("POST")).toBeVisible();
+    });
+
+    expect(screen.getByText("/api/accounts")).toBeVisible();
+    expect(screen.getByText("201")).toBeVisible();
+    expect(screen.getByText("web")).toBeVisible();
+
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("createdAt を JST の ja-JP 形式で表示する", async () => {
+    mockFetchWith(() =>
+      Promise.resolve(jsonResponse(createResponse(1, 1, [createAuditLogEntry()]))),
+    );
+
+    renderWithRouter(<AuditLogsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("2026年7月1日 18:00:00")).toBeVisible();
+    });
+  });
+
+  it("不正な createdAt でもクラッシュせず、生の値を表示する", async () => {
+    mockFetchWith(() =>
+      Promise.resolve(
+        jsonResponse(
+          createResponse(1, 1, [createAuditLogEntry({ createdAt: "not-a-date" })]),
+        ),
+      ),
+    );
+
+    renderWithRouter(<AuditLogsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("not-a-date")).toBeVisible();
+    });
+
+    expect(screen.queryByText("監査ログはありません。")).not.toBeInTheDocument();
+  });
+
+  it("読み込み中は読み込み中と表示し、読み終わると一覧を表示する", async () => {
+    let resolve!: (value: unknown) => void;
+    const promise = new Promise<unknown>((nextResolve) => {
+      resolve = nextResolve;
+    });
+
+    mockFetchWith(() => promise);
+
+    renderWithRouter(<AuditLogsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("読み込み中...")).toBeVisible();
+    });
+
+    resolve(jsonResponse(createResponse(1, 1, [createAuditLogEntry()])));
+
+    await waitFor(() => {
+      expect(screen.getByText("POST")).toBeVisible();
+    });
+
+    expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument();
+  });
+
+  it("エラー時はエラーメッセージを表示し、再試行できる", async () => {
+    mockFetchWith(() => Promise.resolve(jsonResponse({ error: "取得に失敗しました" }, 500)));
+
+    renderWithRouter(<AuditLogsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("取得に失敗しました");
+    });
+
+    expect(screen.queryByText("監査ログはありません。")).not.toBeInTheDocument();
+
+    mockFetchWith(() =>
+      Promise.resolve(jsonResponse(createResponse(1, 1, [createAuditLogEntry()]))),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "再試行" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("POST")).toBeVisible();
+    });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("空の場合は空のメッセージを表示する", async () => {
+    mockFetchWith(() => Promise.resolve(jsonResponse(createResponse(1, 0, []))));
+
+    renderWithRouter(<AuditLogsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("監査ログはありません。")).toBeVisible();
+    });
+
+    expect(screen.getByText("1 / 1 ページ")).toBeVisible();
+  });
+
+  it("51 件以上でページネーションの境界が正しく動作し、前へで戻れる", async () => {
+    mockFetchWith((url) =>
+      Promise.resolve(jsonResponse(createPagedResponse(extractPage(url)))),
+    );
+
+    renderWithRouter(<AuditLogsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("1 / 2 ページ")).toBeVisible();
+    });
+
+    expect(screen.getByRole("button", { name: "前へ" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "次へ" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "次へ" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("2 / 2 ページ")).toBeVisible();
+    });
+
+    expect(screen.getByRole("button", { name: "前へ" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "次へ" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "前へ" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("1 / 2 ページ")).toBeVisible();
+    });
+
+    expect(globalThis.fetch).toHaveBeenLastCalledWith(
+      "/api/audit-logs?page=1&limit=50",
+      expect.any(Object),
+    );
+  });
+
+  it("モバイル表示でも全フィールドを表示する", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).matchMedia = vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    mockFetchWith(() =>
+      Promise.resolve(
+        jsonResponse(
+          createResponse(1, 1, [
+            createAuditLogEntry({
+              method: "DELETE",
+              path: "/api/accounts/11111111-1111-4111-a111-111111111111",
+              status: 204,
+              clientSource: "mcp",
+              requestId: null,
+              sessionId: "long-session-id-that-needs-wrapping",
+              apiTokenId: null,
+            }),
+          ]),
+        ),
+      ),
+    );
+
+    renderWithRouter(<AuditLogsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("DELETE")).toBeVisible();
+    });
+
+    expect(screen.getByText("/api/accounts/11111111-1111-4111-a111-111111111111")).toBeVisible();
+    expect(screen.getByText("mcp")).toBeVisible();
+    expect(screen.getByText("long-session-id-that-needs-wrapping")).toBeVisible();
+    expect(screen.getByText("204")).toBeVisible();
+  });
+});
+
+describe("navigation", () => {
+  it("サイドバーとモバイル その他 メニューに 監査ログ へのリンクがある", async () => {
+    render(
+      <MemoryRouter initialEntries={["/audit-logs"]}>
+        <AppLayout>
+          <div data-testid="page" />
+        </AppLayout>
+      </MemoryRouter>,
+    );
+
+    const moreButton = screen.getByRole("button", { name: "その他" });
+    fireEvent.click(moreButton);
+
+    const links = await waitFor(() => screen.getAllByRole("link", { name: "監査ログ" }));
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    for (const link of links) {
+      expect(link).toHaveAttribute("href", "/audit-logs");
+    }
+  });
+});

--- a/packages/frontend/src/routes/audit-logs.tsx
+++ b/packages/frontend/src/routes/audit-logs.tsx
@@ -1,0 +1,195 @@
+import type { AuditLogEntry, AuditLogsResponse } from "@sui/shared";
+import { startTransition, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { Button } from "../components/ui/button";
+import { Card } from "../components/ui/card";
+import { ResponsiveTable, type ResponsiveTableColumn } from "../components/ui/responsive-table";
+import { useResource } from "../hooks/use-resource";
+import { apiFetch } from "../lib/api";
+import { formatDateTime } from "../lib/format";
+import { cn } from "../lib/utils";
+
+const AUDIT_LOGS_LIMIT = 50;
+
+function buildAuditLogsPath(page: number) {
+  return `/api/audit-logs?page=${page}&limit=${AUDIT_LOGS_LIMIT}`;
+}
+
+function formatValue(value: string | null | undefined, mono = true) {
+  if (value == null) {
+    return <span className="text-ink-3">-</span>;
+  }
+
+  return (
+    <span className={cn("whitespace-pre-wrap break-all", mono && "font-data")}>
+      {value}
+    </span>
+  );
+}
+
+export function AuditLogsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const rawPage = Number(searchParams.get("page") ?? 1);
+  const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
+
+  const { data, loading, error } = useResource(
+    () => apiFetch<AuditLogsResponse>(buildAuditLogsPath(page)),
+    [page, reloadKey],
+  );
+
+  const reload = () => startTransition(() => setReloadKey((key) => key + 1));
+
+  const total = data?.total ?? 0;
+  const limit = data?.limit ?? AUDIT_LOGS_LIMIT;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const canGoBack = page > 1;
+  const canGoNext = page < totalPages;
+
+  const setPage = (next: number) => {
+    if (next === page) {
+      return;
+    }
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("page", String(next));
+    setSearchParams(nextParams);
+  };
+
+  const columns: ResponsiveTableColumn<AuditLogEntry>[] = [
+    {
+      key: "createdAt",
+      header: "日時",
+      mono: true,
+      render: (item) => <span className="text-ink-2">{formatDateTime(item.createdAt)}</span>,
+    },
+    { key: "method", header: "メソッド", render: (item) => formatValue(item.method) },
+    {
+      key: "path",
+      header: "パス",
+      mono: true,
+      render: (item) => formatValue(item.path),
+    },
+    {
+      key: "status",
+      header: "ステータス",
+      render: (item) => <span className="font-data">{item.status}</span>,
+    },
+    { key: "clientSource", header: "クライアント", render: (item) => formatValue(item.clientSource) },
+    { key: "authKind", header: "認証種別", render: (item) => formatValue(item.authKind) },
+    { key: "authMode", header: "認証モード", render: (item) => formatValue(item.authMode) },
+    { key: "subject", header: "主体", render: (item) => formatValue(item.subject) },
+    {
+      key: "requestId",
+      header: "リクエストID",
+      mono: true,
+      render: (item) => formatValue(item.requestId),
+    },
+    {
+      key: "sessionId",
+      header: "セッションID",
+      mono: true,
+      render: (item) => formatValue(item.sessionId),
+    },
+    {
+      key: "apiTokenId",
+      header: "APIトークンID",
+      mono: true,
+      render: (item) => formatValue(item.apiTokenId),
+    },
+  ];
+
+  const mobileRow = (item: AuditLogEntry) => (
+    <div className="grid gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-data text-ink-2">{formatDateTime(item.createdAt)}</span>
+        <span className="font-data font-semibold">{item.method}</span>
+      </div>
+      <div className="font-data whitespace-pre-wrap break-all">{item.path}</div>
+      <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+        {[
+          { label: "ステータス", value: String(item.status), mono: true },
+          { label: "クライアント", value: item.clientSource },
+          { label: "認証種別", value: item.authKind },
+          { label: "認証モード", value: item.authMode },
+          { label: "主体", value: item.subject },
+          { label: "リクエストID", value: item.requestId },
+          { label: "セッションID", value: item.sessionId },
+          { label: "APIトークンID", value: item.apiTokenId },
+        ].map(({ label, value, mono }) => (
+          <div key={label} className="col-span-full grid grid-cols-subgrid">
+            <dt className="text-ink-3">{label}</dt>
+            <dd className="min-w-0">{formatValue(value, mono)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+
+  return (
+    <div className="grid gap-6">
+      <div>
+        <h2 className="text-2xl font-semibold">監査ログ</h2>
+        <p className="mt-2 text-sm text-ink-2">状態を変えたリクエストの記録を確認します。</p>
+      </div>
+
+      <Card>
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-xl font-semibold">リクエスト一覧</h3>
+          <div className="text-sm text-ink-2">{loading ? null : `全 ${total} 件`}</div>
+        </div>
+
+        {error ? (
+          <ErrorBlock message={error} onRetry={reload} />
+        ) : loading ? (
+          <p className="text-sm text-ink-2">読み込み中...</p>
+        ) : (
+          <>
+            <ResponsiveTable
+              columns={columns}
+              rows={data?.items ?? []}
+              rowKey={(item) => item.id}
+              emptyMessage="監査ログはありません。"
+              mobileRow={mobileRow}
+            />
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+              <div className="text-sm text-ink-2" aria-live="polite">
+                {page} / {totalPages} ページ
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  className="border border-line"
+                  disabled={!canGoBack}
+                  onClick={() => setPage(page - 1)}
+                >
+                  前へ
+                </Button>
+                <Button
+                  variant="ghost"
+                  className="border border-line"
+                  disabled={!canGoNext}
+                  onClick={() => setPage(page + 1)}
+                >
+                  次へ
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="grid gap-3 rounded-xl border border-critical/40 bg-critical/10 p-4 text-sm text-ink">
+      <p role="alert">{message}</p>
+      <Button className="justify-self-start" variant="secondary" onClick={onRetry}>
+        再試行
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #427

## 変更内容

- 読み取り専用の `/audit-logs` Web UIを追加
- 既存 `AuditLogEntry` / `AuditLogsResponse` と `useResource` / `ResponsiveTable` を再利用
- 日時を `ja-JP`・`Asia/Tokyo` で表示し、不正日時は例外にせず元値を表示
- method/path/status/client/auth/subject/request/session/token IDをdesktop/mobile双方で完全表示
- null表示、loading/empty/error/retry、50件単位の前後ページングを実装
- システムナビゲーションとモバイル「その他」からの導線を追加
- UI/API/MCPによる監査ログ確認経路をobservability docsへ追記

## 目的

誰が・どのクライアントから・どの変更操作を行ったかを、APIを直接呼ばず日常的に確認できるようにします。

## 検証

- `make lint`
- `make typecheck`
- `make test-unit`（shared 17 / frontend 95 / backend 140）
- `make build`
- OKF validator（0 errors, 0 warnings）
