### PR TITLE
fix(frontend): 長い割り勘タイトルでも按分金額の入力欄を表示する

### DIFF
--- a/e2e/splits.spec.ts
+++ b/e2e/splits.spec.ts
@@ -189,7 +189,8 @@ test.describe("split settlement dialog", () => {
     const firstDialog = page.getByRole("dialog");
     await expect(firstDialog).toBeVisible();
     await firstDialog.getByLabel("メンバー").selectOption(person.id);
-    await expect(firstDialog.getByText(/Lunch（残額 10,000）/)).toBeVisible();
+    await expect(firstDialog.getByTitle("2026-07-24 Lunch")).toBeVisible();
+    await expect(firstDialog.getByText(/残額 10,000 円/)).toBeVisible();
 
     await firstDialog.locator('input[type="date"]').fill("2026-07-25");
     await firstDialog.locator('input[placeholder="円"]').fill("5000");
@@ -216,7 +217,8 @@ test.describe("split settlement dialog", () => {
     );
     await secondDialog.getByLabel("メンバー").selectOption(person.id);
     await expect((await secondSummaryResponse).status()).toBe(200);
-    await expect(secondDialog.getByText(/Lunch（残額 5,000）/)).toBeVisible();
+    await expect(secondDialog.getByTitle("2026-07-24 Lunch")).toBeVisible();
+    await expect(secondDialog.getByText(/残額 5,000 円/)).toBeVisible();
 
     await secondDialog.locator('input[type="date"]').fill("2026-07-26");
     await secondDialog.locator('input[placeholder="円"]').fill("5000");
@@ -309,5 +311,74 @@ test.describe("split settlement dialog", () => {
     );
 
     await assertNoDocumentHorizontalScroll(page);
+  });
+
+  test("keeps the allocation input inside the dialog for a long split description", async ({ page }) => {
+    const person = await seedPerson({ name: "Taro" });
+    const longDescription = "沖縄旅行の宿泊費と交通費とレンタカー代の立替分".repeat(2);
+
+    await seedSplit({
+      date: new Date("2026-07-24T00:00:00Z"),
+      description: longDescription,
+      amount: 12000,
+      shares: [{ personId: person.id, amount: 12000 }],
+    });
+
+    const peoplePromise = waitForApi(page, (path) => path === "/api/people");
+    await page.goto("/splits");
+    await peoplePromise;
+
+    const settlementsPromise = waitForApi(page, (path) => path === "/api/settlements");
+    const settlementsPeoplePromise = waitForApi(page, (path) => path === "/api/people");
+    await page.getByRole("radio", { name: "精算" }).click();
+    await Promise.all([settlementsPromise, settlementsPeoplePromise]);
+
+    await page.getByRole("button", { name: /精算を記録/ }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const summaryPromise = waitForApi(page, (path) => path === `/api/people/${person.id}/summary`);
+    await dialog.getByLabel("メンバー").selectOption(person.id);
+    await summaryPromise;
+
+    await expect(dialog.getByTitle(`2026-07-24 ${longDescription}`)).toBeVisible();
+    await expect(dialog.getByText(/残額 12,000 円/)).toBeVisible();
+
+    const amountInput = dialog.locator('input[placeholder="金額"]');
+
+    for (const viewport of [{ width: 1280, height: 900 }, { width: 375, height: 812 }]) {
+      await page.setViewportSize(viewport);
+      await expect(amountInput).toBeVisible();
+
+      const inputBox = await amountInput.boundingBox();
+      const dialogBox = await dialog.boundingBox();
+      expect(inputBox).not.toBeNull();
+      expect(dialogBox).not.toBeNull();
+      expect(inputBox!.x).toBeGreaterThanOrEqual(dialogBox!.x);
+      expect(inputBox!.x + inputBox!.width).toBeLessThanOrEqual(dialogBox!.x + dialogBox!.width + 1);
+      expect(inputBox!.width).toBeGreaterThan(0);
+
+      const dialogOverflow = await dialog.evaluate((element) => ({
+        scrollWidth: element.scrollWidth,
+        clientWidth: element.clientWidth,
+      }));
+      expect(dialogOverflow.scrollWidth).toBeLessThanOrEqual(dialogOverflow.clientWidth + 1);
+
+      await expect(dialog.getByRole("button", { name: "保存" })).toBeVisible();
+      await expect(dialog.getByRole("button", { name: "キャンセル" })).toBeVisible();
+
+      await assertNoDocumentHorizontalScroll(page);
+    }
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await dialog.locator('input[type="date"]').fill("2026-07-26");
+    await amountInput.fill("5000");
+    const savePromise = page.waitForResponse(
+      (response) => response.url().endsWith("/api/settlements") && response.request().method() === "POST" && response.ok(),
+    );
+    await dialog.getByRole("button", { name: "保存" }).click();
+    await savePromise;
+    await expect(dialog).toHaveCount(0);
+    await expect(page.getByRole("table").getByText("5,000 円")).toBeVisible();
   });
 });

--- a/packages/frontend/src/routes/splits.test.tsx
+++ b/packages/frontend/src/routes/splits.test.tsx
@@ -10,6 +10,7 @@ import {
   getTransactionSettlementRemaining,
   isSettlementCandidate,
   MembersTab,
+  SettlementShareAllocationRow,
   SettlementsTab,
   SettlementTransferDetailPanel,
   SplitsTab,
@@ -479,6 +480,82 @@ describe("CreateSettlementDialog", () => {
     expect(selectedOption.textContent).toMatch(/残り 10,000円/);
     expect(selectedOption.textContent).toMatch(/…$/);
   });
+
+  it("keeps the allocation input usable for a long split description", async () => {
+    const longDescription = "旅行代の精算と立替金の清算用".repeat(4);
+    vi.mocked(apiFetch).mockImplementation((url) => {
+      if (typeof url === "string" && url.includes("/api/people/")) {
+        return Promise.resolve({
+          ...summary,
+          shares: [{ ...share, splitDescription: longDescription }],
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    render(<CreateSettlementDialog open people={[person]} onClose={vi.fn()} onSaved={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("メンバー"), { target: { value: person.id } });
+
+    const input = await screen.findByLabelText(`${longDescription} の按分金額`);
+    fireEvent.change(input, { target: { value: "1500" } });
+    expect(input).toHaveValue(1500);
+
+    const title = screen.getByTitle(`2026-07-24 ${longDescription}`);
+    expect(title).toHaveTextContent(longDescription);
+    expect(title).not.toHaveTextContent("残額");
+    expect(title.parentElement).toHaveTextContent("残額 4,000 円");
+  });
+});
+
+describe("SettlementShareAllocationRow", () => {
+  const share = {
+    id: "share-1",
+    splitId: "split-1",
+    personId: "person-1",
+    personName: "Taro",
+    splitDescription: "沖縄旅行の宿泊費と交通費の立替分",
+    splitDate: "2026-07-24",
+    ratio: null,
+    amount: 4000,
+    settledAmount: 0,
+    remainingAmount: 4000,
+    status: "unsettled" as const,
+  };
+
+  it("keeps the title in a flexible column and the input in a fixed one", () => {
+    render(<SettlementShareAllocationRow share={share} value="" onChange={vi.fn()} />);
+
+    const title = screen.getByTitle(`${share.splitDate} ${share.splitDescription}`);
+    expect(title).toHaveClass("line-clamp-2", "break-words");
+    expect(title.parentElement).toHaveClass("min-w-0");
+
+    const row = title.closest("div")?.parentElement;
+    expect(row).toHaveClass("min-w-0", "sm:grid-cols-[minmax(0,1fr)_7rem]");
+
+    const input = screen.getByLabelText(`${share.splitDescription} の按分金額`);
+    expect(input).toHaveClass("w-full");
+    expect(input.parentElement).toHaveClass("w-full", "sm:w-28");
+  });
+
+  it("shows the remaining amount outside the truncated title", () => {
+    render(<SettlementShareAllocationRow share={share} value="" onChange={vi.fn()} />);
+
+    const title = screen.getByTitle(`${share.splitDate} ${share.splitDescription}`);
+    expect(title).not.toHaveTextContent("残額");
+    expect(title.parentElement).toHaveTextContent("残額 4,000 円");
+  });
+
+  it("caps the input at the remaining amount and reports changes", () => {
+    const onChange = vi.fn();
+    render(<SettlementShareAllocationRow share={share} value="1000" onChange={onChange} />);
+
+    const input = screen.getByLabelText(`${share.splitDescription} の按分金額`);
+    expect(input).toHaveValue(1000);
+    expect(input).toHaveAttribute("max", "4000");
+
+    fireEvent.change(input, { target: { value: "2500" } });
+    expect(onChange).toHaveBeenCalledWith("2500");
+  });
 });
 
 describe("SettlementsTab", () => {
@@ -527,7 +604,8 @@ describe("SettlementsTab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /精算を記録/ }));
     fireEvent.change(screen.getByLabelText("メンバー"), { target: { value: person.id } });
-    await waitFor(() => expect(screen.getByText(/Lunch（残額 10,000）/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTitle("2026-07-24 Lunch")).toBeInTheDocument());
+    expect(screen.getByTitle("2026-07-24 Lunch").parentElement).toHaveTextContent("残額 10,000 円");
 
     const dialog = screen.getByRole("dialog");
     fireEvent.change(dialog.querySelector<HTMLInputElement>('input[type="date"]')!, { target: { value: "2026-07-25" } });
@@ -553,7 +631,9 @@ describe("SettlementsTab", () => {
     await waitFor(() => expect(screen.getByLabelText("振替取引")).toHaveValue(""));
     fireEvent.change(screen.getByLabelText("種別"), { target: { value: "offset" } });
     fireEvent.change(screen.getByLabelText("メンバー"), { target: { value: person.id } });
-    await waitFor(() => expect(screen.getByText(/Lunch（残額 5,000）/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTitle("2026-07-24 Lunch").parentElement).toHaveTextContent("残額 5,000 円"),
+    );
     expect(summaryRequests).toBe(2);
     expect(screen.getByPlaceholderText("金額")).toHaveValue(null);
   });

--- a/packages/frontend/src/routes/splits.tsx
+++ b/packages/frontend/src/routes/splits.tsx
@@ -5,6 +5,7 @@ import type {
   SettlementListItem,
   SettlementsResponse,
   SplitListItem,
+  SplitShareItem,
   SplitStatus,
   SplitsResponse,
   Transaction,
@@ -905,7 +906,7 @@ export function CreateSettlementDialog({
         <DialogDescription className="mt-2 text-sm text-ink-2">
           メンバーの未精算持分を精算します。
         </DialogDescription>
-        <form className="mt-6 grid gap-4">
+        <form className="mt-6 grid min-w-0 gap-4">
           <FormField label="メンバー">
             <Select
               aria-label="メンバー"
@@ -990,7 +991,7 @@ export function CreateSettlementDialog({
           </FormField>
 
           {summary ? (
-            <div className="grid gap-2">
+            <div className="grid min-w-0 gap-2">
               <p className="text-sm font-medium">未精算持分</p>
               {summary.shares.filter((share) => share.remainingAmount > 0).length === 0 ? (
                 <p className="text-sm text-ink-2">未精算の持分はありません。</p>
@@ -998,23 +999,14 @@ export function CreateSettlementDialog({
                 summary.shares
                   .filter((share) => share.remainingAmount > 0)
                   .map((share) => (
-                    <div key={share.id} className="flex items-center gap-3">
-                      <span className="min-w-0 flex-1 text-sm truncate">
-                        {share.splitDate} {share.splitDescription}（残額 {share.remainingAmount.toLocaleString("ja-JP")}）
-                      </span>
-                      <Input
-                        type="number"
-                        inputMode="numeric"
-                        min={1}
-                        max={share.remainingAmount}
-                        className="w-28"
-                        placeholder="金額"
-                        value={allocations[share.id] ?? ""}
-                        onChange={(event) =>
-                          setAllocations((current) => ({ ...current, [share.id]: event.target.value }))
-                        }
-                      />
-                    </div>
+                    <SettlementShareAllocationRow
+                      key={share.id}
+                      share={share}
+                      value={allocations[share.id] ?? ""}
+                      onChange={(value) =>
+                        setAllocations((current) => ({ ...current, [share.id]: value }))
+                      }
+                    />
                   ))
               )}
             </div>
@@ -1031,6 +1023,49 @@ export function CreateSettlementDialog({
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/**
+ * 未精算持分の 1 行。
+ * 割り勘タイトルが長くても按分金額の入力欄が押し出されないよう、
+ * 情報側を可変幅（minmax(0,1fr)）、入力欄を固定幅の列として分離する。
+ */
+export function SettlementShareAllocationRow({
+  share,
+  value,
+  onChange,
+}: {
+  share: SplitShareItem;
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const fullTitle = `${share.splitDate} ${share.splitDescription}`;
+
+  return (
+    <div className="grid min-w-0 gap-1 sm:grid-cols-[minmax(0,1fr)_7rem] sm:items-center sm:gap-3">
+      <div className="min-w-0">
+        <p className="line-clamp-2 break-words text-sm" title={fullTitle}>
+          <span className="font-data">{share.splitDate}</span> {share.splitDescription}
+        </p>
+        <p className="text-xs text-ink-2">
+          残額 <span className="font-data">{share.remainingAmount.toLocaleString("ja-JP")}</span> 円
+        </p>
+      </div>
+      <div className="w-full min-w-0 sm:w-28">
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={1}
+          max={share.remainingAmount}
+          className="w-full"
+          placeholder="金額"
+          aria-label={`${share.splitDescription} の按分金額`}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 概要

「精算を記録」ダイアログの「未精算持分」で、割り勘タイトル（`splitDescription`）が長いと按分金額の入力欄がダイアログ右外へ押し出され、対象持分への充当額を入力できなくなる問題を修正する。

Closes #459

## 原因

持分行は `flex items-center gap-3` の 1 行で、日付・タイトル・残額を連結した 1 つの `span`（`truncate`）と `w-28` の入力欄を並べていた。

- `truncate` は `white-space: nowrap` を含むため、行の min-content 幅がタイトル全長に引きずられる。祖先（`form` の grid、持分一覧の grid）に `min-w-0` がなく、grid アイテムの自動最小サイズ（`min-width: auto`）が効いてトラックがダイアログ幅を超えて広がる
- 残額をタイトル末尾に連結していたため、省略されると残額まで読めなくなる

## 変更

### fix(frontend): 持分の情報と按分金額の入力欄を別の列に分離する

- `SettlementShareAllocationRow` を切り出し、デスクトップは `grid-cols-[minmax(0,1fr)_7rem]`、モバイル（`sm` 未満）は 1 列の縦積みにする。入力欄は固定幅ラッパー内の `w-full` として、可変幅側の内容量に押し出されないようにする
- 日付とタイトルは `line-clamp-2 break-words` で最大 2 行に省略し、全文を `title` 属性で参照できるようにする
- 残額はタイトルの連結をやめ、独立したメタ行（`残額 N 円`）として常に表示する。タイトルの省略に巻き込まれない
- 入力欄に `aria-label`（`<タイトル> の按分金額`）を付け、複数行あっても対象を特定できるようにする
- `form` と持分一覧のコンテナに `min-w-0` を足し、grid アイテムの自動最小サイズによる横方向のはみ出しを止める

短いタイトルの表示は日付・タイトルの 1 行と残額のメタ行に変わるだけで、操作は変わらない。

## テスト

- `packages/frontend/src/routes/splits.test.tsx`
  - `SettlementShareAllocationRow`: 可変幅列と固定幅列のクラス、`line-clamp-2`、`title` 属性、残額がタイトル外にあること、`max` が残額であること、変更が親へ伝わることを検証
  - `CreateSettlementDialog`: 56 文字のタイトルでも `aria-label` から入力欄を取得して入力でき、残額が省略に巻き込まれないことを検証
  - 既存の再オープン回帰テストは、連結テキスト（`Lunch（残額 5,000）`）から `title` 属性 + 残額メタ行の検証へ追随
- `e2e/splits.spec.ts`
  - 46 文字のタイトルで持分を作り、デスクトップ（1280px）とモバイル（375px）の両方で、入力欄の bounding box がダイアログの矩形内に収まること、ダイアログ自身に横スクロールが出ないこと、保存・キャンセルが表示されることを検証。実際に按分額を入力して保存まで通す
  - 既存の部分精算テストも新しい表示に追随

| コマンド | 結果 |
| --- | --- |
| `make lint` | pass |
| `make typecheck` | pass |
| `make test-unit` | pass（frontend 147 / backend 228 / shared 27） |
| `make test-e2e` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
