### PR TITLE
長い精算取引名でも金額と詳細を確認可能にする

### DIFF
--- a/e2e/splits.spec.ts
+++ b/e2e/splits.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test, type Page } from "@playwright/test";
-import { resetDatabase, seedPerson, seedSplit, seedSettlement } from "./helpers/db";
+import {
+  resetDatabase,
+  seedAccount,
+  seedPerson,
+  seedSettlement,
+  seedSplit,
+  seedTransaction,
+} from "./helpers/db";
 
 async function assertNoDocumentHorizontalScroll(page: Page) {
   const overflow = await page.evaluate(() => ({
@@ -154,6 +161,74 @@ test.describe("split list table", () => {
 
     await page.locator("details summary").filter({ hasText: /精算済み/ }).click();
     await expect(page.getByText(archivedDescription)).toBeVisible();
+
+    await assertNoDocumentHorizontalScroll(page);
+  });
+});
+
+test.describe("split settlement dialog", () => {
+  test("shows truncated transfer options and full details without overflowing at 375px", async ({ page }) => {
+    const fromAccount = await seedAccount({ name: "From", balance: 0 });
+    const toAccount = await seedAccount({ name: "To", balance: 0 });
+    const person = await seedPerson({ name: "Taro" });
+
+    await seedSplit({
+      date: new Date("2026-07-24T00:00:00Z"),
+      description: "Lunch",
+      amount: 9000,
+      shares: [{ personId: person.id, amount: 4000 }],
+    });
+
+    const longDescription = "旅行代の精算と立替金の清算用".repeat(5);
+    const transfer = await seedTransaction({
+      accountId: fromAccount.id,
+      transferToAccountId: toAccount.id,
+      type: "transfer",
+      date: new Date("2026-07-26T00:00:00Z"),
+      description: longDescription,
+      amount: 10000,
+    });
+
+    await page.setViewportSize({ width: 375, height: 812 });
+
+    const peoplePromise = waitForApi(page, (path) => path === "/api/people");
+    await page.goto("/splits");
+    await peoplePromise;
+
+    const settlementsPromise = waitForApi(page, (path) => path === "/api/settlements");
+    const peoplePromise2 = waitForApi(page, (path) => path === "/api/people");
+    await page.getByRole("radio", { name: "精算" }).click();
+    await Promise.all([settlementsPromise, peoplePromise2]);
+
+    await page.getByRole("button", { name: "精算を記録" }).click();
+    await page.getByRole("dialog").waitFor();
+
+    const summaryPromise = waitForApi(page, (path) =>
+      path === `/api/people/${person.id}/summary`,
+    );
+    await page.getByLabel("メンバー").selectOption(person.id);
+    await summaryPromise;
+
+    const transactionsPromise = waitForApi(page, (path) =>
+      path === "/api/transactions",
+    );
+    await page.getByLabel("種別").selectOption("transaction");
+    await transactionsPromise;
+
+    await page.getByLabel("振替取引").selectOption(transfer.id);
+
+    const selectedOption = page.getByLabel("振替取引").locator("option:checked");
+    await expect(selectedOption).toHaveText(/2026-07-26/);
+    await expect(selectedOption).toHaveText(/残り 10,000円/);
+    await expect(selectedOption).toHaveText(/…$/);
+
+    await expect(page.getByText(longDescription)).toBeVisible();
+    await expect(page.getByRole("dialog").getByText(/総額 10,000 円/)).toHaveText(
+      /2026-07-26 \/ 総額 10,000 円/,
+    );
+    await expect(page.getByRole("dialog").getByText(/精算済み/)).toHaveText(
+      /精算済み 0 円 \/ 残額 10,000 円/,
+    );
 
     await assertNoDocumentHorizontalScroll(page);
   });

--- a/packages/frontend/src/routes/splits.test.tsx
+++ b/packages/frontend/src/routes/splits.test.tsx
@@ -4,11 +4,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { apiFetch } from "../lib/api";
 import {
   calculateTotalOutstanding,
+  CreateSettlementDialog,
+  formatTransferOptionLabel,
   getSplitStatusBadge,
   getTransactionSettlementRemaining,
   isSettlementCandidate,
   MembersTab,
+  SettlementTransferDetailPanel,
   SplitsTab,
+  truncateByGraphemes,
 } from "./splits";
 
 vi.mock("../lib/api", () => ({ apiFetch: vi.fn() }));
@@ -95,6 +99,34 @@ const person: Person = {
   createdAt: "2026-07-26T00:00:00.000Z",
   updatedAt: "2026-07-26T00:00:00.000Z",
 };
+
+describe("truncateByGraphemes", () => {
+  it("returns the original text when it is within the limit", () => {
+    expect(truncateByGraphemes("旅行代", 10)).toBe("旅行代");
+    expect(truncateByGraphemes("short", 24)).toBe("short");
+  });
+
+  it("truncates long text and appends an ellipsis", () => {
+    const long = "旅行代の精算と立替金の清算用".repeat(5);
+    const result = truncateByGraphemes(long, 24);
+    expect(result).toMatch(/…$/);
+    expect(result.length).toBeLessThan(long.length);
+  });
+
+  it("counts a surrogate pair as one grapheme", () => {
+    const text = "🎉".repeat(30);
+    const result = truncateByGraphemes(text, 24);
+    const visible = result.slice(0, result.indexOf("…"));
+    expect(visible).toBe("🎉".repeat(24));
+  });
+
+  it("keeps Japanese, ASCII and emoji mixed text without raising", () => {
+    const text = "abc日本語🎉123#".repeat(8);
+    const result = truncateByGraphemes(text, 24);
+    expect(result).toMatch(/…$/);
+    expect(result.length).toBeLessThan(text.length);
+  });
+});
 
 describe("getTransactionSettlementRemaining", () => {
   it("prefers settlementRemainingAmount when present", () => {
@@ -282,5 +314,168 @@ describe("SplitsTab table", () => {
 
     const actionsCell = within(activeTable).getByRole("button", { name: "編集" }).closest("td");
     expect(actionsCell).toHaveClass("whitespace-nowrap", "min-w-[4.5rem]");
+  });
+});
+
+describe("formatTransferOptionLabel", () => {
+  it("shows date, remaining amount and short description", () => {
+    const tx = transactionStub({ settlementRemainingAmount: 6000 });
+    const label = formatTransferOptionLabel(tx, 24);
+    expect(label).toMatch(/^2026-07-26 \/ 残り 6,000円 \/ 旅行代の精算$/);
+  });
+
+  it("shows remaining equal to amount for an unsettled transfer", () => {
+    const tx = transactionStub();
+    const label = formatTransferOptionLabel(tx, 24);
+    expect(label).toMatch(/2026-07-26 \/ 残り 10,000円/);
+    expect(label).toMatch(/旅行代の精算$/);
+  });
+
+  it("shows partial remaining for a partially settled transfer", () => {
+    const tx = transactionStub({
+      settlementAllocatedAmount: 4000,
+      settlementRemainingAmount: 6000,
+    });
+    const label = formatTransferOptionLabel(tx, 24);
+    expect(label).toMatch(/2026-07-26 \/ 残り 6,000円/);
+    expect(label).not.toMatch(/総額/);
+  });
+
+  it("truncates a long description and ends with an ellipsis", () => {
+    const long = "旅行代の精算と立替金の清算用".repeat(5);
+    const tx = transactionStub({ description: long });
+    const label = formatTransferOptionLabel(tx, 24);
+    expect(label).toMatch(/…$/);
+    expect(label).not.toContain(long);
+  });
+
+  it("keeps a short description unchanged", () => {
+    const tx = transactionStub({ description: "旅行" });
+    const label = formatTransferOptionLabel(tx, 24);
+    expect(label).toMatch(/旅行$/);
+    expect(label).not.toMatch(/…$/);
+  });
+});
+
+describe("SettlementTransferDetailPanel", () => {
+  it("shows the full description, total, allocated, remaining and both account names", () => {
+    const long = "旅行代の精算と立替金の清算用".repeat(6);
+    const tx = transactionStub({
+      description: long,
+      amount: 10000,
+      settlementAllocatedAmount: 4000,
+      settlementRemainingAmount: 6000,
+      accountName: "Wallet",
+      transferToAccountName: "Bank",
+    });
+    render(<SettlementTransferDetailPanel transaction={tx} />);
+
+    expect(screen.getByText(long)).toBeInTheDocument();
+    expect(screen.getByText(/総額/)).toHaveTextContent("10,000");
+    expect(screen.getByText(/精算済み/)).toHaveTextContent("4,000");
+    expect(screen.getByText(/残額/)).toHaveTextContent("6,000");
+    expect(screen.getByText("振替元:")).toHaveTextContent("Wallet");
+    expect(screen.getByText("振替先:")).toHaveTextContent("Bank");
+  });
+
+  it("falls back to 未設定 when account names are missing", () => {
+    const tx = transactionStub({
+      accountName: undefined,
+      transferToAccountName: undefined,
+    });
+    render(<SettlementTransferDetailPanel transaction={tx} />);
+
+    expect(screen.getByText("振替元:")).toHaveTextContent("未設定");
+    expect(screen.getByText("振替先:")).toHaveTextContent("未設定");
+  });
+});
+
+describe("CreateSettlementDialog", () => {
+  const person = personStub({ id: "person-1", name: "Taro" });
+  const share = {
+    id: "share-1",
+    splitId: "split-1",
+    personId: "person-1",
+    personName: "Taro",
+    splitDescription: "Lunch",
+    splitDate: "2026-07-24",
+    ratio: null,
+    amount: 4000,
+    settledAmount: 0,
+    remainingAmount: 4000,
+    status: "unsettled" as const,
+  };
+  const summary = {
+    person,
+    outstandingAmount: { JPY: 4000 },
+    shares: [share],
+    settlements: [],
+  };
+  const tx = transactionStub({
+    id: "tx-1",
+    description: "旅行代の精算",
+    amount: 10000,
+    settlementAllocatedAmount: 0,
+    settlementRemainingAmount: 10000,
+    accountName: "From",
+    transferToAccountName: "To",
+  });
+
+  it("does not show a detail panel before selecting a transaction", () => {
+    render(<CreateSettlementDialog open people={[person]} onClose={vi.fn()} onSaved={vi.fn()} />);
+    expect(screen.queryByText("総額")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("振替取引")).not.toBeInTheDocument();
+  });
+
+  it("keeps working when no transfer candidates exist", async () => {
+    vi.mocked(apiFetch).mockResolvedValue({ items: [], page: 1, limit: 100, total: 0 });
+    render(<CreateSettlementDialog open people={[person]} onClose={vi.fn()} onSaved={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText("種別"), { target: { value: "transaction" } });
+    await waitFor(() => expect(screen.getByLabelText("振替取引")).toHaveValue(""));
+
+    expect(screen.queryByText("総額")).not.toBeInTheDocument();
+  });
+
+  it("shows full details after selecting a transfer", async () => {
+    const long = "旅行代の精算と立替金の清算用".repeat(6);
+    vi.mocked(apiFetch).mockImplementation((url) => {
+      if (typeof url === "string" && url.includes("/api/people/")) {
+        return Promise.resolve(summary);
+      }
+      if (typeof url === "string" && url.includes("/api/transactions")) {
+        return Promise.resolve({
+          items: [{ ...tx, description: long }],
+          page: 1,
+          limit: 100,
+          total: 1,
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    render(<CreateSettlementDialog open people={[person]} onClose={vi.fn()} onSaved={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText("メンバー"), { target: { value: person.id } });
+    fireEvent.change(screen.getByLabelText("種別"), { target: { value: "transaction" } });
+
+    await waitFor(() => expect(screen.getByLabelText("振替取引").querySelectorAll("option").length).toBeGreaterThan(1));
+
+    fireEvent.change(screen.getByLabelText("振替取引"), { target: { value: tx.id } });
+
+    await waitFor(() => expect(screen.getByText(long)).toBeInTheDocument());
+    expect(screen.getByText(long)).toBeInTheDocument();
+    const detail = screen.getByText(long).parentElement;
+    expect(detail).toHaveTextContent(/総額 10,000 円/);
+    expect(detail).toHaveTextContent(/精算済み 0 円/);
+    expect(detail).toHaveTextContent(/残額 10,000 円/);
+    expect(screen.getByText("振替元:")).toHaveTextContent("From");
+    expect(screen.getByText("振替先:")).toHaveTextContent("To");
+
+    const select = screen.getByLabelText("振替取引") as HTMLSelectElement;
+    const selectedOption = select.options[select.selectedIndex];
+    expect(selectedOption.textContent).toMatch(/2026-07-26/);
+    expect(selectedOption.textContent).toMatch(/残り 10,000円/);
+    expect(selectedOption.textContent).toMatch(/…$/);
   });
 });

--- a/packages/frontend/src/routes/splits.tsx
+++ b/packages/frontend/src/routes/splits.tsx
@@ -69,6 +69,65 @@ export function isSettlementCandidate(transaction: Transaction): boolean {
   );
 }
 
+const TRANSFER_OPTION_DESCRIPTION_MAX_GRAPHEMES = 24;
+
+function getGraphemeSegments(input: string): string[] {
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    try {
+      const segmenter = new Intl.Segmenter("ja", { granularity: "grapheme" });
+      return Array.from(segmenter.segment(input), (segment) => segment.segment);
+    } catch {
+      // fall through to a safe fallback for environments without Segmenter.
+    }
+  }
+  return input.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]|./g) ?? [];
+}
+
+export function truncateByGraphemes(input: string, maxLength: number): string {
+  const segments = getGraphemeSegments(input);
+  if (segments.length <= maxLength) {
+    return input;
+  }
+  return `${segments.slice(0, maxLength).join("")}…`;
+}
+
+export function formatTransferOptionLabel(
+  transaction: Transaction,
+  maxDescriptionLength = TRANSFER_OPTION_DESCRIPTION_MAX_GRAPHEMES,
+): string {
+  const remaining = getTransactionSettlementRemaining(transaction);
+  const description = truncateByGraphemes(transaction.description, maxDescriptionLength);
+  return `${transaction.date} / 残り ${remaining.toLocaleString("ja-JP")}円 / ${description}`;
+}
+
+export function SettlementTransferDetailPanel({ transaction }: { transaction: Transaction }) {
+  const remaining = getTransactionSettlementRemaining(transaction);
+  const allocated = transaction.settlementAllocatedAmount ?? 0;
+  return (
+    <div className="min-w-0 rounded-xl bg-surface-2 p-3 text-sm">
+      <div className="grid gap-1">
+        <div className="break-words font-medium">{transaction.description}</div>
+        <div className="text-ink-2">
+          <span className="font-data">{transaction.date}</span>
+          {" / 総額 "}
+          <span className="font-data">{transaction.amount.toLocaleString("ja-JP")}</span> 円
+        </div>
+        <div className="text-ink-2">
+          精算済み <span className="font-data">{allocated.toLocaleString("ja-JP")}</span> 円
+          {" / 残額 "}
+          <span className="font-data">{remaining.toLocaleString("ja-JP")}</span> 円
+        </div>
+        <div className="text-ink-2">
+          振替元: <span className="break-words">{transaction.accountName ?? "未設定"}</span>
+        </div>
+        <div className="text-ink-2">
+          振替先: <span className="break-words">{transaction.transferToAccountName ?? "未設定"}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function SplitSharesCell({ split }: { split: SplitListItem }) {
   const [expanded, setExpanded] = useState(false);
   const remaining = split.shares.filter((share) => share.remainingAmount > 0);
@@ -721,7 +780,7 @@ function SettlementsTab() {
   );
 }
 
-function CreateSettlementDialog({
+export function CreateSettlementDialog({
   open,
   people,
   onClose,
@@ -858,6 +917,7 @@ function CreateSettlementDialog({
         <form className="mt-6 grid gap-4">
           <FormField label="メンバー">
             <Select
+              aria-label="メンバー"
               value={personId}
               onChange={(event) => {
                 setPersonId(event.target.value);
@@ -873,7 +933,11 @@ function CreateSettlementDialog({
           </FormField>
 
           <FormField label="種別">
-            <Select value={kind} onChange={(event) => setKind(event.target.value as SettlementKind)}>
+            <Select
+              aria-label="種別"
+              value={kind}
+              onChange={(event) => setKind(event.target.value as SettlementKind)}
+            >
               <option value="offset">相殺・現金精算</option>
               <option value="transaction">振替取引で精算</option>
             </Select>
@@ -884,15 +948,25 @@ function CreateSettlementDialog({
               <Input type="date" value={date} onChange={(event) => setDate(event.target.value)} />
             </FormField>
           ) : (
-            <FormField label="振替取引">
-              <Select value={transactionId} onChange={(event) => setTransactionId(event.target.value)}>
+            <FormField label="振替取引" className="min-w-0">
+              <Select
+                aria-label="振替取引"
+                value={transactionId}
+                onChange={(event) => setTransactionId(event.target.value)}
+                className="w-full min-w-0 truncate"
+              >
                 <option value="">選択してください</option>
                 {transferOptions.map((transaction) => (
                   <option key={transaction.id} value={transaction.id}>
-                    {transaction.date} {transaction.description} ({transaction.amount.toLocaleString("ja-JP")} 円)
+                    {formatTransferOptionLabel(transaction)}
                   </option>
                 ))}
               </Select>
+              {selectedTransaction ? (
+                <div className="mt-2 min-w-0">
+                  <SettlementTransferDetailPanel transaction={selectedTransaction} />
+                </div>
+              ) : null}
             </FormField>
           )}
 


### PR DESCRIPTION
Closes #390

## 変更内容

- 精算対象の振替optionを `日付 / 残り金額 / 省略した取引名` の順に変更
- `Intl.Segmenter` と安全なfallbackで日本語・ASCII・絵文字を24 grapheme単位で省略
- 選択後に完全な取引名、日付、総額、精算済み額、残額、振替元・振替先を表示
- 片側口座なしを「未設定」とし、長い名前をdialog内で折り返す
- select/dialogを375px viewport内へ収めるレイアウトを追加
- formatter・詳細panel・候補0件/未選択をfrontend testで固定
- 100文字超の取引名を使う375px Playwright回帰テストを追加

## 目的

長い取引名でも、誤選択を防ぐ主要金額と完全な取引情報を精算前に確認できるようにします。

## 検証

- `make lint`
- `make typecheck`
- `make test-unit`（shared 17 / frontend 107 / backend 140）
- `make test-e2e`（80 tests passed。#390の375pxケースを含む）
- `make build`

## 依存関係

- Base: #437（Issue #424）
- #424 の `settlementRemainingAmount` をoption表示と詳細表示に使用します。
- #437 を先にmerge後、このPRのbaseを `main` へ変更します。
