### PR TITLE
fix(frontend): 精算ダイアログ再オープン時に残額の持分を表示する

### DIFF
--- a/e2e/splits.spec.ts
+++ b/e2e/splits.spec.ts
@@ -167,6 +167,84 @@ test.describe("split list table", () => {
 });
 
 test.describe("split settlement dialog", () => {
+  test("records a partial settlement, then records the remaining share after reopening", async ({ page }) => {
+    const person = await seedPerson({ name: "Taro" });
+    await seedSplit({
+      date: new Date("2026-07-24T00:00:00Z"),
+      description: "Lunch",
+      amount: 10000,
+      shares: [{ personId: person.id, amount: 10000 }],
+    });
+
+    const peoplePromise = waitForApi(page, (path) => path === "/api/people");
+    await page.goto("/splits");
+    await peoplePromise;
+
+    const settlementsPromise = waitForApi(page, (path) => path === "/api/settlements");
+    const settlementsPeoplePromise = waitForApi(page, (path) => path === "/api/people");
+    await page.getByRole("radio", { name: "精算" }).click();
+    await Promise.all([settlementsPromise, settlementsPeoplePromise]);
+
+    await page.getByRole("button", { name: /精算を記録/ }).click();
+    const firstDialog = page.getByRole("dialog");
+    await expect(firstDialog).toBeVisible();
+    await firstDialog.getByLabel("メンバー").selectOption(person.id);
+    await expect(firstDialog.getByText(/Lunch（残額 10,000）/)).toBeVisible();
+
+    await firstDialog.locator('input[type="date"]').fill("2026-07-25");
+    await firstDialog.locator('input[placeholder="円"]').fill("5000");
+    await firstDialog.getByRole("button", { name: "自動按分" }).click();
+    await expect(firstDialog.locator('input[placeholder="金額"]')).toHaveValue("5000");
+    const firstSavePromise = page.waitForResponse(
+      (response) => response.url().endsWith("/api/settlements") && response.request().method() === "POST" && response.ok(),
+    );
+    await firstDialog.getByRole("button", { name: "保存" }).click();
+    await firstSavePromise;
+    await expect(firstDialog).toHaveCount(0);
+    await expect(page.getByRole("table").getByText("5,000 円")).toBeVisible();
+
+    await page.getByRole("button", { name: /精算を記録/ }).click();
+    const secondDialog = page.getByRole("dialog");
+    await expect(secondDialog).toBeVisible();
+    await expect(secondDialog.getByLabel("メンバー")).toHaveValue("");
+    await expect(secondDialog.getByLabel("種別")).toHaveValue("offset");
+    await expect(secondDialog.locator('input[type="date"]')).toHaveValue("");
+    await expect(secondDialog.locator('input[placeholder="円"]')).toHaveValue("");
+    await expect(secondDialog.getByRole("textbox").nth(1)).toHaveValue("");
+    const secondSummaryResponse = page.waitForResponse(
+      (response) => new URL(response.url()).pathname === `/api/people/${person.id}/summary`,
+    );
+    await secondDialog.getByLabel("メンバー").selectOption(person.id);
+    await expect((await secondSummaryResponse).status()).toBe(200);
+    await expect(secondDialog.getByText(/Lunch（残額 5,000）/)).toBeVisible();
+
+    await secondDialog.locator('input[type="date"]').fill("2026-07-26");
+    await secondDialog.locator('input[placeholder="円"]').fill("5000");
+    await secondDialog.getByRole("button", { name: "自動按分" }).click();
+    await expect(secondDialog.locator('input[placeholder="金額"]')).toHaveValue("5000");
+    const secondSavePromise = page.waitForResponse(
+      (response) => response.url().endsWith("/api/settlements") && response.request().method() === "POST" && response.ok(),
+    );
+    await secondDialog.getByRole("button", { name: "保存" }).click();
+    await secondSavePromise;
+    await expect(secondDialog).toHaveCount(0);
+    await expect(page.getByRole("table").getByText("5,000 円")).toHaveCount(2);
+
+    const membersPeoplePromise = waitForApi(page, (path) => path === "/api/people");
+    await page.getByRole("radio", { name: "メンバー" }).click();
+    await membersPeoplePromise;
+    await expect(page.getByTestId("members-total-outstanding")).toHaveText(/0 円/);
+
+    const returnedSettlementsPromise = waitForApi(page, (path) => path === "/api/settlements");
+    const returnedPeoplePromise = waitForApi(page, (path) => path === "/api/people");
+    await page.getByRole("radio", { name: "精算" }).click();
+    await Promise.all([returnedSettlementsPromise, returnedPeoplePromise]);
+    await page.getByRole("button", { name: /精算を記録/ }).click();
+    const finalDialog = page.getByRole("dialog");
+    await finalDialog.getByLabel("メンバー").selectOption(person.id);
+    await expect(finalDialog.getByText("未精算の持分はありません。")).toBeVisible();
+  });
+
   test("shows truncated transfer options and full details without overflowing at 375px", async ({ page }) => {
     const fromAccount = await seedAccount({ name: "From", balance: 0 });
     const toAccount = await seedAccount({ name: "To", balance: 0 });

--- a/packages/backend/src/routes/people.integration.test.ts
+++ b/packages/backend/src/routes/people.integration.test.ts
@@ -164,4 +164,36 @@ describe("people routes", () => {
     });
     expect(body.outstandingAmount).toEqual({ JPY: 1500 });
   });
+
+  it("returns a partial share and its settlement history after an offset settlement", async () => {
+    const person = await testPrisma.person.create({ data: { name: "Taro", sortOrder: 1 } });
+    const split = await testPrisma.transactionSplit.create({
+      data: {
+        date: new Date("2026-07-25"),
+        description: "Lunch",
+        memo: null,
+        amount: 10000,
+        method: "equal",
+        ownRatio: 1,
+        shares: { create: { personId: person.id, amount: 10000 } },
+      },
+      include: { shares: true },
+    });
+    await testPrisma.settlement.create({
+      data: {
+        kind: "offset",
+        personId: person.id,
+        date: new Date("2026-07-26"),
+        allocations: { create: { shareId: split.shares[0].id, amount: 5000 } },
+      },
+    });
+
+    const response = await client.get(`/api/people/${person.id}/summary`);
+    const body = await parseJson<PersonSummaryResponse>(response);
+
+    expect(response.status).toBe(200);
+    expect(body.shares[0]).toMatchObject({ remainingAmount: 5000, status: "partial" });
+    expect(body.settlements).toHaveLength(1);
+    expect(body.settlements[0]).toMatchObject({ personName: "Taro" });
+  });
 });

--- a/packages/backend/src/services/people.ts
+++ b/packages/backend/src/services/people.ts
@@ -111,7 +111,7 @@ export async function getPersonSummary(prisma: PrismaClient, id: string): Promis
         orderBy: { split: { date: "asc" } },
       },
       settlements: {
-        include: { allocations: true, transaction: true },
+        include: { person: true, allocations: true, transaction: true },
         orderBy: { date: "desc" },
       },
     },

--- a/packages/frontend/src/routes/splits.test.tsx
+++ b/packages/frontend/src/routes/splits.test.tsx
@@ -10,6 +10,7 @@ import {
   getTransactionSettlementRemaining,
   isSettlementCandidate,
   MembersTab,
+  SettlementsTab,
   SettlementTransferDetailPanel,
   SplitsTab,
   truncateByGraphemes,
@@ -477,5 +478,83 @@ describe("CreateSettlementDialog", () => {
     expect(selectedOption.textContent).toMatch(/2026-07-26/);
     expect(selectedOption.textContent).toMatch(/残り 10,000円/);
     expect(selectedOption.textContent).toMatch(/…$/);
+  });
+});
+
+describe("SettlementsTab", () => {
+  it("unmounts the dialog on close and fetches a fresh summary after reopening", async () => {
+    const person = personStub({ outstandingAmount: { JPY: 10000 } });
+    let summaryRequests = 0;
+    vi.mocked(apiFetch).mockImplementation((url) => {
+      if (url === "/api/settlements") {
+        return Promise.resolve([]);
+      }
+      if (url === "/api/people") {
+        return Promise.resolve([person]);
+      }
+      if (url === "/api/transactions?type=transfer&limit=100") {
+        return Promise.resolve({ items: [transactionStub()], page: 1, limit: 100, total: 1 });
+      }
+      if (url === `/api/people/${person.id}/summary`) {
+        summaryRequests += 1;
+        const remainingAmount = summaryRequests === 1 ? 10000 : 5000;
+        return Promise.resolve({
+          person: personStub({ outstandingAmount: { JPY: remainingAmount } }),
+          outstandingAmount: { JPY: remainingAmount },
+          shares: [
+            {
+              id: "share-1",
+              splitId: "split-1",
+              personId: person.id,
+              personName: person.name,
+              splitDescription: "Lunch",
+              splitDate: "2026-07-24",
+              ratio: null,
+              amount: 10000,
+              settledAmount: 10000 - remainingAmount,
+              remainingAmount,
+              status: remainingAmount === 10000 ? "unsettled" : "partial",
+            },
+          ],
+          settlements: [],
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    render(<SettlementsTab />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /精算を記録/ })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole("button", { name: /精算を記録/ }));
+    fireEvent.change(screen.getByLabelText("メンバー"), { target: { value: person.id } });
+    await waitFor(() => expect(screen.getByText(/Lunch（残額 10,000）/)).toBeInTheDocument());
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.change(dialog.querySelector<HTMLInputElement>('input[type="date"]')!, { target: { value: "2026-07-25" } });
+    fireEvent.change(dialog.querySelector<HTMLInputElement>('input[placeholder="円"]')!, { target: { value: "5000" } });
+    fireEvent.change(dialog.querySelector<HTMLInputElement>('input:not([type])')!, { target: { value: "first settlement" } });
+    fireEvent.change(dialog.querySelector<HTMLInputElement>('input[placeholder="金額"]')!, { target: { value: "5000" } });
+    fireEvent.change(screen.getByLabelText("種別"), { target: { value: "transaction" } });
+    await waitFor(() => expect(screen.getByLabelText("振替取引")).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText("振替取引"), { target: { value: "tx-1" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /精算を記録/ }));
+    const reopenedDialog = screen.getByRole("dialog");
+    expect(screen.getByLabelText("メンバー")).toHaveValue("");
+    expect(screen.getByLabelText("種別")).toHaveValue("offset");
+    expect(reopenedDialog.querySelector<HTMLInputElement>('input[type="date"]')).toHaveValue("");
+    expect(screen.getByPlaceholderText("円")).toHaveValue(null);
+    expect(screen.getByRole("textbox")).toHaveValue("");
+
+    fireEvent.change(screen.getByLabelText("種別"), { target: { value: "transaction" } });
+    await waitFor(() => expect(screen.getByLabelText("振替取引")).toHaveValue(""));
+    fireEvent.change(screen.getByLabelText("種別"), { target: { value: "offset" } });
+    fireEvent.change(screen.getByLabelText("メンバー"), { target: { value: person.id } });
+    await waitFor(() => expect(screen.getByText(/Lunch（残額 5,000）/)).toBeInTheDocument());
+    expect(summaryRequests).toBe(2);
+    expect(screen.getByPlaceholderText("金額")).toHaveValue(null);
   });
 });

--- a/packages/frontend/src/routes/splits.tsx
+++ b/packages/frontend/src/routes/splits.tsx
@@ -679,7 +679,7 @@ export function SplitsTab() {
   );
 }
 
-function SettlementsTab() {
+export function SettlementsTab() {
   const [reloadKey, setReloadKey] = useState(0);
   const [createOpen, setCreateOpen] = useState(false);
   const { data, loading, error } = useResource(() =>
@@ -770,12 +770,14 @@ function SettlementsTab() {
         {loading ? <div className="mt-2 text-sm text-ink-3">読み込み中...</div> : null}
       </Card>
 
-      <CreateSettlementDialog
-        open={createOpen}
-        people={data?.people ?? []}
-        onClose={() => setCreateOpen(false)}
-        onSaved={reload}
-      />
+      {createOpen ? (
+        <CreateSettlementDialog
+          open
+          people={data?.people ?? []}
+          onClose={() => setCreateOpen(false)}
+          onSaved={reload}
+        />
+      ) : null}
     </>
   );
 }
@@ -810,16 +812,6 @@ export function CreateSettlementDialog({
         : Promise.resolve(null),
     [kind],
   );
-
-  const reset = () => {
-    setPersonId("");
-    setKind("offset");
-    setTransactionId("");
-    setDate("");
-    setOffsetTotal("");
-    setNote("");
-    setAllocations({});
-  };
 
   const handleSave = async () => {
     if (!personId) {
@@ -856,7 +848,6 @@ export function CreateSettlementDialog({
       toast({ title: "精算を記録しました" });
       onSaved();
       onClose();
-      reset();
     } catch (saveError) {
       toast({ title: "精算の記録に失敗しました", description: describeError(saveError), variant: "error" });
     }


### PR DESCRIPTION
同一メンバーの同一持分を部分精算したあと、精算ダイアログを閉じて再度「精算を記録」を開くと、残額がある持分が「未精算持分」に表示されず 2 回目の精算を登録できない不具合を修正する。

## 根本原因

原因は 2 つあった。

### 1. `GET /api/people/:id/summary` が 500 を返していた（主因）

`packages/backend/src/services/people.ts` の `getPersonSummary()` は `settlements` の include に `person` を含めていないのに、`buildSettlementListItem()` が `settlement.person.name` を参照していた。
そのため、**精算が 1 件でも付いたメンバーの summary 取得は必ず 500 になっていた**。
`settlement as unknown as PrismaSettlement` のキャストによって型エラーが検出されていなかった。

1 回目の精算を保存した直後からこの状態になるため、2 回目に同じメンバーを選んでも持分一覧を取得できなかった。

### 2. 閉じたダイアログがマウントされたままだった

`packages/frontend/src/routes/splits.tsx` の `SettlementsTab` は `createOpen === false` のときも `CreateSettlementDialog` を描画し続け、`open` prop だけを切り替えていた。
`personId` / `kind` / `transactionId` / `date` / `offsetTotal` / `note` / `allocations` と、`useResource` が保持する summary・振替取引一覧が閉じても残っていた。

## 変更内容

- `packages/backend/src/services/people.ts`: `settlements` の include に `person` を追加。
- `packages/frontend/src/routes/splits.tsx`: `createOpen` が true の間だけ `CreateSettlementDialog` を描画し、閉じたら unmount する。再オープン時は mount によってフォーム状態が初期化され、summary と振替候補も新規取得される。不要になった `reset()` を削除。

ドメイン規則・API 契約・DB スキーマは変更していない。`docs/concepts/split-and-settlement.md` の「一つの負担が複数回に分けて返ってくることもある」という既存の規則どおりの挙動へ戻すだけであり、ドキュメント更新は不要。

#424 で導入した `settlementAllocatedAmount` / `settlementRemainingAmount` のロジック（`isSettlementCandidate`、`getTransactionSettlementRemaining`、`formatTransferOptionLabel`）は変更していない。

## テスト

- `packages/backend/src/routes/people.integration.test.ts`: 部分精算後の summary が 200 で残額 5,000 円と精算履歴（`personName` を含む）を返す回帰テストを追加。修正前はここで 500 になる。
- `packages/frontend/src/routes/splits.test.tsx`: `SettlementsTab` のライフサイクルテストを追加。閉じると unmount されること、再オープン時に全フォーム値が初期値へ戻ること、同じメンバーを再選択すると summary が再取得され更新後の `remainingAmount` が表示されることを検証。
- `e2e/splits.spec.ts`: 10,000 円の持分を UI 操作で 5,000 円ずつ 2 回精算する回帰テストを追加。1 回目保存後の履歴、再オープン時の「残額 5,000」、2 回目保存後の未回収 0、全額精算後に未精算持分が表示されないことを確認。

### 検証結果（push 対象の HEAD `9ff6d17` でローカル実行）

| コマンド | 結果 |
| --- | --- |
| `make lint` | exit 0 |
| `make typecheck` | exit 0 |
| `make test-unit` | exit 0（shared 27 / frontend 143 / backend 227 / runner 40） |
| `make test-integration` | exit 0（20 files, 228 tests） |
| `make test-e2e` | exit 0（92 tests） |
| `make build` | exit 0 |

Closes #447
