### PR TITLE
割り勘一覧のテーブルレイアウトを安定化

### DIFF
--- a/e2e/helpers/db-runner.ts
+++ b/e2e/helpers/db-runner.ts
@@ -123,6 +123,34 @@ type DbCommand =
       description?: string;
       amount?: number;
     }>;
+  }
+  | {
+    action: "seedPerson";
+    payload: {
+      name: string;
+      memo?: string | null;
+      sortOrder?: number;
+    };
+  }
+  | {
+    action: "seedSplit";
+    payload: {
+      date: string;
+      description: string;
+      amount: number;
+      shares: Array<{ personId: string; amount: number }>;
+    };
+  }
+  | {
+    action: "seedSettlement";
+    payload: {
+      kind: "transaction" | "offset";
+      personId: string;
+      transactionId?: string | null;
+      date: string;
+      note?: string | null;
+      allocations: Array<{ shareId: string; amount: number }>;
+    };
   };
 
 function resolveDatabaseUrl() {
@@ -242,6 +270,47 @@ async function run(command: DbCommand) {
           }),
         ),
       );
+    case "seedPerson":
+      return prisma.person.create({
+        data: {
+          name: command.payload.name,
+          memo: command.payload.memo ?? null,
+          sortOrder: command.payload.sortOrder ?? 0,
+        },
+      });
+    case "seedSplit":
+      return prisma.transactionSplit.create({
+        data: {
+          date: new Date(command.payload.date),
+          description: command.payload.description,
+          amount: command.payload.amount,
+          method: "amount",
+          shares: {
+            create: command.payload.shares.map((share) => ({
+              personId: share.personId,
+              amount: share.amount,
+            })),
+          },
+        },
+        include: { shares: true },
+      });
+    case "seedSettlement":
+      return prisma.settlement.create({
+        data: {
+          kind: command.payload.kind,
+          personId: command.payload.personId,
+          transactionId: command.payload.transactionId ?? null,
+          date: new Date(command.payload.date),
+          note: command.payload.note ?? null,
+          allocations: {
+            create: command.payload.allocations.map((allocation) => ({
+              shareId: allocation.shareId,
+              amount: allocation.amount,
+            })),
+          },
+        },
+        include: { allocations: true },
+      });
   }
 }
 

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -10,10 +10,15 @@ import type {
   CreditCard,
   CreditCardBilling,
   Loan,
+  Person,
   RecurringItem,
   SalaryRecord,
+  Settlement,
+  SettlementAllocation,
+  SplitShare,
   Subscription,
   Transaction,
+  TransactionSplit,
 } from "@sui/db";
 
 type DbCommand =
@@ -125,6 +130,34 @@ type DbCommand =
       description?: string;
       amount?: number;
     }>;
+  }
+  | {
+    action: "seedPerson";
+    payload: {
+      name: string;
+      memo?: string | null;
+      sortOrder?: number;
+    };
+  }
+  | {
+    action: "seedSplit";
+    payload: {
+      date: string;
+      description: string;
+      amount: number;
+      shares: Array<{ personId: string; amount: number }>;
+    };
+  }
+  | {
+    action: "seedSettlement";
+    payload: {
+      kind: "transaction" | "offset";
+      personId: string;
+      transactionId?: string | null;
+      date: string;
+      note?: string | null;
+      allocations: Array<{ shareId: string; amount: number }>;
+    };
   };
 
 const runnerPath = path.resolve(process.cwd(), "e2e/helpers/db-runner.ts");
@@ -465,5 +498,61 @@ export async function seedTransactions(
       description: overrides.description,
       amount: overrides.amount,
     })),
+  });
+}
+
+export type SplitWithShares = TransactionSplit & { shares: SplitShare[] };
+export type SettlementWithAllocations = Settlement & { allocations: SettlementAllocation[] };
+
+export async function seedPerson(overrides: {
+  name: string;
+  memo?: string | null;
+  sortOrder?: number;
+}): Promise<Person> {
+  return runDbCommand<Person>({
+    action: "seedPerson",
+    payload: {
+      name: overrides.name,
+      memo: overrides.memo ?? null,
+      sortOrder: overrides.sortOrder ?? 0,
+    },
+  });
+}
+
+export async function seedSplit(overrides: {
+  date: Date;
+  description: string;
+  amount: number;
+  shares: Array<{ personId: string; amount: number }>;
+}): Promise<SplitWithShares> {
+  return runDbCommand<SplitWithShares>({
+    action: "seedSplit",
+    payload: {
+      date: serializeOptionalDate(overrides.date) as string,
+      description: overrides.description,
+      amount: overrides.amount,
+      shares: overrides.shares,
+    },
+  });
+}
+
+export async function seedSettlement(overrides: {
+  kind: "transaction" | "offset";
+  personId: string;
+  transactionId?: string | null;
+  date: Date;
+  note?: string | null;
+  allocations: Array<{ shareId: string; amount: number }>;
+}): Promise<SettlementWithAllocations> {
+  return runDbCommand<SettlementWithAllocations>({
+    action: "seedSettlement",
+    payload: {
+      kind: overrides.kind,
+      personId: overrides.personId,
+      transactionId: overrides.transactionId ?? null,
+      date: serializeOptionalDate(overrides.date) as string,
+      note: overrides.note ?? null,
+      allocations: overrides.allocations,
+    },
   });
 }

--- a/e2e/splits.spec.ts
+++ b/e2e/splits.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type Page } from "@playwright/test";
+import { resetDatabase, seedPerson, seedSplit, seedSettlement } from "./helpers/db";
+
+async function assertNoDocumentHorizontalScroll(page: Page) {
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
+}
+
+async function waitForApi(page: Page, pathPredicate: (url: string) => boolean) {
+  return page.waitForResponse(
+    (response) => {
+      try {
+        const url = new URL(response.url());
+        return pathPredicate(url.pathname) && response.status() === 200;
+      } catch {
+        return false;
+      }
+    },
+    { timeout: 5000 },
+  );
+}
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test.describe("split list table", () => {
+  test("keeps columns readable and scrolls inside its wrapper at narrow desktop widths", async ({ page }) => {
+    const personA = await seedPerson({ name: "Taro" });
+    const personB = await seedPerson({ name: "Hanako" });
+
+    const activeDescription = "未精算の割り勘：旅行代の精算と立替金の清算用".repeat(2);
+    const archivedDescription = "精算済みの割り勘：旅行代の精算と立替金の清算用".repeat(2);
+
+    await seedSplit({
+      date: new Date("2026-07-24T00:00:00Z"),
+      description: activeDescription,
+      amount: 10000,
+      shares: [
+        { personId: personA.id, amount: 4000 },
+        { personId: personB.id, amount: 3000 },
+      ],
+    });
+
+    const archivedSplit = await seedSplit({
+      date: new Date("2026-07-23T00:00:00Z"),
+      description: archivedDescription,
+      amount: 7000,
+      shares: [{ personId: personA.id, amount: 7000 }],
+    });
+    await seedSettlement({
+      kind: "offset",
+      personId: personA.id,
+      date: new Date("2026-07-25T00:00:00Z"),
+      allocations: [{ shareId: archivedSplit.shares[0].id, amount: 7000 }],
+    });
+
+    for (const width of [1440, 1024, 768]) {
+      await page.setViewportSize({ width, height: 800 });
+
+      const peoplePromise = waitForApi(page, (path) => path === "/api/people");
+      await page.goto("/splits");
+      await peoplePromise;
+
+      const splitsPromise = waitForApi(page, (path) => path === "/api/splits");
+      const peoplePromise2 = waitForApi(page, (path) => path === "/api/people");
+      await page.getByRole("radio", { name: "割り勘一覧" }).click();
+      await Promise.all([splitsPromise, peoplePromise2]);
+
+      const tables = page.locator("table");
+      await expect(tables).toHaveCount(2);
+      for (const table of await tables.all()) {
+        await expect(table).toHaveClass(/min-w-\[60rem\]/);
+      }
+
+      await expect(page.getByText(activeDescription)).toBeVisible();
+
+      // The archived table is still collapsed; measure only the visible active table.
+      const activeTable = tables.first();
+      const activeWrapperScroll = await activeTable.evaluate((table) => {
+        const wrapper = table.parentElement;
+        return wrapper ? wrapper.scrollWidth > wrapper.clientWidth : false;
+      });
+      if (width === 768) {
+        expect(activeWrapperScroll).toBe(true);
+      }
+
+      // Open the archived section and verify both table wrappers.
+      await page.locator("details summary").filter({ hasText: /精算済み/ }).click();
+      await expect(page.getByText(archivedDescription)).toBeVisible();
+
+      const visibleTables = page.locator("table");
+      await expect(visibleTables).toHaveCount(2);
+      for (const table of await visibleTables.all()) {
+        await expect(table).toHaveClass(/min-w-\[60rem\]/);
+      }
+
+      const wrapperScrolls = await visibleTables.evaluateAll((tables) =>
+        tables.map((table) => {
+          const wrapper = table.parentElement;
+          return wrapper ? wrapper.scrollWidth > wrapper.clientWidth : false;
+        }),
+      );
+      if (width === 768) {
+        expect(wrapperScrolls.every(Boolean)).toBe(true);
+      }
+
+      await assertNoDocumentHorizontalScroll(page);
+    }
+  });
+
+  test("switches to mobile cards at 375px", async ({ page }) => {
+    const personA = await seedPerson({ name: "Taro" });
+
+    const activeDescription = "未精算の割り勘：旅行代の精算と立替金の清算用".repeat(2);
+    const archivedDescription = "精算済みの割り勘：旅行代の精算と立替金の清算用".repeat(2);
+
+    await seedSplit({
+      date: new Date("2026-07-24T00:00:00Z"),
+      description: activeDescription,
+      amount: 10000,
+      shares: [{ personId: personA.id, amount: 4000 }],
+    });
+
+    const archivedSplit = await seedSplit({
+      date: new Date("2026-07-23T00:00:00Z"),
+      description: archivedDescription,
+      amount: 7000,
+      shares: [{ personId: personA.id, amount: 7000 }],
+    });
+    await seedSettlement({
+      kind: "offset",
+      personId: personA.id,
+      date: new Date("2026-07-25T00:00:00Z"),
+      allocations: [{ shareId: archivedSplit.shares[0].id, amount: 7000 }],
+    });
+
+    await page.setViewportSize({ width: 375, height: 812 });
+
+    const peoplePromise = waitForApi(page, (path) => path === "/api/people");
+    await page.goto("/splits");
+    await peoplePromise;
+
+    const splitsPromise = waitForApi(page, (path) => path === "/api/splits");
+    const peoplePromise2 = waitForApi(page, (path) => path === "/api/people");
+    await page.getByRole("radio", { name: "割り勘一覧" }).click();
+    await Promise.all([splitsPromise, peoplePromise2]);
+
+    await expect(page.locator("table")).toHaveCount(0);
+    await expect(page.getByText(activeDescription)).toBeVisible();
+
+    await page.locator("details summary").filter({ hasText: /精算済み/ }).click();
+    await expect(page.getByText(archivedDescription)).toBeVisible();
+
+    await assertNoDocumentHorizontalScroll(page);
+  });
+});

--- a/packages/frontend/src/components/ui/responsive-table.tsx
+++ b/packages/frontend/src/components/ui/responsive-table.tsx
@@ -31,6 +31,7 @@ export type ResponsiveTableColumn<T> = {
   render: (row: T) => ReactNode;
   align?: "left" | "right";
   mono?: boolean;
+  className?: string;
 };
 
 /**
@@ -82,7 +83,7 @@ export function ResponsiveTable<T>({
               <th
                 key={column.key}
                 scope="col"
-                className={cn("px-3 py-3", column.align === "right" && "text-right")}
+                className={cn("px-3 py-3", column.align === "right" && "text-right", column.className)}
               >
                 {column.header}
               </th>
@@ -106,6 +107,7 @@ export function ResponsiveTable<T>({
                       "px-3 py-3",
                       column.align === "right" && "text-right",
                       column.mono && "font-data",
+                      column.className,
                     )}
                   >
                     {column.render(row)}

--- a/packages/frontend/src/routes/splits.test.tsx
+++ b/packages/frontend/src/routes/splits.test.tsx
@@ -1,12 +1,14 @@
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
-import type { Person, Transaction } from "@sui/shared";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { Person, SplitListItem, Transaction } from "@sui/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { apiFetch } from "../lib/api";
 import {
   calculateTotalOutstanding,
+  getSplitStatusBadge,
   getTransactionSettlementRemaining,
   isSettlementCandidate,
   MembersTab,
+  SplitsTab,
 } from "./splits";
 
 vi.mock("../lib/api", () => ({ apiFetch: vi.fn() }));
@@ -50,6 +52,49 @@ function personStub(overrides: Partial<Person> = {}): Person {
     ...overrides,
   };
 }
+
+function splitStub(overrides: Partial<SplitListItem> = {}): SplitListItem {
+  return {
+    id: "split-1",
+    date: "2026-07-26",
+    description: "旅行代の精算と立替金の清算用",
+    memo: null,
+    amount: 10000,
+    method: "equal",
+    ownRatio: 0,
+    ownShare: 3000,
+    status: "unsettled",
+    createdAt: "2026-07-26T00:00:00.000Z",
+    updatedAt: "2026-07-26T00:00:00.000Z",
+    shares: [
+      {
+        id: "share-1",
+        splitId: "split-1",
+        personId: "person-1",
+        personName: "Taro",
+        splitDescription: "旅行代の精算と立替金の清算用",
+        splitDate: "2026-07-26",
+        ratio: null,
+        amount: 4000,
+        settledAmount: 0,
+        remainingAmount: 4000,
+        status: "unsettled",
+      },
+    ],
+    ...overrides,
+  } as SplitListItem;
+}
+
+const person: Person = {
+  id: "person-1",
+  name: "Taro",
+  memo: null,
+  sortOrder: 0,
+  outstandingAmount: { JPY: 4000 },
+  deletedAt: null,
+  createdAt: "2026-07-26T00:00:00.000Z",
+  updatedAt: "2026-07-26T00:00:00.000Z",
+};
 
 describe("getTransactionSettlementRemaining", () => {
   it("prefers settlementRemainingAmount when present", () => {
@@ -175,5 +220,67 @@ describe("MembersTab", () => {
     await waitFor(() => expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument());
 
     expect(screen.getByText("0 円")).toBeInTheDocument();
+  });
+});
+
+describe("getSplitStatusBadge", () => {
+  it("renders the status label with whitespace-nowrap", () => {
+    const { container } = render(getSplitStatusBadge("partial")!);
+    const badge = container.querySelector("span");
+    expect(badge).toHaveTextContent("一部精算");
+    expect(badge).toHaveClass("whitespace-nowrap");
+  });
+});
+
+describe("SplitsTab table", () => {
+  it("sets an explicit min-width on active and archived tables and keeps nowrap on compact cells", async () => {
+    vi.mocked(apiFetch).mockImplementation((url) => {
+      if (typeof url === "string" && url.includes("/api/splits")) {
+        return Promise.resolve([
+          splitStub(),
+          splitStub({ id: "split-2", status: "settled" }),
+        ] as SplitListItem[]);
+      }
+      if (typeof url === "string" && url === "/api/people") {
+        return Promise.resolve([person]);
+      }
+      return Promise.resolve([]);
+    });
+
+    render(<SplitsTab />);
+
+    await waitFor(() => expect(screen.getByText("割り勘一覧")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("精算済み (1)"));
+    await waitFor(() => expect(screen.getAllByRole("table")).toHaveLength(2));
+
+    const [activeTable, archivedTable] = screen.getAllByRole("table");
+    for (const table of [activeTable, archivedTable]) {
+      expect(table).toHaveClass("min-w-[60rem]");
+    }
+
+    const activeStatus = within(activeTable).getByText("未精算").closest("td");
+    expect(activeStatus).toHaveClass("whitespace-nowrap", "min-w-[5.5rem]");
+    expect(activeStatus!.querySelector(".whitespace-nowrap")).toHaveTextContent("未精算");
+
+    const archivedStatus = within(archivedTable).getByText("精算済").closest("td");
+    expect(archivedStatus).toHaveClass("whitespace-nowrap", "min-w-[5.5rem]");
+
+    const dateCell = within(activeTable).getByText("2026-07-26").closest("td");
+    expect(dateCell).toHaveClass("whitespace-nowrap", "min-w-[6.5rem]");
+
+    const amountCell = within(activeTable).getByText("10,000 円").closest("td");
+    expect(amountCell).toHaveClass("whitespace-nowrap", "min-w-[6.5rem]");
+
+    const descriptionCell = within(activeTable).getByText("旅行代の精算と立替金の清算用").closest("td");
+    expect(descriptionCell).toHaveClass("break-words", "min-w-[10rem]", "max-w-[16rem]");
+
+    const breakdownCell = within(activeTable)
+      .getByRole("button", { name: /未回収/ })
+      .closest("td");
+    expect(breakdownCell).toHaveClass("min-w-[10rem]");
+    expect(within(activeTable).getByRole("button", { name: /未回収/ })).toHaveClass("whitespace-nowrap");
+
+    const actionsCell = within(activeTable).getByRole("button", { name: "編集" }).closest("td");
+    expect(actionsCell).toHaveClass("whitespace-nowrap", "min-w-[4.5rem]");
   });
 });

--- a/packages/frontend/src/routes/splits.tsx
+++ b/packages/frontend/src/routes/splits.tsx
@@ -50,11 +50,11 @@ const splitStatusTone: Record<Exclude<SplitStatus, "none">, "warning" | "success
   settled: "success",
 };
 
-function getSplitStatusBadge(status: SplitStatus) {
+export function getSplitStatusBadge(status: SplitStatus) {
   if (status === "none") {
     return null;
   }
-  return <Badge tone={splitStatusTone[status]}>{splitStatusLabels[status]}</Badge>;
+  return <Badge tone={splitStatusTone[status]} className="whitespace-nowrap">{splitStatusLabels[status]}</Badge>;
 }
 
 export function getTransactionSettlementRemaining(transaction: Transaction): number {
@@ -81,7 +81,7 @@ function SplitSharesCell({ split }: { split: SplitListItem }) {
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
-        className="flex items-center gap-1 text-ink-2 transition hover:text-ink"
+        className="flex min-w-0 items-center gap-1 whitespace-nowrap text-ink-2 transition hover:text-ink"
       >
         <span>
           未回収 {remaining.length}人（合計 {total.toLocaleString("ja-JP")}円）
@@ -372,7 +372,7 @@ export function MembersTab() {
   );
 }
 
-function SplitsTab() {
+export function SplitsTab() {
   const [reloadKey, setReloadKey] = useState(0);
   const [status, setStatus] = useState<SplitStatus | "all">("all");
   const [personId, setPersonId] = useState<string>("all");
@@ -420,40 +420,49 @@ function SplitsTab() {
   const settledSplits = splits.filter((split) => split.status === "settled");
 
   const columns: ResponsiveTableColumn<SplitListItem>[] = [
-    { key: "date", header: "日付", mono: true, render: (split) => split.date },
-    { key: "description", header: "内容", render: (split) => split.description },
+    { key: "date", header: "日付", mono: true, className: "min-w-[6.5rem] whitespace-nowrap", render: (split) => split.date },
+    { key: "description", header: "内容", className: "min-w-[10rem] max-w-[16rem] break-words", render: (split) => split.description },
     {
       key: "amount",
       header: "合計金額",
       align: "right",
+      mono: true,
+      className: "min-w-[6.5rem] whitespace-nowrap",
       render: (split) => `${split.amount.toLocaleString("ja-JP")} 円`,
     },
     {
       key: "ownShare",
       header: "自分負担",
       align: "right",
+      mono: true,
+      className: "min-w-[6.5rem] whitespace-nowrap",
       render: (split) => `${split.ownShare.toLocaleString("ja-JP")} 円`,
     },
     {
       key: "status",
       header: "状態",
+      className: "min-w-[5.5rem] whitespace-nowrap",
       render: (split) => getSplitStatusBadge(split.status),
     },
     {
       key: "remaining",
       header: "未回収",
       align: "right",
+      mono: true,
+      className: "min-w-[6.5rem] whitespace-nowrap",
       render: (split) =>
         `${split.shares.reduce((sum, share) => sum + share.remainingAmount, 0).toLocaleString("ja-JP")} 円`,
     },
     {
       key: "shareBreakdown",
       header: "未回収内訳",
+      className: "min-w-[10rem]",
       render: (split) => <SplitSharesCell split={split} />,
     },
     {
       key: "actions",
       header: "",
+      className: "min-w-[4.5rem] whitespace-nowrap",
       render: (split) => (
         <div className="flex justify-end gap-1">
           <IconButton aria-label="編集" onClick={() => setEditingSplit(split)}>
@@ -503,6 +512,7 @@ function SplitsTab() {
               columns={columns}
               rows={activeSplits}
               rowKey={(split) => split.id}
+              className="min-w-[60rem]"
               emptyMessage={
                 activeSplits.length === 0 && settledSplits.length > 0
                   ? "未精算の割り勘はありません。"
@@ -540,6 +550,7 @@ function SplitsTab() {
                 columns={columns}
                 rows={settledSplits}
                 rowKey={(split) => split.id}
+                className="min-w-[60rem]"
                 mobileRow={(split) => (
                   <>
                     <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## 概要

- 割り勘一覧の各列へ最小幅と折り返し規則を設定
- 現役・精算済みの両テーブルを、狭い画面ではテーブル領域内で横スクロール
- 375px では従来どおりモバイルカードを表示
- 768px / 1024px / 1440px / 375px の回帰 E2E を追加

## 検証

- `make lint`
- `make typecheck`
- `make test-unit`（shared 17 / frontend 87 / backend 140）
- `make test-e2e`（81 passed）
- `make build`

Closes #395
