### PR TITLE
ci(release): リリース workflow から chart の appVersion 更新と publish を行う

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,9 +1,12 @@
 name: Publish Helm Chart
 
 # sui は release-please を使わず、独自のリリースパイプライン (release.yml) が
-# image を publish する。chart の appVersion は「公開済みの image」を renovate が
-# 検出して chart の patch version と同じ PR で更新する (経路 B) ので、
-# アプリのリリースと chart の publish を DAG で繋ぐ必要がない。
+# image を publish する。chart の appVersion を進める経路は 2 つある。
+#
+#   - release.yml が image の publish を見届けてから appVersion を main に commit し、
+#     この workflow を dispatch する (主経路)
+#   - 何らかの理由で↑が届かなかった場合に renovate が公開済みの image を検出し、
+#     chart の patch version と同じ PR で appVersion を更新する (経路 B / fallback)
 #
 # そのため他アプリの caller にある「appVersion だけの変更なら起動しない」triage は
 # 持たない。ここで起動しないと拾い手がいなくなる。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,3 +185,82 @@ jobs:
             echo "Watching ${workflow} run ${run_id}"
             gh run watch "$run_id" --exit-status
           done
+
+      # image が publish されたことを確認してから chart の appVersion を進める。
+      # 「appVersion は publish 済みの image しか指さない」という不変条件を
+      # renovate 経由の経路 B と揃えるため、この順序は入れ替えてはいけない。
+      - name: Update chart appVersion
+        run: |
+          set -euo pipefail
+
+          chart=charts/sui/Chart.yaml
+
+          for _ in 1 2 3; do
+            git fetch --quiet origin main
+            git checkout --quiet FETCH_HEAD
+
+            if [ "$(yq -r '.appVersion' "$chart")" = "$VERSION" ]; then
+              echo "appVersion is already $VERSION; nothing to commit."
+              exit 0
+            fi
+
+            yq -i ".appVersion = \"$VERSION\"" "$chart"
+            git add "$chart"
+            git commit --quiet -m "chore(chart): set appVersion to $VERSION"
+
+            if git push --quiet origin HEAD:main; then
+              echo "Committed appVersion $VERSION as $(git rev-parse HEAD)."
+              exit 0
+            fi
+
+            echo "Push was rejected (main moved); retrying from the new main."
+          done
+
+          echo "Could not update $chart after 3 attempts because main kept moving." >&2
+          exit 1
+
+      # chart version の採番と image の実在確認は共有 workflow の reconcile が持つ。
+      # ここは起動と結果の見届けだけを担う。
+      - name: Publish Helm chart
+        run: |
+          set -euo pipefail
+
+          workflow="chart-release.yaml"
+
+          latest_run_id() {
+            gh run list \
+              --workflow "$workflow" \
+              --event workflow_dispatch \
+              --json databaseId \
+              --jq 'map(.databaseId) | max // 0'
+          }
+
+          # push で main が動いた分と区別できないので、run の識別は dispatch 前の
+          # 最新 id を基準にする。headSha 一致では main が動いたときに取り逃がす。
+          before=$(latest_run_id)
+
+          echo "Dispatching ${workflow}"
+          gh workflow run "$workflow" --ref main
+
+          run_id=""
+
+          for _ in {1..30}; do
+            candidate=$(latest_run_id)
+
+            if [ "$candidate" -gt "$before" ]; then
+              run_id="$candidate"
+              break
+            fi
+
+            sleep 2
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "Could not find the dispatched run for ${workflow}." >&2
+            exit 1
+          fi
+
+          # 共有 workflow は concurrency queue で待たされることがある。
+          # gh run watch は queued のまま待機するので、そのまま見届けてよい。
+          echo "Watching ${workflow} run ${run_id}"
+          gh run watch "$run_id" --exit-status

--- a/renovate.json5
+++ b/renovate.json5
@@ -27,8 +27,9 @@
       versioningTemplate: 'docker',
     },
     // Chart.yaml の appVersion を「公開済みの」image に追従させる。
-    // sui の release workflow は package.json 群しか commit しないので、
-    // Chart.yaml の更新はここが唯一の経路になる。
+    // 通常は release.yml が image の publish 後に appVersion を commit するので
+    // ここは何も検出しない。release.yml の chart step が落ちた場合や、
+    // 手動で image を publish した場合の fallback として残している。
     {
       customType: 'regex',
       managerFilePatterns: [


### PR DESCRIPTION
## 背景

`release.yml` と `chart-release.yaml` は直接繋がっておらず、Renovate 経由で非同期に連結されていた。

```
release.yml → docker.yaml → image publish
     ⇣ (最大3時間の空白)
renovate (cron 0 */3) → Chart.yaml の appVersion 追従 PR → automerge
     ⇣
chart-release.yaml (push: main, paths: charts/**) → OCI に publish
```

`charts/sui/templates/deployment.yaml` は `image.tag | default .Chart.AppVersion`、`values.yaml` の tag は空なので、appVersion がそのままデプロイされる版になる。つまりリリースしてから実際に chart が出るまで最大3時間かかっていた。

## 変更

`release.yml` の末尾、docker.yaml の watch 成功**後**に2ステップ追加する。

1. **Update chart appVersion** — `origin/main` を取り直して `charts/sui/Chart.yaml` の `appVersion` を `$VERSION` に更新し commit・push。既に一致していれば no-op。push が reject された場合 (renovate の automerge 等で main が動いた場合) は fetch からやり直し、最大3回。
2. **Publish Helm chart** — `chart-release.yaml` を dispatch し `gh run watch --exit-status` で見届ける。

chart version の採番も image の実在確認も共有 workflow の reconcile が既に持っているため、`release.yml` 側には一切持ち込んでいない。appVersion だけが変わった状態は reconcile の**経路4** (patch bump → commit back → publish) に落ちる。

あわせて、前提が変わった `chart-release.yaml` と `renovate.json5` のコメントを実態に更新。

## 設計上の判断

- **順序**: 「appVersion は publish 済みの image しか指さない」という現行の不変条件を維持するため、docker の publish を見届けてから appVersion を書く。release commit に混ぜると docker が落ちたとき存在しない image を指す Chart.yaml が main に残る。
- **run の特定**: docker 側の既存ロジックは `headSha` 一致で run を探すが、chart 側は `--ref main` なので push 直後に main が動くと取り逃がす。dispatch 前の最新 run id を watermark にした。
- **prerelease も追従させる** — 現行の renovate 経路の挙動と揃える (実際 appVersion は現在 `2.0.0-beta.3`)。
- **chart publish の失敗は job の失敗として扱う** — image と tag は既に出た後なので再実行や cron で回収できるが、気付けるようにする。
- **renovate 経路と cron は残す** — appVersion が既に最新なら PR は出ないので、fallback として遊ぶだけ。

## 既知のトレードオフ

main に載る commit が1つ増える。renovate 経路は `bumpVersions` が同じ PR で chart version も上げるため reconcile の経路2 (未 publish version をそのまま publish) になるが、本 PR の主経路は経路4 になるので `chore(chart): set appVersion to X` と `chore(chart): bump ... to 0.3.1` の2つになる。最終状態は同じで、採番が image 検証の後に行われる分むしろ安全側。

## 検証

- `actionlint` clean (shellcheck 含む)
- `yq -i '.appVersion = "..."'` が `# renovate: image=...` コメントとダブルクォートを保持することを yq v4 で確認済み。renovate の custom manager 正規表現も引き続きマッチする。
- yq は GitHub-hosted runner にプリインストール (共有 workflow も install せずに使用している)。
- 実際の dispatch と watch の挙動は本番リリースを回すまで未検証。次のリリース時に要注視。

🤖 Generated with [Claude Code](https://claude.com/claude-code)